### PR TITLE
CLI router refactor: explicit command dispatch + env subcommand stubs

### DIFF
--- a/pkg/userFlags/cli_contract_test.go
+++ b/pkg/userFlags/cli_contract_test.go
@@ -10,7 +10,7 @@ import (
 func TestSubCommandsExist(t *testing.T) {
 	root := subCommands()
 
-	expected := []string{"version", "init", "migrate", "doctor", "gql", "help"}
+	expected := []string{"version", "init", "migrate", "doctor", "gql", "env", "help"}
 	for _, name := range expected {
 		if root.findSub(name) == nil {
 			t.Errorf("expected subcommand %q to exist", name)
@@ -90,6 +90,118 @@ func TestFlagAliasesShareVariable(t *testing.T) {
 		// Restore original values to avoid leaking state to other tests
 		_ = short.Value.Set(origShort)
 		_ = long.Value.Set(origLong)
+	}
+}
+
+// TestEnvSubCommandsExist verifies every expected env subcommand is registered.
+func TestEnvSubCommandsExist(t *testing.T) {
+	root := subCommands()
+	envCmd := root.findSub("env")
+	if envCmd == nil {
+		t.Fatal("expected env subcommand to exist")
+	}
+
+	expected := []string{"set", "get", "list", "keys", "delete"}
+	for _, name := range expected {
+		if envCmd.findSub(name) == nil {
+			t.Errorf("expected env subcommand %q to exist", name)
+		}
+	}
+}
+
+// TestEnvListAlias verifies "ls" resolves to the "list" subcommand.
+func TestEnvListAlias(t *testing.T) {
+	root := subCommands()
+	envCmd := root.findSub("env")
+	if envCmd == nil {
+		t.Fatal("expected env subcommand to exist")
+	}
+
+	for _, name := range []string{"list", "ls"} {
+		if envCmd.findSub(name) == nil {
+			t.Errorf("expected env subcommand %q to resolve", name)
+		}
+	}
+}
+
+// TestEnvSetAlias verifies "add" resolves to the "set" subcommand.
+func TestEnvSetAlias(t *testing.T) {
+	root := subCommands()
+	envCmd := root.findSub("env")
+	if envCmd == nil {
+		t.Fatal("expected env subcommand to exist")
+	}
+
+	for _, name := range []string{"set", "add"} {
+		if envCmd.findSub(name) == nil {
+			t.Errorf("expected env subcommand %q to resolve", name)
+		}
+	}
+}
+
+// TestEnvKeysAlias verifies "key" resolves to the "keys" subcommand.
+func TestEnvKeysAlias(t *testing.T) {
+	root := subCommands()
+	envCmd := root.findSub("env")
+	if envCmd == nil {
+		t.Fatal("expected env subcommand to exist")
+	}
+
+	for _, name := range []string{"keys", "key"} {
+		if envCmd.findSub(name) == nil {
+			t.Errorf("expected env subcommand %q to resolve", name)
+		}
+	}
+}
+
+// TestEnvDeleteAlias verifies "rm" and "remove" resolve to the "delete" subcommand.
+func TestEnvDeleteAlias(t *testing.T) {
+	root := subCommands()
+	envCmd := root.findSub("env")
+	if envCmd == nil {
+		t.Fatal("expected env subcommand to exist")
+	}
+
+	for _, name := range []string{"delete", "rm", "remove"} {
+		if envCmd.findSub(name) == nil {
+			t.Errorf("expected env subcommand %q to resolve", name)
+		}
+	}
+}
+
+// TestEnvSubCommandsHaveFlags verifies env subcommands that need flags have them.
+func TestEnvSubCommandsHaveFlags(t *testing.T) {
+	root := subCommands()
+	envCmd := root.findSub("env")
+	if envCmd == nil {
+		t.Fatal("expected env subcommand to exist")
+	}
+
+	for _, sub := range envCmd.SubCommands {
+		if sub.Flags == nil {
+			t.Errorf("env subcommand %q should have its own FlagSet", sub.Name)
+			continue
+		}
+		if sub.Flags.Lookup("env") == nil {
+			t.Errorf("env subcommand %q should have an --env flag", sub.Name)
+		}
+	}
+}
+
+// TestEnvFlagDoesNotConflictWithEnvSubcommand verifies that the -env global
+// flag and the env subcommand coexist. The flag is prefixed with "-" so the
+// router dispatches them to different paths.
+func TestEnvFlagDoesNotConflictWithEnvSubcommand(t *testing.T) {
+	root := subCommands()
+
+	// "env" (no dash) should resolve as a subcommand
+	if root.findSub("env") == nil {
+		t.Error("expected 'env' to resolve as a subcommand")
+	}
+
+	// "-env" should NOT resolve as a subcommand (it's a flag)
+	if root.findSub("-env") != nil {
+		t.Error("'-env' should not resolve as a subcommand")
 	}
 }
 

--- a/pkg/userFlags/cli_contract_test.go
+++ b/pkg/userFlags/cli_contract_test.go
@@ -114,62 +114,31 @@ func TestEnvSubCommandsExist(t *testing.T) {
 	}
 }
 
-// TestEnvListAlias verifies "ls" resolves to the "list" subcommand.
-func TestEnvListAlias(t *testing.T) {
+// TestEnvAliases verifies that all env subcommand aliases resolve correctly.
+func TestEnvAliases(t *testing.T) {
 	root := subCommands()
 	envCmd := root.findSub("env")
 	if envCmd == nil {
 		t.Fatal("expected env subcommand to exist")
 	}
 
-	for _, name := range []string{"list", "ls"} {
-		if envCmd.findSub(name) == nil {
-			t.Errorf("expected env subcommand %q to resolve", name)
-		}
-	}
-}
-
-// TestEnvSetAlias verifies "add" resolves to the "set" subcommand.
-func TestEnvSetAlias(t *testing.T) {
-	root := subCommands()
-	envCmd := root.findSub("env")
-	if envCmd == nil {
-		t.Fatal("expected env subcommand to exist")
+	tests := []struct {
+		name    string
+		aliases []string
+	}{
+		{"list", []string{"ls"}},
+		{"set", []string{"add"}},
+		{"keys", []string{"key"}},
+		{"delete", []string{"rm", "remove"}},
 	}
 
-	for _, name := range []string{"set", "add"} {
-		if envCmd.findSub(name) == nil {
-			t.Errorf("expected env subcommand %q to resolve", name)
-		}
-	}
-}
-
-// TestEnvKeysAlias verifies "key" resolves to the "keys" subcommand.
-func TestEnvKeysAlias(t *testing.T) {
-	root := subCommands()
-	envCmd := root.findSub("env")
-	if envCmd == nil {
-		t.Fatal("expected env subcommand to exist")
-	}
-
-	for _, name := range []string{"keys", "key"} {
-		if envCmd.findSub(name) == nil {
-			t.Errorf("expected env subcommand %q to resolve", name)
-		}
-	}
-}
-
-// TestEnvDeleteAlias verifies "rm" and "remove" resolve to the "delete" subcommand.
-func TestEnvDeleteAlias(t *testing.T) {
-	root := subCommands()
-	envCmd := root.findSub("env")
-	if envCmd == nil {
-		t.Fatal("expected env subcommand to exist")
-	}
-
-	for _, name := range []string{"delete", "rm", "remove"} {
-		if envCmd.findSub(name) == nil {
-			t.Errorf("expected env subcommand %q to resolve", name)
+	for _, tc := range tests {
+		for _, alias := range append([]string{tc.name}, tc.aliases...) {
+			t.Run(alias, func(t *testing.T) {
+				if envCmd.findSub(alias) == nil {
+					t.Errorf("expected env subcommand %q to resolve (alias of %q)", alias, tc.name)
+				}
+			})
 		}
 	}
 }

--- a/pkg/userFlags/cli_contract_test.go
+++ b/pkg/userFlags/cli_contract_test.go
@@ -33,7 +33,7 @@ func TestGQLAliases(t *testing.T) {
 // registered on flag.CommandLine. Removing a flag breaks the CLI contract.
 func TestGlobalFlagsRegistered(t *testing.T) {
 	expected := []string{
-		"env", "fp", "file-path", "f", "file",
+		"env", "environment", "fp", "file-path", "f", "file",
 		"debug", "dir", "dirseq",
 		"v", "version", "h", "help",
 	}
@@ -53,6 +53,7 @@ func TestFlagAliasesShareVariable(t *testing.T) {
 		short string
 		long  string
 	}{
+		{"env", "environment"},
 		{"fp", "file-path"},
 		{"f", "file"},
 		{"v", "version"},
@@ -196,6 +197,83 @@ func TestEnvSubCommandsHaveFlags(t *testing.T) {
 		}
 		if sub.Flags.Lookup("env") == nil {
 			t.Errorf("env subcommand %q should have an --env flag", name)
+		}
+	}
+}
+
+// TestEnvSubCommandsHaveEnvironmentAlias verifies that env subcommands
+// accepting --env also accept --environment.
+func TestEnvSubCommandsHaveEnvironmentAlias(t *testing.T) {
+	root := subCommands()
+	envCmd := root.findSub("env")
+	if envCmd == nil {
+		t.Fatal("expected env subcommand to exist")
+	}
+
+	needsEnvFlag := []string{"set", "get", "list", "keys", "delete", "edit"}
+	for _, name := range needsEnvFlag {
+		sub := envCmd.findSub(name)
+		if sub == nil {
+			t.Errorf("expected env subcommand %q to exist", name)
+			continue
+		}
+		if sub.Flags == nil {
+			t.Errorf("env subcommand %q should have its own FlagSet", name)
+			continue
+		}
+		if sub.Flags.Lookup("environment") == nil {
+			t.Errorf("env subcommand %q should have an --environment alias", name)
+		}
+	}
+}
+
+// TestEnvSubCommandSpecificFlags verifies subcommand-specific flags
+// that are part of the CLI contract don't get accidentally removed.
+func TestEnvSubCommandSpecificFlags(t *testing.T) {
+	root := subCommands()
+	envCmd := root.findSub("env")
+	if envCmd == nil {
+		t.Fatal("expected env subcommand to exist")
+	}
+
+	tests := []struct {
+		subcommand string
+		flag       string
+	}{
+		{"set", "stdin"},
+		{"keys", "show"},
+		{"import-key", "stdin"},
+		{"export-key", "armor"},
+	}
+
+	for _, tc := range tests {
+		sub := envCmd.findSub(tc.subcommand)
+		if sub == nil {
+			t.Errorf("expected env subcommand %q to exist", tc.subcommand)
+			continue
+		}
+		if sub.Flags == nil {
+			t.Errorf("env subcommand %q should have a FlagSet", tc.subcommand)
+			continue
+		}
+		if sub.Flags.Lookup(tc.flag) == nil {
+			t.Errorf("env subcommand %q should have a --%s flag", tc.subcommand, tc.flag)
+		}
+	}
+}
+
+// TestEnvSubCommandsHaveRunHandlers verifies every env subcommand has a
+// non-nil Run handler so dispatch doesn't silently fall through to help.
+func TestEnvSubCommandsHaveRunHandlers(t *testing.T) {
+	root := subCommands()
+	envCmd := root.findSub("env")
+	if envCmd == nil {
+		t.Fatal("expected env subcommand to exist")
+	}
+
+	for _, sub := range envCmd.SubCommands {
+		if sub.Run == nil {
+			t.Errorf("env subcommand %q is missing a Run handler", sub.Name)
 		}
 	}
 }

--- a/pkg/userFlags/cli_contract_test.go
+++ b/pkg/userFlags/cli_contract_test.go
@@ -101,7 +101,11 @@ func TestEnvSubCommandsExist(t *testing.T) {
 		t.Fatal("expected env subcommand to exist")
 	}
 
-	expected := []string{"set", "get", "list", "keys", "delete"}
+	expected := []string{
+		"set", "get", "list", "keys", "delete", "edit",
+		"import-key", "export-key",
+		"add-recipient", "remove-recipient", "list-recipients",
+	}
 	for _, name := range expected {
 		if envCmd.findSub(name) == nil {
 			t.Errorf("expected env subcommand %q to exist", name)
@@ -169,7 +173,8 @@ func TestEnvDeleteAlias(t *testing.T) {
 	}
 }
 
-// TestEnvSubCommandsHaveFlags verifies env subcommands that need flags have them.
+// TestEnvSubCommandsHaveFlags verifies env subcommands that operate on a
+// specific environment have an --env flag in their FlagSet.
 func TestEnvSubCommandsHaveFlags(t *testing.T) {
 	root := subCommands()
 	envCmd := root.findSub("env")
@@ -177,13 +182,20 @@ func TestEnvSubCommandsHaveFlags(t *testing.T) {
 		t.Fatal("expected env subcommand to exist")
 	}
 
-	for _, sub := range envCmd.SubCommands {
+	// Subcommands that target a specific environment
+	needsEnvFlag := []string{"set", "get", "list", "keys", "delete", "edit"}
+	for _, name := range needsEnvFlag {
+		sub := envCmd.findSub(name)
+		if sub == nil {
+			t.Errorf("expected env subcommand %q to exist", name)
+			continue
+		}
 		if sub.Flags == nil {
-			t.Errorf("env subcommand %q should have its own FlagSet", sub.Name)
+			t.Errorf("env subcommand %q should have its own FlagSet", name)
 			continue
 		}
 		if sub.Flags.Lookup("env") == nil {
-			t.Errorf("env subcommand %q should have an --env flag", sub.Name)
+			t.Errorf("env subcommand %q should have an --env flag", name)
 		}
 	}
 }

--- a/pkg/userFlags/command.go
+++ b/pkg/userFlags/command.go
@@ -129,8 +129,12 @@ func (cmd *command) printHelp() {
 		utils.PrintWarning("COMMANDS")
 		var entries []*utils.CommandHelp
 		for _, sub := range cmd.SubCommands {
+			name := sub.Name
+			if len(sub.Aliases) > 0 {
+				name += " (" + strings.Join(sub.Aliases, ", ") + ")"
+			}
 			entries = append(entries, &utils.CommandHelp{
-				Command:     sub.Name,
+				Command:     name,
 				Description: sub.Short,
 			})
 		}

--- a/pkg/userFlags/command.go
+++ b/pkg/userFlags/command.go
@@ -14,10 +14,11 @@ import (
 // The long form is hidden from help output; only the short form is shown
 // with both names on one line (e.g. "-fp, --file-path").
 var flagAliases = map[string]string{
-	"file-path": "fp",
-	"file":      "f",
-	"version":   "v",
-	"help":      "h",
+	"file-path":   "fp",
+	"file":        "f",
+	"environment": "env",
+	"version":     "v",
+	"help":        "h",
 }
 
 // hiddenFlags are omitted from help output entirely (utility flags

--- a/pkg/userFlags/command_test.go
+++ b/pkg/userFlags/command_test.go
@@ -250,6 +250,38 @@ func TestPrintHelp(t *testing.T) {
 	}
 }
 
+func TestPrintHelpShowsAliases(t *testing.T) {
+	cmd := &command{
+		Name: "root",
+		Long: "Root command",
+		SubCommands: []*command{
+			{Name: "list", Aliases: []string{"ls"}, Short: "List items"},
+			{Name: "delete", Aliases: []string{"rm", "remove"}, Short: "Delete an item"},
+			{Name: "get", Short: "Get an item"},
+		},
+	}
+
+	output := captureStdout(t, func() {
+		cmd.printHelp()
+	})
+
+	checks := []string{
+		"list (ls)",
+		"delete (rm, remove)",
+		"get",
+	}
+	for _, check := range checks {
+		if !strings.Contains(output, check) {
+			t.Errorf("help output missing %q\nGot:\n%s", check, output)
+		}
+	}
+
+	// "get" should NOT have parentheses since it has no aliases
+	if strings.Contains(output, "get (") {
+		t.Errorf("get should not show alias parentheses\nGot:\n%s", output)
+	}
+}
+
 // captureStdout redirects os.Stdout to a pipe, runs fn, and returns
 // everything that was written to stdout as a string
 func captureStdout(t *testing.T, fn func()) string {

--- a/pkg/userFlags/flags.go
+++ b/pkg/userFlags/flags.go
@@ -34,6 +34,7 @@ var (
 // go's init func executes automatically, and registers the flags during package initialization
 func init() {
 	flag.StringVar(&flagEnv, "env", utils.DefaultEnvVal, "Environment file to use during the call")
+	flag.StringVar(&flagEnv, "environment", utils.DefaultEnvVal, "Environment file to use during the call")
 
 	flag.StringVar(&flagFP, "fp", "", "Relative (or absolute) file path of the request file")
 	flag.StringVar(&flagFP, "file-path", "", "Relative (or absolute) file path of the request file")

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -47,6 +47,7 @@ func subCommands() *command {
 		newMigrateCmd(),
 		newDoctorCmd(),
 		newGQLCmd(),
+		newEnvCmd(),
 		newHelpCmd(root),
 	}
 
@@ -194,6 +195,120 @@ func newGQLCmd() *command {
 	}
 
 	return gqlCmd
+}
+
+func newEnvCmd() *command {
+	envCmd := &command{
+		Name:  "env",
+		Short: "Manage encrypted environment secrets",
+		Long: "Manage environment secrets stored in the encrypted vault (.hulak/store.age).\n\n" +
+			"Secrets are organized by environment (e.g. global, staging, prod).\n" +
+			"The default environment is \"global\" unless --env is specified.",
+		Examples: []*utils.CommandHelp{
+			{
+				Command:     "hulak env list",
+				Description: "List all key-value pairs in the default environment",
+			},
+			{
+				Command:     "hulak env set API_KEY sk-123 --env prod",
+				Description: "Set a secret in the prod environment",
+			},
+			{
+				Command:     "hulak env get API_KEY --env staging",
+				Description: "Get a secret from the staging environment",
+			},
+			{
+				Command:     "hulak env keys --env prod",
+				Description: "List all keys in the prod environment",
+			},
+			{
+				Command:     "hulak env delete OLD_KEY",
+				Description: "Delete a key from the default environment",
+			},
+		},
+	}
+
+	// use utils.DefaultEnvVal if user does not provide env
+	// set — store a key-value pair
+	setFs := flag.NewFlagSet("env set", flag.ContinueOnError)
+	setFs.String("env", utils.DefaultEnvVal, "Environment to operate on")
+	setFs.Bool("stdin", false, "Read value from stdin")
+
+	// get — retrieve a value by key
+	getFs := flag.NewFlagSet("env get", flag.ContinueOnError)
+	getFs.String("env", utils.DefaultEnvVal, "Environment to operate on")
+
+	// list — show all key-value pairs
+	listFs := flag.NewFlagSet("env list", flag.ContinueOnError)
+	listFs.String("env", utils.DefaultEnvVal, "Environment to operate on")
+
+	// keys — list keys only
+	keysFs := flag.NewFlagSet("env keys", flag.ContinueOnError)
+	keysFs.String("env", utils.DefaultEnvVal, "Environment to operate on")
+	keysFs.Bool("show", false, "Show actual values instead of masked output")
+
+	// delete — remove a key
+	deleteFs := flag.NewFlagSet("env delete", flag.ContinueOnError)
+	deleteFs.String("env", utils.DefaultEnvVal, "Environment to operate on")
+
+	notImplemented := func(name string) func([]string) error {
+		return func(_ []string) error {
+			fmt.Printf("hulak env %s is not yet implemented\n", name)
+			return nil
+		}
+	}
+
+	envCmd.SubCommands = []*command{
+		{
+			Name:  "set",
+			Short: "Set a key-value pair",
+			Long:  "Store a secret in the encrypted vault.\n\nUse --stdin to pipe the value from standard input.",
+			Flags: setFs,
+			Args: []argDef{
+				{Name: "key", Required: true, Desc: "Secret key name"},
+				{Name: "value", Desc: "Secret value (omit to use --stdin)"},
+			},
+			Run: notImplemented("set"),
+		},
+		{
+			Name:  "get",
+			Short: "Get a value by key",
+			Long:  "Retrieve a secret from the encrypted vault and print it to stdout.",
+			Flags: getFs,
+			Args: []argDef{
+				{Name: "key", Required: true, Desc: "Secret key to retrieve"},
+			},
+			Run: notImplemented("get"),
+		},
+		{
+			Name:    "list",
+			Aliases: []string{"ls"},
+			Short:   "List all key-value pairs",
+			Long:    "Show all secrets in an environment. Values are masked by default.",
+			Flags:   listFs,
+			Run:     notImplemented("list"),
+		},
+		{
+			Name:  "keys",
+			Short: "List keys only",
+			Long:  "Show all secret key names in an environment without values.\n\nUse --show to display actual values.",
+			Flags: keysFs,
+			Run:   notImplemented("keys"),
+		},
+		{
+			Name:    "delete",
+			Aliases: []string{"rm"},
+			Short:   "Delete a key",
+			Long:    "Remove a secret from the encrypted vault.",
+			Flags:   deleteFs,
+			Args: []argDef{
+				{Name: "key", Required: true, Desc: "Secret key to delete"},
+			},
+			Run: notImplemented("delete"),
+		},
+	}
+
+	return envCmd
 }
 
 func newHelpCmd(root *command) *command {

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -260,10 +260,11 @@ func newEnvCmd() *command {
 
 	envCmd.SubCommands = []*command{
 		{
-			Name:  "set",
-			Short: "Set a key-value pair",
-			Long:  "Store a secret in the encrypted vault.\n\nUse --stdin to pipe the value from standard input.",
-			Flags: setFs,
+			Name:    "set",
+			Aliases: []string{"add"},
+			Short:   "Set a key-value pair",
+			Long:    "Store a secret in the encrypted vault.\n\nUse --stdin to pipe the value from standard input.",
+			Flags:   setFs,
 			Args: []argDef{
 				{Name: "key", Required: true, Desc: "Secret key name"},
 				{Name: "value", Desc: "Secret value (omit to use --stdin)"},
@@ -289,15 +290,16 @@ func newEnvCmd() *command {
 			Run:     notImplemented("list"),
 		},
 		{
-			Name:  "keys",
-			Short: "List keys only",
-			Long:  "Show all secret key names in an environment without values.\n\nUse --show to display actual values.",
-			Flags: keysFs,
-			Run:   notImplemented("keys"),
+			Name:    "keys",
+			Aliases: []string{"key"},
+			Short:   "List keys only",
+			Long:    "Show all secret key names in an environment without values.\n\nUse --show to display actual values.",
+			Flags:   keysFs,
+			Run:     notImplemented("keys"),
 		},
 		{
 			Name:    "delete",
-			Aliases: []string{"rm"},
+			Aliases: []string{"rm", "remove"},
 			Short:   "Delete a key",
 			Long:    "Remove a secret from the encrypted vault.",
 			Flags:   deleteFs,

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -229,6 +229,7 @@ func newEnvCmd() *command {
 	}
 
 	// use utils.DefaultEnvVal if user does not provide env
+
 	// set — store a key-value pair
 	setFs := flag.NewFlagSet("env set", flag.ContinueOnError)
 	setFs.String("env", utils.DefaultEnvVal, "Environment to operate on")
@@ -250,6 +251,18 @@ func newEnvCmd() *command {
 	// delete — remove a key
 	deleteFs := flag.NewFlagSet("env delete", flag.ContinueOnError)
 	deleteFs.String("env", utils.DefaultEnvVal, "Environment to operate on")
+
+	// edit — interactive editor
+	editFs := flag.NewFlagSet("env edit", flag.ContinueOnError)
+	editFs.String("env", utils.DefaultEnvVal, "Environment to operate on")
+
+	// import-key — import an age identity
+	importKeyFs := flag.NewFlagSet("env import-key", flag.ContinueOnError)
+	importKeyFs.Bool("stdin", false, "Read key from stdin")
+
+	// export-key — export the age identity
+	exportKeyFs := flag.NewFlagSet("env export-key", flag.ContinueOnError)
+	exportKeyFs.Bool("armor", false, "Output in ASCII-armored format")
 
 	notImplemented := func(name string) func([]string) error {
 		return func(_ []string) error {
@@ -307,6 +320,48 @@ func newEnvCmd() *command {
 				{Name: "key", Required: true, Desc: "Secret key to delete"},
 			},
 			Run: notImplemented("delete"),
+		},
+		{
+			Name:  "edit",
+			Short: "Edit secrets interactively",
+			Long:  "Open an interactive editor for secrets in an environment.",
+			Flags: editFs,
+			Run:   notImplemented("edit"),
+		},
+		{
+			Name:  "import-key",
+			Short: "Import an age identity file",
+			Long:  "Import an age private key from a file or stdin into the hulak config directory.",
+			Flags: importKeyFs,
+			Args:  []argDef{{Name: "path", Desc: "Path to the identity file (omit to read from stdin)"}},
+			Run:   notImplemented("import-key"),
+		},
+		{
+			Name:  "export-key",
+			Short: "Export the age identity file",
+			Long:  "Print the age private key to stdout for backup or transfer to another machine.",
+			Flags: exportKeyFs,
+			Run:   notImplemented("export-key"),
+		},
+		{
+			Name:  "add-recipient",
+			Short: "Add a recipient for shared vault access",
+			Long:  "Add an age public key as a recipient so another user can decrypt the vault.",
+			Args:  []argDef{{Name: "public-key", Required: true, Desc: "Age public key to add"}},
+			Run:   notImplemented("add-recipient"),
+		},
+		{
+			Name:  "remove-recipient",
+			Short: "Remove a recipient",
+			Long:  "Remove an age public key from the recipient list.",
+			Args:  []argDef{{Name: "public-key", Required: true, Desc: "Age public key to remove"}},
+			Run:   notImplemented("remove-recipient"),
+		},
+		{
+			Name:  "list-recipients",
+			Short: "List all recipients",
+			Long:  "Show all age public keys that can decrypt the vault.",
+			Run:   notImplemented("list-recipients"),
 		},
 	}
 

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -148,7 +148,9 @@ func newDoctorCmd() *command {
 
 func newGQLCmd() *command {
 	fs := flag.NewFlagSet("gql", flag.ContinueOnError)
-	envFlag := fs.String("env", "", "Environment to use (skips interactive selector)")
+	var envFlagVal string
+	fs.StringVar(&envFlagVal, "env", "", "Environment to use (skips interactive selector)")
+	fs.StringVar(&envFlagVal, "environment", "", "Environment to use (skips interactive selector)")
 
 	gqlCmd := &command{
 		Name:    "gql",
@@ -184,7 +186,7 @@ func newGQLCmd() *command {
 			gqlCmd.printHelp()
 			return nil
 		}
-		data, refreshFn, warnings := loadGraphQLOperations(args[0], *envFlag)
+		data, refreshFn, warnings := loadGraphQLOperations(args[0], envFlagVal)
 		if data.Operations == nil {
 			return nil
 		}
@@ -230,31 +232,39 @@ func newEnvCmd() *command {
 
 	// use utils.DefaultEnvVal if user does not provide env
 
+	// registerEnvFlag adds both -env and --environment aliases to a FlagSet,
+	// pointing to the same underlying variable.
+	registerEnvFlag := func(fs *flag.FlagSet) {
+		var envVal string
+		fs.StringVar(&envVal, "env", utils.DefaultEnvVal, "Environment to operate on")
+		fs.StringVar(&envVal, "environment", utils.DefaultEnvVal, "Environment to operate on")
+	}
+
 	// set — store a key-value pair
 	setFs := flag.NewFlagSet("env set", flag.ContinueOnError)
-	setFs.String("env", utils.DefaultEnvVal, "Environment to operate on")
+	registerEnvFlag(setFs)
 	setFs.Bool("stdin", false, "Read value from stdin")
 
 	// get — retrieve a value by key
 	getFs := flag.NewFlagSet("env get", flag.ContinueOnError)
-	getFs.String("env", utils.DefaultEnvVal, "Environment to operate on")
+	registerEnvFlag(getFs)
 
 	// list — show all key-value pairs
 	listFs := flag.NewFlagSet("env list", flag.ContinueOnError)
-	listFs.String("env", utils.DefaultEnvVal, "Environment to operate on")
+	registerEnvFlag(listFs)
 
 	// keys — list keys only
 	keysFs := flag.NewFlagSet("env keys", flag.ContinueOnError)
-	keysFs.String("env", utils.DefaultEnvVal, "Environment to operate on")
+	registerEnvFlag(keysFs)
 	keysFs.Bool("show", false, "Show actual values instead of masked output")
 
 	// delete — remove a key
 	deleteFs := flag.NewFlagSet("env delete", flag.ContinueOnError)
-	deleteFs.String("env", utils.DefaultEnvVal, "Environment to operate on")
+	registerEnvFlag(deleteFs)
 
 	// edit — interactive editor
 	editFs := flag.NewFlagSet("env edit", flag.ContinueOnError)
-	editFs.String("env", utils.DefaultEnvVal, "Environment to operate on")
+	registerEnvFlag(editFs)
 
 	// import-key — import an age identity
 	importKeyFs := flag.NewFlagSet("env import-key", flag.ContinueOnError)

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -233,38 +233,40 @@ func newEnvCmd() *command {
 	// use utils.DefaultEnvVal if user does not provide env
 
 	// registerEnvFlag adds both -env and --environment aliases to a FlagSet,
-	// pointing to the same underlying variable.
-	registerEnvFlag := func(fs *flag.FlagSet) {
+	// pointing to the same underlying variable, and returns a pointer so
+	// Run handlers can read the parsed value.
+	registerEnvFlag := func(fs *flag.FlagSet) *string {
 		var envVal string
 		fs.StringVar(&envVal, "env", utils.DefaultEnvVal, "Environment to operate on")
 		fs.StringVar(&envVal, "environment", utils.DefaultEnvVal, "Environment to operate on")
+		return &envVal
 	}
 
 	// set — store a key-value pair
 	setFs := flag.NewFlagSet("env set", flag.ContinueOnError)
-	registerEnvFlag(setFs)
+	_ = registerEnvFlag(setFs)
 	setFs.Bool("stdin", false, "Read value from stdin")
 
 	// get — retrieve a value by key
 	getFs := flag.NewFlagSet("env get", flag.ContinueOnError)
-	registerEnvFlag(getFs)
+	_ = registerEnvFlag(getFs)
 
 	// list — show all key-value pairs
 	listFs := flag.NewFlagSet("env list", flag.ContinueOnError)
-	registerEnvFlag(listFs)
+	_ = registerEnvFlag(listFs)
 
 	// keys — list keys only
 	keysFs := flag.NewFlagSet("env keys", flag.ContinueOnError)
-	registerEnvFlag(keysFs)
+	_ = registerEnvFlag(keysFs)
 	keysFs.Bool("show", false, "Show actual values instead of masked output")
 
 	// delete — remove a key
 	deleteFs := flag.NewFlagSet("env delete", flag.ContinueOnError)
-	registerEnvFlag(deleteFs)
+	_ = registerEnvFlag(deleteFs)
 
 	// edit — interactive editor
 	editFs := flag.NewFlagSet("env edit", flag.ContinueOnError)
-	registerEnvFlag(editFs)
+	_ = registerEnvFlag(editFs)
 
 	// import-key — import an age identity
 	importKeyFs := flag.NewFlagSet("env import-key", flag.ContinueOnError)

--- a/pkg/userFlags/userflags.go
+++ b/pkg/userFlags/userflags.go
@@ -4,6 +4,7 @@ package userflags
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -25,6 +26,12 @@ type AllFlags struct {
 func ParseFlagsSubcmds() (*AllFlags, error) {
 	subCmds := subCommands()
 
+	// Override Go's default flag error handling so we show hulak-style
+	// errors instead of the raw flag.Usage dump.
+	flag.CommandLine.Init(os.Args[0], flag.ContinueOnError)
+	flag.CommandLine.Usage = func() {}     // suppress default usage on error
+	flag.CommandLine.SetOutput(io.Discard) // suppress "flag provided but not defined" to stderr
+
 	if len(os.Args) >= 2 {
 		first := os.Args[1]
 		switch {
@@ -34,7 +41,10 @@ func ParseFlagsSubcmds() (*AllFlags, error) {
 			}
 			os.Exit(0)
 		case strings.HasPrefix(first, "-"):
-			flag.Parse()
+			if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
+				utils.PrintRed(fmt.Sprintf("%s\nSee 'hulak help' for available flags", err))
+				os.Exit(1)
+			}
 			switch {
 			case flagVersion:
 				getVersion()
@@ -51,7 +61,7 @@ func ParseFlagsSubcmds() (*AllFlags, error) {
 
 	envSet := false
 	flag.Visit(func(f *flag.Flag) {
-		if f.Name == "env" {
+		if f.Name == "env" || f.Name == "environment" {
 			envSet = true
 		}
 	})

--- a/pkg/userFlags/userflags.go
+++ b/pkg/userFlags/userflags.go
@@ -3,7 +3,11 @@ package userflags
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"strings"
+
+	"github.com/xaaha/hulak/pkg/utils"
 )
 
 // AllFlags  All user flags and subcommands
@@ -22,21 +26,26 @@ func ParseFlagsSubcmds() (*AllFlags, error) {
 	subCmds := subCommands()
 
 	if len(os.Args) >= 2 {
-		if !hasFlag() {
+		first := os.Args[1]
+		switch {
+		case subCmds.findSub(first) != nil:
 			if err := subCmds.Execute(os.Args[1:]); err != nil {
 				return nil, err
 			}
 			os.Exit(0)
-		}
-
-		flag.Parse()
-		switch {
-		case flagVersion:
-			getVersion()
-			os.Exit(0)
-		case flagHelp:
-			subCmds.printHelp()
-			os.Exit(0)
+		case strings.HasPrefix(first, "-"):
+			flag.Parse()
+			switch {
+			case flagVersion:
+				getVersion()
+				os.Exit(0)
+			case flagHelp:
+				subCmds.printHelp()
+				os.Exit(0)
+			}
+		default:
+			utils.PrintRed(fmt.Sprintf("unknown command %q. See 'hulak help'", first))
+			os.Exit(1)
 		}
 	}
 
@@ -56,9 +65,4 @@ func ParseFlagsSubcmds() (*AllFlags, error) {
 		Dir:      flagDir,
 		Dirseq:   flagDirseq,
 	}, nil
-}
-
-// hasFlag checks if user passed in a flag with -
-func hasFlag() bool {
-	return len(os.Args[1]) > 0 && os.Args[1][0] == '-'
 }


### PR DESCRIPTION
## Summary

Closes #141

- Replaced `hasFlag()` with explicit 3-way dispatch in `ParseFlagsSubcmds()`: known subcommand → dispatch, `-` prefix → flag parse, unknown → error
- Added `env` subcommand with all 11 nested subcommand stubs (`set`, `get`, `list`, `keys`, `delete`, `edit`, `import-key`, `export-key`, `add-recipient`, `remove-recipient`, `list-recipients`), each with its own `flag.NewFlagSet`
- Added `--environment` as long-form alias for `-env` on global flags and all env subcommand FlagSets
- Added subcommand aliases: `set`/`add`, `list`/`ls`, `keys`/`key`, `delete`/`rm`/`remove`
- Aliases now visible in `--help` output (e.g. `delete (rm, remove)`)
- Unknown flags now show hulak-styled error instead of Go's raw usage dump
- Contract tests for all subcommands, aliases, flags, and regression protection

## Test plan

- [x] `mise run check` passes (lint + all tests)
- [x] `hulak env` shows help with all subcommands
- [x] `hulak env set` prints stub message
- [x] `hulak --environment staging -fp file.yaml` works same as `-env`
- [x] `hulak foobar` shows clean error
- [x] `hulak -fp file.yaml --typo` shows hulak-styled error