### PR TITLE
feat: add -v and --version flags to print version (#98)

### DIFF
--- a/pkg/userFlags/flags.go
+++ b/pkg/userFlags/flags.go
@@ -27,6 +27,10 @@ var (
 	//
 	// In the above case, the files in the shallowest directories will be processed before deeper ones.
 	dirseq *string
+
+	//version flags
+	vFlag       *bool
+	versionFlag *bool
 )
 
 // go's init func executes automatically, and registers the flags during package initialization
@@ -60,6 +64,9 @@ func init() {
 		"",
 		"Directory path to run in alphabetical order",
 	)
+
+	vFlag = flag.Bool("v", false, "Print the version")
+	versionFlag = flag.Bool("version", false, "Print the version")
 }
 
 // FilePath returns the parsed value of the file path "fp" flag -fp

--- a/pkg/userFlags/userflags.go
+++ b/pkg/userFlags/userflags.go
@@ -22,6 +22,10 @@ func ParseFlagsSubcmds() (*AllFlags, error) {
 	if len(os.Args) >= 2 {
 		if HasFlag() {
 			flag.Parse()
+			if *vFlag || *versionFlag {
+				getVersion()
+				os.Exit(0)
+			}
 		} else {
 			err := HandleSubcommands()
 			if err != nil {


### PR DESCRIPTION
## Summary
Added support for `-v` and `--version` flags to print the CLI version. Previously, only the `version` subcommand was supported. 

### Changes:
- Registered `v` and `version` boolean flags in `pkg/userFlags`.
- Updated `ParseFlagsSubcmds` to intercept these flags and call `getVersion()`.
- Verified locally that `hulak -v`, `hulak --version`, and `hulak version` all work correctly.

Fixes: #98