### PR TITLE
fix: gql env selector not triggered when templates exist in headers/body

### DIFF
--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -260,14 +260,9 @@ func loadFromFile(filePath string, env string) []graphql.ProcessResult {
 	if err != nil {
 		utils.PanicRedAndExit("%v", err)
 	}
-	var secretsMap map[string]any
-	if strings.Contains(rawURL, "{{") {
-		secretsMap = graphql.GetSecretsForEnv(map[string]string{rawURL: filePath}, env)
-		if secretsMap == nil {
-			return nil
-		}
-	} else {
-		secretsMap = map[string]any{}
+	secretsMap := graphql.GetSecretsForEnv(map[string]string{rawURL: filePath}, env)
+	if secretsMap == nil {
+		return nil
 	}
 	return graphql.ProcessFilesConcurrent([]string{filePath}, secretsMap)
 }


### PR DESCRIPTION
## Summary

- **Bug**: Running `hulak gql file.hk.yaml` on a file with template variables in headers (e.g., `Authorization: Bearer {{.token}}`) but a plain URL would skip the env selector TUI entirely, producing a "key not found in environment" error instead.
- **Root cause**: `loadFromFile` and `NeedsEnvResolution` only checked the URL for `{{` patterns to decide whether env secrets were needed. Template variables in headers, body, or other fields were invisible to this check.
- **Fix**: Added `FileHasTemplateVars` which scans raw file content for Go template dot-access patterns (`{{.key}}`), and updated `NeedsEnvResolution` to check both URLs and file contents. Simplified `loadFromFile` to always delegate to `GetSecretsForEnv` (which now makes the right call for both URL and non-URL templates).

## What changed

| File | Change |
|------|--------|
| `pkg/features/graphql/gqlFiles.go` | Added `templateVarPattern` regex, `FileHasTemplateVars()`, updated `NeedsEnvResolution` to also check file contents |
| `pkg/userFlags/subcommands.go` | Simplified `loadFromFile` — removed URL-only `{{` gate, always delegates to `GetSecretsForEnv` |
| `pkg/features/graphql/gqlFiles_test.go` | Added 15 new test cases across `TestFileHasTemplateVars`, `TestFileHasTemplateVars_NonexistentFile`, and `TestNeedsEnvResolution_FileContentCheck` |

## Notes

- The regex `\{\{\s*\.` specifically matches env variable references (`{{.key}}`, `{{ .key }}`) — it does **not** false-positive on `{{getFile ...}}` or `{{getValueOf ...}}` which don't require the secrets map.
- All existing `TestNeedsEnvResolution` cases still pass unchanged (backward compatible).