### PR TITLE
Propagate user defined url params

### DIFF
--- a/pkg/apiCalls/apicalls.go
+++ b/pkg/apiCalls/apicalls.go
@@ -35,7 +35,7 @@ func StandardCall(apiInfo yamlparser.ApiInfo, debug bool) (CustomResponse, error
 
 	newBodyReader := bytes.NewReader(bodyBytes)
 	headers := apiInfo.Headers
-	urlParams := map[string]string{}
+	urlParams := HandleUrlParams(apiInfo.UrlParams)
 	preparedURL := PrepareURL(urlStr, urlParams)
 
 	reqBodyForDebug := make([]byte, len(bodyBytes))

--- a/pkg/apiCalls/utils.go
+++ b/pkg/apiCalls/utils.go
@@ -1,0 +1,13 @@
+package apicalls
+
+// HandleUrlParams handles setting url params if passed
+// otherwise defaults to empty map
+func HandleUrlParams(apiInfoUrlParams map[string]string) map[string]string {
+
+	urlParams := map[string]string{}
+	if len(apiInfoUrlParams) > 0 {
+		urlParams = apiInfoUrlParams
+	}
+
+	return urlParams
+}

--- a/pkg/apiCalls/utils_test.go
+++ b/pkg/apiCalls/utils_test.go
@@ -1,0 +1,40 @@
+package apicalls
+
+import (
+	"maps"
+	"testing"
+)
+
+func TestHandleUrlParams(t *testing.T) {
+	tests := []struct {
+		name              string
+		apiInfoUrlParams  map[string]string
+		expectedUrlParams map[string]string
+	}{
+		{
+			name: "Params are passed",
+			apiInfoUrlParams: map[string]string{
+				"param1": "value1",
+				"param2": "value2",
+			},
+			expectedUrlParams: map[string]string{
+				"param1": "value1",
+				"param2": "value2",
+			},
+		},
+		{
+			name:              "Params are not passed",
+			apiInfoUrlParams:  nil,
+			expectedUrlParams: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			if !maps.Equal(tt.apiInfoUrlParams, tt.expectedUrlParams) {
+				t.Errorf("HandleUrlParams = %v, expected %v", tt.apiInfoUrlParams, tt.expectedUrlParams)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context

When specifying the url params in the request yaml, they are not propagated to the request as expected. This PR addresses it.

> This addresses https://github.com/xaaha/hulak/issues/48.


# Changes
- Updated the StandardCall to propagate the specified URL parameters properly.

