### PR TITLE
fix: show response body and status when introspection returns non-JSON

### DIFF
--- a/pkg/apiCalls/writeResponse.go
+++ b/pkg/apiCalls/writeResponse.go
@@ -12,17 +12,17 @@ import (
 	"golang.org/x/net/html"
 )
 
-func isJSON(str string) bool {
+func IsJSON(str string) bool {
 	var jsBfr json.RawMessage
 	return json.Unmarshal([]byte(str), &jsBfr) == nil
 }
 
-func isXML(str string) bool {
+func IsXML(str string) bool {
 	var v any
 	return xml.Unmarshal([]byte(str), &v) == nil
 }
 
-func isHTML(str string) bool {
+func IsHTML(str string) bool {
 	doc, err := html.Parse(strings.NewReader(str))
 	return err == nil && strings.Contains(str, "</html>") && doc != nil
 }
@@ -45,11 +45,11 @@ func evalAndWriteRes(resBody, path string) error {
 	}
 
 	switch {
-	case isJSON(resBody):
+	case IsJSON(resBody):
 		writeFile(path, ".json", resBody)
-	case isXML(resBody):
+	case IsXML(resBody):
 		writeFile(path, ".xml", resBody)
-	case isHTML(resBody):
+	case IsHTML(resBody):
 		writeFile(path, ".html", resBody)
 	default:
 		writeFile(path, ".txt", resBody)

--- a/pkg/features/graphql/graphql.go
+++ b/pkg/features/graphql/graphql.go
@@ -52,19 +52,56 @@ func FetchAndParseSchema(apiInfo yamlparser.ApiInfo) (Schema, error) {
 		}
 	}
 
-	// Parse introspection response
+	statusCode := resp.Response.StatusCode
+	bodyStr := string(bodyBytes)
+
+	if statusCode < 200 || statusCode >= 300 {
+		return Schema{}, fmt.Errorf(
+			"introspection request returned status %d (%s).\nResponse body:\n%s",
+			statusCode,
+			resp.Response.Status,
+			truncateBody(bodyStr, 500),
+		)
+	}
+
+	if !apicalls.IsJSON(bodyStr) {
+		return Schema{}, fmt.Errorf(
+			"expected JSON response but received %s (status %d).\nResponse body:\n%s",
+			detectContentType(bodyStr),
+			statusCode,
+			truncateBody(bodyStr, 500),
+		)
+	}
+
 	introspectionData, err := ParseIntrospectionResponse(bodyBytes)
 	if err != nil {
 		return Schema{}, err
 	}
 
-	// Convert to domain model
 	schema, err := ConvertToSchema(introspectionData)
 	if err != nil {
 		return Schema{}, err
 	}
 
 	return schema, nil
+}
+
+func detectContentType(body string) string {
+	switch {
+	case apicalls.IsHTML(body):
+		return "HTML"
+	case apicalls.IsXML(body):
+		return "XML"
+	default:
+		return "non-JSON"
+	}
+}
+
+func truncateBody(body string, maxLen int) string {
+	if len(body) <= maxLen {
+		return body
+	}
+	return body[:maxLen] + "\n... (truncated)"
 }
 
 // GetSecretsForEnv checks if any URL needs template resolution and loads secrets.

--- a/pkg/features/graphql/schemaparser.go
+++ b/pkg/features/graphql/schemaparser.go
@@ -23,7 +23,11 @@ type IntrospectionResponse struct {
 func ParseIntrospectionResponse(jsonData []byte) (*introspection.Schema, error) {
 	var response IntrospectionResponse
 	if err := json.Unmarshal(jsonData, &response); err != nil {
-		return nil, fmt.Errorf("failed to parse introspection response: %w", err)
+		return nil, fmt.Errorf(
+			"failed to parse introspection response: %w\nResponse preview:\n%s",
+			err,
+			truncateBody(string(jsonData), 300),
+		)
 	}
 
 	// Check for GraphQL errors


### PR DESCRIPTION
## Summary

- **Problem**: When a GraphQL introspection request returns non-JSON (e.g., HTML error page, XML, plain text), the user sees a cryptic `invalid character '<' looking for beginning of value` error with no visibility into what the server actually returned.
- **Fix**: Added two validation layers in `FetchAndParseSchema` before attempting JSON parse:
  1. **Status code check** — non-2xx responses now report the status code, status text, and a truncated body preview
  2. **Content type detection** — non-JSON responses are identified (HTML/XML/other) using the existing `IsJSON`/`IsHTML`/`IsXML` helpers, with the response body shown to the user
- `ParseIntrospectionResponse` also now includes a response preview when `json.Unmarshal` fails, as a safety net

## Before / After

**Before:**
```
failed to parse introspection response: invalid character '<' looking for beginning of value
```

**After (non-2xx):**
```
introspection request returned status 404 (404 Not Found).
Response body:
<!DOCTYPE html><html><body><h1>Not Found</h1></body></html>
```

**After (2xx but HTML):**
```
expected JSON response but received HTML (status 200).
Response body:
<!DOCTYPE html><html>...
```

## What changed

| File | Change |
|------|--------|
| `pkg/apiCalls/writeResponse.go` | Exported `IsJSON`, `IsHTML`, `IsXML` for cross-package reuse |
| `pkg/features/graphql/graphql.go` | Added status code check, content type detection with `detectContentType()`, body preview with `truncateBody()` |
| `pkg/features/graphql/schemaparser.go` | `ParseIntrospectionResponse` includes response preview on parse failure |
| `pkg/features/graphql/schemaparser_test.go` | Added 11 new test cases: HTML/XML/plain text parse errors, `TestDetectContentType`, `TestTruncateBody` |