### PR TITLE
hulak run: explicit subcommand for running request files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Browse schemas from multiple endpoints, search operations, build queries interac
 ### Install
 
 ```bash
-brew install --cask xaaha/tap/hulak
+brew install xaaha/tap/hulak
 ```
 
 Other install options:

--- a/README.md
+++ b/README.md
@@ -7,435 +7,130 @@
 </h3>
 
 <p align="center">
-  A file-based API client for your terminal. Define requests in YAML, run them instantly, version-control everything.
+  A file-based API client for your terminal. Define requests in YAML, run them instantly, and keep everything in git.
   <br/>
-  REST, GraphQL, OAuth 2.0 — zero GUI overhead.
+  REST, GraphQL, and OAuth 2.0 without GUI overhead.
 </p>
 
 <p align="center">
-  <a href="#getting-started">Getting Started</a> &bull;
-  <a href="#why-hulak">Why Hulak</a> &bull;
-  <a href="#graphql-explorer-1">GraphQL Explorer</a> &bull;
-  <a href="#documentation">Docs</a>
+  <a href="#quick-start">Quick Start</a> &bull;
+  <a href="#graphql-explorer">GraphQL Explorer</a> &bull;
+  <a href="#documentation">Documentation</a>
 </p>
 
 ---
 
-### 20 API requests. Under 2 seconds. Concurrently.
+### Run one request, a whole directory, or stay interactive
 
 <img alt="Concurrent Execution" src="./assets/concurrent.gif" width="720" />
 
 ```bash
-hulak -dir ./requests/    # fire every YAML file in the directory, concurrently
+hulak run ./requests/
 ```
+
+Hulak runs request files directly from your project, supports concurrent directory execution, and falls back to an interactive picker when you simply run `hulak`.
 
 ### Dedicated GraphQL Explorer
 
 <img alt="GraphQL Explorer" src="./assets/gql.gif" width="720" />
 
-Browse schemas from multiple endpoints, search operations, build queries interactively, execute inline, and save results — all from the terminal.
+Browse schemas from multiple endpoints, search operations, build queries interactively, execute inline, and save generated files from the terminal.
 
-### Fast Interactive Runner
+## Quick Start
 
-<img alt="Interactive Runner" src="./assets/fp.gif" width="720" />
-
-Just type `hulak` → find your request file → pick an environment → get your response.
-
-### Quick Install
+### Install
 
 ```bash
-brew install xaaha/tap/hulak
+brew install --cask xaaha/tap/hulak
 ```
 
----
+Other install options:
 
-## Why Hulak
+- `go install github.com/xaaha/hulak@latest`
+- build from source with `go build -o hulak`
 
-|                            | Hulak                      | GUI Clients (Postman, Insomnia, Bruno) |
-| -------------------------- | -------------------------- | -------------------------------------- |
-| **Startup time**           | Instant (native Go binary) | 3-10s (Electron)                       |
-| **20 concurrent requests** | < 2 seconds                | Manual, one-by-one                     |
-| **Account required**       | No                         | Often yes                              |
-| **Telemetry**              | None                       | Varies                                 |
-| **Version control**        | YAML files in git          | Export/import dance                    |
-| **CI/CD friendly**         | `hulak -dir ./tests/`      | Needs extra tooling                    |
-| **Env management**         | `.env` files, git-friendly | UI-only, fragile                       |
-
----
-
-# Table of Contents
-
-- [Getting Started](#getting-started)
-  - [Installation](#installation)
-    - [1. Homebrew](#1-homebrew)
-    - [2. go install](#2-go-install)
-    - [3. Build from source](#3-build-from-source)
-  - [Verify Installation](#verify-installation)
-  - [Initialize Project](#initialize-project)
-  - [Create An API File](#create-an-api-file)
-- [GraphQL Explorer](#graphql-explorer-1)
-- [Actions](#actions)
-  - [.Key](#key)
-  - [getValueOf](#getvalueof)
-  - [getFile](#getfile)
-  - [basicAuth](#basicauth)
-- [Flags and Subcommands](#flags-and-subcommands)
-  - [Flags](#flags)
-  - [Subcommands](#subcommands)
-- [Schema](#schema)
-- [Auth2.0 (Beta)](#auth20-beta)
-- [Documentation](#documentation)
-- [Planned Features](#planned-features)
-- [Contributing](#contributing)
-- [Support the Project](#support-the-project)
-
-# Getting Started
-
-## Installation
-
-### 1. Homebrew
+### Initialize a project
 
 ```bash
-brew install xaaha/tap/hulak
-```
-
-### 2. `go install`
-
-- Run
-
-```bash
-go install github.com/xaaha/hulak@latest
-```
-
-- You need to install `go` in your system
-- In order for any utility, installed with `go install`, to be available for use, you need the path from `go env GOPATH` to be in the shell's PATH.
-
-  • If it's not, add the following to your shell's configuration file.
-
-```bash
-export GOPATH=$HOME/go
-export PATH=$PATH:$(go env GOPATH)/bin
-```
-
-- Then source your shell configuration file `source ~/.zshrc` or `source ~/.bashrc`
-
-### 3. Build from source
-
-- Clone the repo
-- Install required dependencies: Run `go mod tidy` in the root of the project
-- Build the executable with: `go build -o hulak`
-- Move the executable to the path.
-  - On Mac/Linux: `sudo mv hulak /usr/local/bin/`
-    - Verify the project exists in path with: `which hulak`
-  - On Windows:
-    - Move the `hulak.exe` binary to a folder that is in your PATH. A common location for this is `C:\Go\bin` (or another directory you've added to your PATH).
-    - To add a folder to your PATH in Windows:
-      Go to `Control Panel > System and Security > System > Advanced system settings`.
-      Click `Environment Variables`.
-      Under `System variables`, find the `Path ` variable and click `Edit`.
-      Add the path to your folder (e.g., `C:\Go\bin`) and click `OK`.
-
-## Verify Installation
-
-```bash
-hulak version
-# or
-hulak help
-```
-
----
-
-## Initialize Project
-
-Create a project directory and cd into it. Then initialize the project
-
-```bash
-mkdir my_apis & cd my_apis
+mkdir my_apis && cd my_apis
 hulak init
 ```
 
-Hulak uses `env` directory to store secrets (e.g., passwords, client IDs) used in API calls that reference environment template vars like `{{.key}}`. It allows separation between different environments like local, test, and production. The `hulak init` command above sets up the secrets directory structure `env/` and also provides an `apiOptions.hk.yaml` file for your reference.
+If you want multiple environment files right away:
 
 ```bash
-# to create multiple .env files in the env directory run
 hulak init -env staging prod
 ```
 
-You can store all secrets in `global.env`, but for running tests with different credentials, use additional `<custom_file_name>.env` files like `staging.env` or `prod.env`.
+Hulak creates an `env/` directory for secrets used by request files that reference template values like `{{.key}}`.
 
-If a selected request needs `{{.key}}` values and `env/global.env` is absent, Hulak will prompt you to create the project setup at runtime. Requests without environment template vars can run without `env/`. For more details read this [environment documentation](./docs/environment.md).
-
-```bash
-# example directory structure
-env/
-  global.env    # default env file used when environment vars are needed
-  prod.env      # user defined, could be anything
-  staging.env   # user defined
-collection/     # example directory
-    test.yaml   # example api file
-```
-
-### Using OS environment variables
-
-If you use a `.env` file to store secrets, you might not want to duplicate secrets already stored in your system environment (for example, your shell). To avoid this, you can reference system environment variables in your `.env` file by using the `$` prefix.
-
-For example, if you had an environment variable `USER=foo` set on your system, and the following was in your `<custom_file_name>.env` file.
-
-```
-exampleVar = $USER
-```
-
-Using `{{.exampleVar}}` within a request file, i.e.
+### Create a request file
 
 ```yaml
-# test.yaml
-method: Get
-url: http://some.api.com/tests?bar={{.exampleVar}}
-```
-
-would result in the request targeting `http://some.api.com/tests?bar=foo`
-
-## Create An API File
-
-A basic API call looks like `test.yaml` below. See full documentation on Request Body structure [here](./docs/body.md). More request examples are [here](https://github.com/xaaha/hulak/tree/main/e2etests/test_collection).
-
-```yaml
-# test.yaml
+# test.hk.yaml
 method: Get
 url: https://jsonplaceholder.typicode.com/todos/1
 ```
 
-Run the file with
+### Run it
 
 ```bash
-hulak -f test
+hulak run test.hk.yaml
+
+# use a specific environment
+hulak run test.hk.yaml --env staging
+
+# run every request in a directory concurrently
+hulak run ./requests/
+
+# or open the interactive picker
+hulak
 ```
 
-Since global is default environment, we don't need to specify `-env global`. If the matched files do not contain environment template vars (`{{.key}}`), Hulak runs them without requiring `env/`.
+If the selected request does not use environment template values, Hulak runs it without requiring `env/` setup.
 
-File's response is printed in the console and also saved at the same location as the calling file with `_response.json` suffix.
-Read more about response in [response documentation](./docs/response.md).
+## GraphQL Explorer
 
-```json
-{
-  "body": {
-    "completed": false,
-    "id": 1,
-    "title": "delectus aut autem",
-    "userId": 1
-  },
-  "status": "200 OK"
-}
-```
-
-Here's a more advanced example using templates, actions, and GraphQL:
-
-```yaml
-# ────────────────────────────────────────────────────
-# Example: test_gql.hk.yaml
-# ────────────────────────────────────────────────────
----
-method: POST
-url: "{{.graphqlUrl}}"
-headers:
-  Content-Type: application/json
-  Authorization: Bearer {{getValueOf "data.access_token" "employer_auth.json"}}
-body:
-  graphql:
-    query: '{{getFile "e2etests/test_collection/test.graphql"}}'
-    variables:
-      name: "{{.userName}} of age {{.userAge}}"
-      age: "{{.userAge}}"
-```
+Start the explorer with a file or a directory:
 
 ```bash
-# Run the file using secrets from staging.env file
-hulak -env staging -f test_gql
-```
-
-# GraphQL Explorer
-
-Hulak has a dedicated GraphQL explorer for schema discovery, operation search, query building, validation, and saving generated files.
-
-Use it when you know a query or mutation exists somewhere but do not remember which endpoint or file owns it.
-
-```bash
-# Explore one GraphQL source file
 hulak gql e2etests/gql_schemas/countries.yml
-
-# Explore all GraphQL source files in the current directory
 hulak gql .
-
-# Skip the environment selector
 hulak gql -env staging ./collections/graphql
 ```
 
-Directory mode auto-detects GraphQL source files by looking for `kind: GraphQL` with a non-empty `url`. Single-file mode only requires a valid file with a non-empty `url`.
-
-The explorer gives you:
-
-- fast operation search
-- type filters with `q:`, `m:`, and `s:`
-- endpoint filtering with `e:`
-- interactive argument and field selection
-- generated query and variables panels
-- inline query execution
-- response inspection and saving
-- generated `.gql` and `.hk.yaml` request files
-
 Read the full guide in [docs/graphql-explorer.md](./docs/graphql-explorer.md).
 
-# Actions
+## Documentation
 
-Actions make it easier to retrieve values from other files. See [actions documentation](./docs/actions.md) for more detailed explanation.
+Start here for the full reference:
 
-### `.Key`
-
-```yaml
-# example section
-body:
-  graphql:
-    query: |
-      query Hello($name: String!, $age: Int) {
-        hello(person: { name: $name, age: $age })
-      }
-    variables:
-      name: "{{.userName}} of age {{.userAge}}"
-      age: "{{.userAge}}"
-```
-
-`.Key` is a variable, that is present in one of the `.env` files. It grabs the value from environment files in the `env/` directory in the root of the project [created above](#initialize-project). The value of `Key` is replaced during runtime.
-In the example above, `.userName` and `.userAge` are examples of retrieving key from secrets stored in `env/`.
-
-### `getValueOf`
-
-```yaml
-# example
-url: `{{getValueOf "key" "file_name" }}`
-```
-
-`getValueOf` looks for the value of the `key` inside the `file_name.json` file. Since responses of the api requests are saved in `file_name_response.json` file in the same directory, you don't need to provide `_response.json` suffix when using `getValueOf`.
-If multiple `file_name.json` is found, hulak recurses through the directory and uses the first file match. So, it's recommended that you use a unique name for each file.
-You can also provide the exact file location instead of `file_name` as `./e2etests/test_collection/graphql_response.json`
-
-- `"key"` and `"file_name"`: Should be surrounded by double quotes (Go template).
-- `key` you are looking for could be in a nested object as well. For example, `user.name` means give me the name inside the user's object. You can escape the dot (.) with single curly brace like `{user.name}`. Here, `user.name` is considered a `key`.
-- `file_name` could be the only file name or the entire file path from project root. If only name is provided, first match will be used.
-
-```yaml
-# name is inside the user object in the user.json file
-name: '{{getValueOf "user.name" "user.json"}}'
-# extract the value of name from nested object from provided json file path
-name: '{{getValueOf "data.users[0].name" "e2etests/test_collection/graphql_response.json"}}'
-# where name is the key in the file
-name: `{{getValueOf "name" "user.json"}}`
-```
-
-### `getFile`
-
-Gets the file content as string and dumps the entire file content in context. It takes file path as an argument. Do not use `getFile` action to pass token in auth header.
-
-```yaml
-# example
-body:
-  graphql:
-    query: '{{getFile "e2etests/test_collection/test.graphql"}}'
-```
-
-### `basicAuth`
-
-Generates a `Basic` authentication header value from a username and password. Hulak joins them with a colon, base64-encodes the result, and returns the full header value.
-
-```yaml
-headers:
-  # with env vars from .env files
-  Authorization: '{{basicAuth .apiUser .apiPassword}}'
-  # with literal strings
-  Authorization: '{{basicAuth "admin" "secret123"}}'
-```
-
-No manual base64 encoding needed — works like `curl -u username:password`.
-
-Learn more about these actions [here](./docs/actions.md)
-
-# Flags and Subcommands
-
-## Flags
-
-| Flag      | Description                                                                                                                                                                                                                                                                                                                                                              | Usage                            |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- |
-| `-env`    | Specify the environment file you want to use for Api Call. If the user flag is absent, it defaults to `global`.                                                                                                                                                                                                                                                          | `-env prod`                      |
-| `-fp`     | Represents file-path for the file/directory you want to run.                                                                                                                                                                                                                                                                                                             | -fp "./collection/getUsers.yaml" |
-| `-f`      | File name (yaml/yml) to run. Hulak searches your directories and subdirectories from the root and finds the matching yaml file(s). If multiple matches are found, they run concurrently                                                                                                                                                                                  | `-f graphql`                     |
-| `-debug`  | Add debug boolean flag to get the entire request, response, headers, and TLS info about the api request                                                                                                                                                                                                                                                                  | `-debug`                         |
-| `-dir`    | Run entire directory concurrently. Only supports (.yaml or .yam) file. All files use the same provided environment                                                                                                                                                                                                                                                       | `-dir path/to/directory/`        |
-| `-dirseq` | Run entire directory one file at a time. Only supports (.yaml or .yam) file. All files use the same provided environment. In nested directory, it is not guaranteed that files will run as they appear in the file system. If the order matters, it's recommended to have a directory without nested directories inside it, in which case, files will run alphabetically | `-dirseq path/to/directory/`     |
-
-Interactive mode (`hulak` with no file/directory flags) picks the request file first. If the selected file requires `{{.key}}`, Hulak then asks for environment selection. During slow file discovery, a spinner appears after a short delay.
-
-## Subcommands
-
-| Subcommand | Description                                                              | Usage                                                                |
-| ---------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------- |
-| help       | display help message                                                     | `hulak help`                                                         |
-| init       | Initialize environment directory and files in it                         | `hulak init` or `hulak init -env global prod staging`                |
-| migrate    | migrates postman environment and collection (v2.1 only) files for hulak. | `hulak migrate "path/to/environment.json" "path/to/collection.json"` |
-| gql        | open the GraphQL explorer for one file or a directory                    | `hulak gql .` or `hulak gql -env staging path/to/graphql`            |
-
-# Schema
-
-To enable auto-completion for Hulak YAML files, you have the following options:
-
-> **Note:** You need a YAML language server for any of these options to work.
-
-## Option 1: Schema Store (Recommended)
-
-The Hulak schema is now available in the [Schema Store](https://www.schemastore.org/). If your editor supports Schema Store (most do, like VS Code and Neovim with `yaml-language-server`), auto-completion will work automatically for files ending in `.hk.yaml` or `.hk.yml`.
-If Schema Store is not set up in your editor, use **Option 2** or **Option 3** below.
-
-## Option 2: Declare Schema in the File
-
-You can declare the schema at the top of your YAML file. This can either be a local schema or a schema referenced by a URL. Here are two examples:
-
-### Local Schema
-
-```yaml
-# yaml-language-server: $schema=../../assets/schema.json
----
-```
-
-OR
-
-```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/xaaha/hulak/refs/heads/main/assets/schema.json
----
-```
-
-## Option 3: Configure Your Editor
-
-Alternatively, you can configure your editor to enable auto-completion without needing to declare the schema in each file. For Neovim users, you can find my configuration [here](https://github.com/xaaha/dev-env/blob/7d25456e59a3a73081baedfd9060810afa4332e4/nvim/.config/nvim/lua/pratik/plugins/lsp/lspconfig.lua).
-Once configured, you can simply rename your file to `yourFile.hk.yaml` for auto-completion.
-
-# Auth2.0 (Beta)
-
-Hulak supports auth2.0 web-application-flow. Follow the auth2.0 provider instruction to set it up. Read more [here](./docs/auth20.md)
-
-# Documentation
-
-For deeper docs, start here:
-
-- [GraphQL Explorer](./docs/graphql-explorer.md)
+- [CLI Reference](./docs/cli.md)
 - [Request Body](./docs/body.md)
 - [Actions](./docs/actions.md)
 - [Environment Secrets](./docs/environment.md)
 - [Response Files](./docs/response.md)
+- [GraphQL Explorer](./docs/graphql-explorer.md)
 - [Auth2.0](./docs/auth20.md)
 
-# Planned Features
+If you want the full list of commands, flags, and subcommands, use [docs/cli.md](./docs/cli.md) or run:
 
-[See Features and Fixes Milestone](https://github.com/xaaha/hulak/milestone) to see all the upcoming, exciting features
+```bash
+hulak help
+hulak <command> --help
+```
 
-# Contributing
+## Schema Support
+
+The Hulak schema is available in the [Schema Store](https://www.schemastore.org/), so editors that support Schema Store can automatically enable completion for `.hk.yaml` and `.hk.yml` files.
+
+You can also point your YAML language server directly at:
+
+```text
+https://raw.githubusercontent.com/xaaha/hulak/refs/heads/main/assets/schema.json
+```
+
+## Contributing
 
 ```bash
 git clone https://github.com/xaaha/hulak.git
@@ -443,8 +138,8 @@ cd hulak
 mise install
 ```
 
-See **[CONTRIBUTING.md](./CONTRIBUTING.md)** for the full guide covering development workflow.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full development workflow.
 
-# Support the Project
+## Support the Project
 
-If you enjoy the project, please consider supporting it by reporting a bug, suggesting a feature request, or sponsoring the project. Your pull request contributions are also welcome. Feel free to open an issue indicating your interest in tackling a bug or implementing a new feature.
+If Hulak is useful to you, open an issue, suggest a feature, send a pull request, or sponsor the project.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,16 +41,16 @@ For command-specific help, prefer `hulak <command> --help`.
 
 ## Command Index
 
-| Command | Purpose | Example |
-| --- | --- | --- |
-| `run` | Run one request file or a directory | `hulak run requests/get-user.hk.yaml` |
-| `version` | Print the current Hulak version | `hulak version` |
-| `init` | Create project setup and env files | `hulak init` |
-| `migrate` | Convert Postman exports to Hulak files | `hulak migrate collection.json` |
-| `doctor` | Check project health | `hulak doctor` |
-| `gql` | Open the GraphQL explorer | `hulak gql .` |
-| `env` | Inspect the environment-secrets command tree | `hulak env --help` |
-| `help` | Show top-level help | `hulak help` |
+| Command   | Purpose                                      | Example                               |
+| --------- | -------------------------------------------- | ------------------------------------- |
+| `run`     | Run one request file or a directory          | `hulak run requests/get-user.hk.yaml` |
+| `version` | Print the current Hulak version              | `hulak version`                       |
+| `init`    | Create project setup and env files           | `hulak init`                          |
+| `migrate` | Convert Postman exports to Hulak files       | `hulak migrate collection.json`       |
+| `doctor`  | Check project health                         | `hulak doctor`                        |
+| `gql`     | Open the GraphQL explorer                    | `hulak gql .`                         |
+| `env`     | Inspect the environment-secrets command tree | `hulak env --help`                    |
+| `help`    | Show top-level help                          | `hulak help`                          |
 
 ## Core Behaviors
 
@@ -84,11 +84,11 @@ hulak run path/to/dir/ --sequential
 
 Supported flags:
 
-| Flag | Meaning |
-| --- | --- |
-| `--env`, `--environment` | Use a specific environment |
-| `--debug` | Print request and response debug details |
-| `--sequential`, `--seq` | Run directory files one at a time |
+| Flag                     | Meaning                                  |
+| ------------------------ | ---------------------------------------- |
+| `--env`, `--environment` | Use a specific environment               |
+| `--debug`                | Print request and response debug details |
+| `--sequential`, `--seq`  | Run directory files one at a time        |
 
 Notes:
 
@@ -154,8 +154,8 @@ Aliases:
 
 Supported flags:
 
-| Flag | Meaning |
-| --- | --- |
+| Flag                     | Meaning                                          |
+| ------------------------ | ------------------------------------------------ |
 | `--env`, `--environment` | Use a specific environment and skip the selector |
 
 Read the full guide in [graphql-explorer.md](./graphql-explorer.md).
@@ -185,8 +185,6 @@ Subcommands currently shown by the CLI:
 - `remove-recipient`
 - `list-recipients`
 
-Important: the command surface is present, but the current handlers still print `not yet implemented` for the scaffolded `env` subcommands.
-
 ### `help`
 
 Print the top-level command list.
@@ -205,15 +203,15 @@ hulak <command> --help
 
 These are still supported. They are useful when you want the older root-flag style or need file-name search behavior.
 
-| Flag | Meaning | Example |
-| --- | --- | --- |
-| `-env`, `--environment` | Select an environment for root-flag execution | `hulak -env prod -fp requests/get-user.hk.yaml` |
-| `-fp`, `--file-path` | Run one exact file path | `hulak -fp requests/get-user.hk.yaml` |
-| `-f`, `--file` | Search for matching file names recursively and run matches | `hulak -f getUser` |
-| `-dir` | Run a directory concurrently | `hulak -dir ./requests/` |
-| `-dirseq` | Run a directory sequentially | `hulak -dirseq ./requests/` |
-| `-debug` | Enable debug output | `hulak -fp requests/get-user.hk.yaml -debug` |
-| `-v`, `--version` | Print version | `hulak --version` |
-| `-h`, `--help` | Print help | `hulak --help` |
+| Flag                    | Meaning                                                    | Example                                         |
+| ----------------------- | ---------------------------------------------------------- | ----------------------------------------------- |
+| `-env`, `--environment` | Select an environment for root-flag execution              | `hulak -env prod -fp requests/get-user.hk.yaml` |
+| `-fp`, `--file-path`    | Run one exact file path                                    | `hulak -fp requests/get-user.hk.yaml`           |
+| `-f`, `--file`          | Search for matching file names recursively and run matches | `hulak -f getUser`                              |
+| `-dir`                  | Run a directory concurrently                               | `hulak -dir ./requests/`                        |
+| `-dirseq`               | Run a directory sequentially                               | `hulak -dirseq ./requests/`                     |
+| `-debug`                | Enable debug output                                        | `hulak -fp requests/get-user.hk.yaml -debug`    |
+| `-v`, `--version`       | Print version                                              | `hulak --version`                               |
+| `-h`, `--help`          | Print help                                                 | `hulak --help`                                  |
 
 Use the shorthand form when it fits your workflow, but prefer `hulak run ...` in examples and onboarding material.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,219 @@
+# Hulak CLI Reference
+
+Hulak supports two ways of running requests:
+
+- **Recommended:** command-first usage such as `hulak run path/to/file.yaml`
+- **Supported shorthand:** root flags such as `hulak -fp path/to/file.yaml` or `hulak -dir path/to/dir/`
+
+If you are documenting or teaching Hulak, prefer the command-first form.
+
+## Quick Start
+
+```bash
+# run one request file
+hulak run path/to/file.yaml
+
+# run one request file with a specific environment
+hulak run path/to/file.yaml --env staging
+
+# run a directory concurrently
+hulak run path/to/dir/
+
+# run a directory sequentially
+hulak run path/to/dir/ --sequential
+
+# open the interactive picker
+hulak
+```
+
+## Discovering Commands
+
+Use these help entry points when you want the current CLI surface from the binary itself:
+
+```bash
+hulak help
+hulak run --help
+hulak gql --help
+hulak env --help
+```
+
+For command-specific help, prefer `hulak <command> --help`.
+
+## Command Index
+
+| Command | Purpose | Example |
+| --- | --- | --- |
+| `run` | Run one request file or a directory | `hulak run requests/get-user.hk.yaml` |
+| `version` | Print the current Hulak version | `hulak version` |
+| `init` | Create project setup and env files | `hulak init` |
+| `migrate` | Convert Postman exports to Hulak files | `hulak migrate collection.json` |
+| `doctor` | Check project health | `hulak doctor` |
+| `gql` | Open the GraphQL explorer | `hulak gql .` |
+| `env` | Inspect the environment-secrets command tree | `hulak env --help` |
+| `help` | Show top-level help | `hulak help` |
+
+## Core Behaviors
+
+### Interactive mode
+
+Running `hulak` with no file or directory target opens the interactive picker.
+
+- Hulak asks you to choose a request file first.
+- It only asks for an environment if the selected request uses template values like `{{.key}}`.
+- In non-interactive shells, you should pass a file or directory target instead.
+
+### Environment selection
+
+- The default environment is `global`.
+- Environment selection only matters when the request needs template resolution.
+- `run` and `gql` support `--env` / `--environment` to skip the environment picker.
+
+## Commands
+
+### `run`
+
+Run a single request file or every request file in a directory.
+
+```bash
+hulak run path/to/file.yaml
+hulak run path/to/file.yaml --env staging
+hulak run path/to/file.yaml --debug
+hulak run path/to/dir/
+hulak run path/to/dir/ --sequential
+```
+
+Supported flags:
+
+| Flag | Meaning |
+| --- | --- |
+| `--env`, `--environment` | Use a specific environment |
+| `--debug` | Print request and response debug details |
+| `--sequential`, `--seq` | Run directory files one at a time |
+
+Notes:
+
+- `hulak run` accepts either a file path or a directory path.
+- Directories run concurrently by default.
+- `hulak run path/to/file.yaml --debug --env staging` is supported; trailing flags after the path are parsed correctly.
+
+### `version`
+
+Print the installed Hulak version.
+
+```bash
+hulak version
+```
+
+### `init`
+
+Create the default Hulak project layout in the current directory.
+
+```bash
+hulak init
+hulak init -env staging prod
+```
+
+Notes:
+
+- `hulak init` creates the default setup, including `env/global.env` and the example API options file.
+- On `init`, `-env` is a **boolean setup flag**, not an environment selector. It tells Hulak to create the named env files you pass after it.
+
+### `migrate`
+
+Convert Postman v2.1 environment and collection exports into Hulak files.
+
+```bash
+hulak migrate collection.json
+hulak migrate env.json collection.json
+```
+
+### `doctor`
+
+Run project health checks.
+
+```bash
+hulak doctor
+```
+
+This checks for common issues such as missing `.gitignore` entries, weak env file permissions, and secrets in git history.
+
+### `gql`
+
+Open the GraphQL explorer for one file or a directory.
+
+```bash
+hulak gql .
+hulak gql path/to/schema.yml
+hulak gql -env staging ./collections/graphql
+```
+
+Aliases:
+
+- `graphql`
+- `GraphQL`
+
+Supported flags:
+
+| Flag | Meaning |
+| --- | --- |
+| `--env`, `--environment` | Use a specific environment and skip the selector |
+
+Read the full guide in [graphql-explorer.md](./graphql-explorer.md).
+
+### `env`
+
+The `env` command tree is exposed in the CLI for encrypted environment-secret management.
+
+```bash
+hulak env --help
+hulak env set API_KEY value --env prod
+hulak env list --env staging
+hulak env keys --env prod
+```
+
+Subcommands currently shown by the CLI:
+
+- `set` (`add`)
+- `get`
+- `list` (`ls`)
+- `keys` (`key`)
+- `delete` (`rm`, `remove`)
+- `edit`
+- `import-key`
+- `export-key`
+- `add-recipient`
+- `remove-recipient`
+- `list-recipients`
+
+Important: the command surface is present, but the current handlers still print `not yet implemented` for the scaffolded `env` subcommands.
+
+### `help`
+
+Print the top-level command list.
+
+```bash
+hulak help
+```
+
+For command-specific help, use:
+
+```bash
+hulak <command> --help
+```
+
+## Supported Root Flags (Shorthand)
+
+These are still supported. They are useful when you want the older root-flag style or need file-name search behavior.
+
+| Flag | Meaning | Example |
+| --- | --- | --- |
+| `-env`, `--environment` | Select an environment for root-flag execution | `hulak -env prod -fp requests/get-user.hk.yaml` |
+| `-fp`, `--file-path` | Run one exact file path | `hulak -fp requests/get-user.hk.yaml` |
+| `-f`, `--file` | Search for matching file names recursively and run matches | `hulak -f getUser` |
+| `-dir` | Run a directory concurrently | `hulak -dir ./requests/` |
+| `-dirseq` | Run a directory sequentially | `hulak -dirseq ./requests/` |
+| `-debug` | Enable debug output | `hulak -fp requests/get-user.hk.yaml -debug` |
+| `-v`, `--version` | Print version | `hulak --version` |
+| `-h`, `--help` | Print help | `hulak --help` |
+
+Use the shorthand form when it fits your workflow, but prefer `hulak run ...` in examples and onboarding material.

--- a/main.go
+++ b/main.go
@@ -5,10 +5,10 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"slices"
 	"strings"
 
 	"github.com/xaaha/hulak/pkg/envparser"
+	"github.com/xaaha/hulak/pkg/runner"
 	"github.com/xaaha/hulak/pkg/tui"
 	"github.com/xaaha/hulak/pkg/tui/envselect"
 	userflags "github.com/xaaha/hulak/pkg/userFlags"
@@ -16,59 +16,26 @@ import (
 )
 
 func main() {
+	// Subcommands and root file/dir flags handle execution directly
+	// inside ParseFlagsSubcmds. It only returns here for interactive mode.
 	flags, err := userflags.ParseFlagsSubcmds()
 	if err != nil {
 		utils.PanicRedAndExit("%v", err)
 	}
 
-	hasDirFlags := flags.Dir != "" || flags.Dirseq != ""
-	hasFileFlags := flags.FilePath != "" || flags.File != ""
-
-	// TUI mode, currently only supports -fp (single file run)
-	if !hasFileFlags && !hasDirFlags {
-		if !isInteractiveTerminal() {
-			utils.PanicRedAndExit(
-				"interactive mode requires a TTY. Use -f, -fp, -dir, or -dirseq flags. See 'hulak help'",
-			)
-		}
-		flags.FilePath = runInteractiveFlow(&flags.Env, flags.EnvSet)
-		var envMap map[string]any
-		if utils.FileHasTemplateVars(flags.FilePath) {
-			envMap = InitializeProject(flags.Env, false)
-		}
-		HandleAPIRequests(envMap, flags.Debug, []string{flags.FilePath}, nil, flags.FilePath)
-		return
+	if !isInteractiveTerminal() {
+		utils.PanicRedAndExit(
+			"interactive mode requires a TTY. Use 'hulak run <path>'. See 'hulak help'",
+		)
 	}
 
-	// CLI mode
-	fileList, concurrentDir, sequentialDir := DiscoverFilePaths(
-		flags.File,
-		flags.FilePath,
-		flags.Dir,
-		flags.Dirseq,
-		hasDirFlags,
-	)
-
-	allPaths := slices.Concat(fileList, concurrentDir, sequentialDir)
+	filePath := runInteractiveFlow(&flags.Env, flags.EnvSet)
 
 	var envMap map[string]any
-	// check if any file in the list contains template variable
-	// Returns true at the first match (short-circuits), so best-case is O(1)
-	// and worst-case (no templates anywhere) is O(n) file reads.
-	if slices.ContainsFunc(allPaths, utils.FileHasTemplateVars) {
-		if !utils.IsHulakProject() {
-			ensureHulakProject()
-		}
-		envMap = InitializeProject(flags.Env, true)
+	if utils.FileHasTemplateVars(filePath) {
+		envMap = runner.InitializeProject(flags.Env, false)
 	}
-
-	HandleAPIRequests(
-		envMap,
-		flags.Debug,
-		slices.Concat(fileList, concurrentDir),
-		sequentialDir,
-		flags.FilePath,
-	)
+	runner.ExecuteSingleFile(envMap, flags.Debug, filePath)
 }
 
 func runInteractiveFlow(env *string, envSet bool) string {

--- a/man/hulak.1
+++ b/man/hulak.1
@@ -1,178 +1,187 @@
 HULAK(1)                                          General Commands Manual                                          HULAK(1)
 
 NAME
-       hulak - File Based API client for terminal nerds 
+       hulak - file-based API client for the terminal
 
 SYNOPSIS
        hulak
-       hulak [OPTIONS] -f <file>
-       hulak [OPTIONS] -fp <file_path>
-       hulak [OPTIONS] -dir <directory_path>
-       hulak [OPTIONS] -dirseq <directory_path>
+       hulak run <path> [--env <environment>] [--debug] [--sequential]
+       hulak version
+       hulak init [-env <name> ...]
+       hulak migrate <json_file> [<json_file> ...]
+       hulak doctor
        hulak gql [-env <environment>] <path>
-       hulak migrate <json_file>
+       hulak env <subcommand> [options]
+       hulak help
+
+       Supported shorthand forms:
+       hulak [-env <environment>] -fp <file_path> [-debug]
+       hulak [-env <environment>] -f <file_name> [-debug]
+       hulak [-env <environment>] -dir <directory_path> [-debug]
+       hulak [-env <environment>] -dirseq <directory_path> [-debug]
 
 DESCRIPTION
-       Hulak is a user-friendly API client designed for developers and terminal users. It supports multiple HTTP methods and facilitates easy API testing and integration by leveraging YAML configuration files.
+       Hulak runs API requests defined in YAML files. The recommended style is command-first usage with
+       hulak run <path>, where <path> is either a single request file or a directory of request files.
 
-       When run without file or directory flags, hulak launches an interactive single-file helper and asks you to pick a file first.
-       If that file contains environment template vars (for example {{.token}}), hulak then asks you to pick an environment.
-       Use -f for multi-match concurrent runs, -dir for directory concurrent runs, and -dirseq for directory sequential runs.
-       If only -env is provided without a file, hulak opens the helper with the environment pre-selected.
+       Running hulak with no file or directory target opens the interactive picker. Hulak asks you to pick
+       a request file first, and only asks for an environment when the selected request uses template values
+       like {{.token}}.
 
-       Hulak also includes a dedicated GraphQL explorer TUI through the gql subcommand.
-       The explorer loads one GraphQL file or a directory of GraphQL files, fetches schemas, lets you search operations, build queries and variables, execute them, and save generated files.
+       Hulak also includes a GraphQL explorer through the gql subcommand for schema discovery, operation
+       search, query building, execution, and saving generated files.
 
-OPTIONS
-       -env <environment>
-               Specifies an environment file inside the env directory for API calls that require environment template vars.
-               If not provided, the default "global" environment is used.
+COMMANDS
+       run
+              Run a single request file or a directory. Directories run concurrently by default.
 
-       -f <file>
-              Specifies a YAML/YML file to run. Hulak searches recursively through directories to locate matching yaml/yml files and executes all matches concurrently if more than one is found.
+       version
+              Print the installed Hulak version.
 
-       -fp <file_path>
-              Specifies the exact file path of the file to run.
+       init
+              Create the default Hulak project setup in the current directory.
+
+       migrate
+              Convert Postman v2.1 environment and collection exports into Hulak files.
+
+       doctor
+              Run project health checks.
+
+       gql
+              Open the GraphQL explorer for one file or a directory.
+
+       env
+              Show the environment-secrets command tree.
+
+       help
+              Print top-level help.
+
+RUN FLAGS
+       --env, --environment <environment>
+              Use a specific environment and skip the environment picker.
+
+       --debug
+              Print request and response debug details.
+
+       --sequential, --seq
+              Run directory files one at a time instead of concurrently.
+
+GLOBAL SHORTHAND FLAGS
+       These root flags remain supported, but hulak run <path> is the preferred form for examples and
+       onboarding.
+
+       -env, --environment <environment>
+              Select the environment for root-flag execution.
+
+       -fp, --file-path <file_path>
+              Run one exact file path.
+
+       -f, --file <file_name>
+              Search recursively for matching YAML file names and run the matches.
 
        -dir <directory_path>
-              Run entire directory concurrently. Only supports (.yaml or .yml) files. All files use the same provided environment.
+              Run a directory concurrently.
 
        -dirseq <directory_path>
-              Run entire directory one file at a time. Only supports (.yaml or .yml) files. All files use the same provided environment. 
-              In nested directories, the execution order is not guaranteed to follow the file system appearance. If order matters, 
-              it's recommended to use a directory without nested directories, in which case files will run alphabetically.
+              Run a directory sequentially.
 
-       gql [-env <environment>] <path>
-              Opens the GraphQL explorer for one file or a directory.
-              In single-file mode, the file only needs a non-empty url field.
-              In directory mode, files are discovered recursively only when they contain kind: GraphQL and a non-empty url field.
-              If GraphQL files need environment values and -env is not provided, Hulak shows the environment selector.
+       -debug
+              Enable debug output.
 
-       migrate <json_file>
-              Migrates the specified JSON file(s) to the new Hulak format.
-       
-       init   Initializes the default environment configuration.
-              When used with -env flag, creates specific environment files.
-          
-       help   Displays command usage information.
+       -v, --version
+              Print the current version.
 
-FLAGS
-       -env    Specifies the environment file for API calls.
-       -f      Designates the YAML/YML file to be executed.
-       -fp     Specifies the direct file path for the file to execute.
-       -dir    Run an entire directory of YAML/YML files concurrently.
-       -dirseq Run an entire directory of YAML/YML files sequentially.
-       -debug  Get the entire request, response, headers, and TLS info about the request 
+       -h, --help
+              Print help.
 
-INSTALLATION
-       Hulak can be installed using either `go install` or built from source or using homebrew
+INTERACTIVE MODE
+       hulak
+              Open the interactive request picker.
 
-       Using go install:
-              go install github.com/xaaha/hulak@latest
+       hulak -env staging
+              Open the interactive picker with a preselected environment.
 
-              Ensure that your GOPATH is added to your shell's PATH:
-              export GOPATH=$HOME/go
-              export PATH=$PATH:$(go env GOPATH)/bin
+       In non-interactive shells, you should pass a file or directory target instead of relying on the picker.
 
-              Reload your shell configuration:
-              source ~/.zshrc   or   source ~/.bashrc
+ENVIRONMENT SETUP
+       Create a project directory and initialize it with:
 
-       Build from source:
-              git clone https://github.com/xaaha/hulak.git
-              cd hulak
-              go mod tidy
-              go build -o hulak
-              sudo mv hulak /usr/local/bin/
+              hulak init
 
-       Using Homebrew:
-              `brew install xaaha/tap/hulak`
+       To create named environment files immediately:
 
-       ENVIRONMENT SETUP
-       Create a project dir for hulak and run:
-             `hulak init`
+              hulak init -env staging prod
 
-       Note: env/ setup is required only when request files use environment template vars like {{.key}}.
-
-SCHEMA
-       You can find the schema at:
-            https://raw.githubusercontent.com/xaaha/hulak/refs/heads/main/assets/schema.json 
+       Hulak uses env/ files only when request files need template resolution such as {{.key}}.
 
 EXAMPLES
-       Interactive mode:
+       Run a single request file:
 
-              # Select file interactively, then environment only when needed
-              hulak
+              hulak run requests/get-user.hk.yaml
 
-              # Select file interactively with a pre-selected environment
-              hulak -env staging
+       Run a single request file with a specific environment:
 
-       Basic API call:
+              hulak run requests/get-user.hk.yaml --env staging
 
-              # test.yaml
-              method: GET
-              url: https://jsonplaceholder.typicode.com/todos/1
+       Run a directory concurrently:
 
-              Run with:
-              hulak -f test
+              hulak run ./requests/
 
-       Using environment variables:
+       Run a directory sequentially:
 
-              # test.yaml
-              method: POST
-              url: "{{.Url}}"
+              hulak run ./requests/ --sequential
 
-              Run with:
-              hulak -env prod -f test
-              
-       Processing a directory of API requests:
-       
-              # Run all .yaml files in the directory concurrently
-              hulak -dir path/to/directory/
-              
-              # Run all .yaml files in the directory sequentially
-              hulak -dirseq path/to/directory/
+       Use the GraphQL explorer:
 
-       GraphQL explorer:
-
-              # Explore one GraphQL source file
-              hulak gql e2etests/gql_schemas/countries.yml
-
-              # Explore GraphQL files in the current directory
               hulak gql .
-
-              # Explore a directory with a pre-selected environment
+              hulak gql path/to/schema.yml
               hulak gql -env staging ./collections/graphql
 
-              # Minimal GraphQL source file for directory discovery
-              ---
-              kind: GraphQL
-              url: https://countries.trevorblades.com/
-              headers:
-                Content-Type: application/json
+       Use shorthand root flags:
 
-              # Generated or hand-written GraphQL request file
-              ---
-              method: POST
-              kind: GraphQL
-              url: "{{.graphqlUrl}}"
-              headers:
-                Content-Type: application/json
-              body:
-                graphql:
-                  query: '{{getFile "queries/GetCountry.gql"}}'
-                  variables:
-                    code: "NP"
+              hulak -fp requests/get-user.hk.yaml
+              hulak -dir ./requests/
 
-AUTH 2.0
-       Supports OAuth 2.0 web-application flow. Refer to the documentation for detailed setup instructions:
-       https://github.com/xaaha/hulak/blob/main/docs/auth20.md
+INSTALLATION
+       Homebrew tap (cask):
+
+              brew install --cask xaaha/tap/hulak
+
+       The Homebrew tap publishes Hulak as a cask generated by GoReleaser. That cask links the hulak binary
+       and the bundled manpage from the release archive.
+
+       go install:
+
+              go install github.com/xaaha/hulak@latest
+
+       Build from source:
+
+              git clone https://github.com/xaaha/hulak.git
+              cd hulak
+              go build -o hulak
+
+SCHEMA
+       Schema URL:
+
+              https://raw.githubusercontent.com/xaaha/hulak/refs/heads/main/assets/schema.json
 
 DOCUMENTATION
-       Full GraphQL explorer documentation:
-       https://github.com/xaaha/hulak/blob/main/docs/graphql-explorer.md
+       CLI reference:
+              https://github.com/xaaha/hulak/blob/main/docs/cli.md
+
+       GraphQL explorer guide:
+              https://github.com/xaaha/hulak/blob/main/docs/graphql-explorer.md
+
+       Auth 2.0 guide:
+              https://github.com/xaaha/hulak/blob/main/docs/auth20.md
+
+       For the current CLI surface from the binary itself, use:
+
+              hulak help
+              hulak <command> --help
 
 COPYRIGHT
-       Copyright (c) 2025 Pratik Thapa 
+       Copyright (c) 2025 Pratik Thapa
 
        This software is released under the MIT License. For details, see the LICENSE file in the project repository.
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -38,7 +38,7 @@ func Execute(f *Flags) {
 		f.Dir != "" || f.Dirseq != "",
 	)
 
-	allPaths := append(append(fileList, concurrentDir...), sequentialDir...)
+	allPaths := slices.Concat(fileList, concurrentDir, sequentialDir)
 
 	var envMap map[string]any
 	if containsTemplateVars(allPaths) {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1,10 +1,12 @@
-// Package main initializes the project and runs the query
-package main
+// Package runner contains the API request execution pipeline.
+// It is imported by both the run subcommand and main's interactive mode.
+package runner
 
 import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"sync"
 	"time"
 
@@ -15,9 +17,58 @@ import (
 	"github.com/xaaha/hulak/pkg/yamlparser"
 )
 
-/*
-InitializeProject starts the project by creating envfolder and global.env file in it.
-*/
+// Flags holds parsed CLI flags needed by the execution pipeline.
+type Flags struct {
+	Env      string
+	EnvSet   bool
+	FilePath string
+	File     string
+	Debug    bool
+	Dir      string
+	Dirseq   string
+}
+
+// Execute runs the full pipeline: discover files, resolve env, execute requests.
+func Execute(f *Flags) {
+	fileList, concurrentDir, sequentialDir := discoverFilePaths(
+		f.File,
+		f.FilePath,
+		f.Dir,
+		f.Dirseq,
+		f.Dir != "" || f.Dirseq != "",
+	)
+
+	allPaths := append(append(fileList, concurrentDir...), sequentialDir...)
+
+	var envMap map[string]any
+	if containsTemplateVars(allPaths) {
+		if !utils.IsHulakProject() {
+			utils.PanicRedAndExit("fatal: not a hulak project \n\nRun 'hulak init' to set up")
+		}
+		envMap = InitializeProject(f.Env, true)
+	}
+
+	handleAPIRequests(
+		envMap,
+		f.Debug,
+		append(fileList, concurrentDir...),
+		sequentialDir,
+		f.FilePath,
+	)
+}
+
+// ExecuteSingleFile runs a single file through the pipeline.
+// Used by interactive mode where the file is already known.
+func ExecuteSingleFile(envMap map[string]any, debug bool, filePath string) {
+	handleAPIRequests(envMap, debug, []string{filePath}, nil, filePath)
+}
+
+// containsTemplateVars returns true if any file in the list uses template vars.
+func containsTemplateVars(paths []string) bool {
+	return slices.ContainsFunc(paths, utils.FileHasTemplateVars)
+}
+
+// InitializeProject creates the env setup and returns the secrets map.
 func InitializeProject(env string, isCli bool) map[string]any {
 	if err := envparser.CreateDefaultEnvs(nil); err != nil {
 		utils.PanicRedAndExit("%v", err)
@@ -29,123 +80,8 @@ func InitializeProject(env string, isCli bool) map[string]any {
 	return envMap
 }
 
-// runTasks manages the go tasks with a limited worker pool
-func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp string) {
-	// Configuration parameters
-	maxWorkers := utils.GetWorkers(nil) // Dynamically determine worker count
-	maxRetries := 3                     // Number of retries for failed tasks
-	timeout := 60 * time.Second         // Timeout for each API call
-
-	if fp != "" {
-		// If fp flag has a path, then let's not retry it again
-		maxRetries = 1
-	}
-
-	var wg sync.WaitGroup
-	taskChan := make(chan string, len(filePathList)) // Buffered channel for tasks
-
-	// Fill the task channel with file paths
-	for _, path := range filePathList {
-		taskChan <- path
-	}
-	close(taskChan)
-
-	// Create a pool of worker goroutines
-	for i := range maxWorkers {
-		wg.Add(1)
-		go func(_ int) {
-			defer wg.Done()
-
-			for path := range taskChan {
-				// Process each task with retry logic
-				success := false
-				var lastErr error
-
-				for attempt := 0; attempt < maxRetries && !success; attempt++ {
-					if attempt > 0 {
-						// Exponential backoff for retries
-						backoffDuration := time.Duration(1<<(attempt-1)) * time.Second
-						utils.PrintWarning(fmt.Sprintf("Retrying %s (attempt %d/%d) after %v",
-							path, attempt+1, maxRetries, backoffDuration))
-						time.Sleep(backoffDuration)
-					}
-
-					// Create a context with timeout
-					ctx, cancel := context.WithTimeout(context.Background(), timeout)
-
-					// Use a channel to handle the task completion
-					doneChan := make(chan struct{})
-					errChan := make(chan error, 1)
-
-					// Execute the task in a separate goroutine
-					go func() {
-						err := processTask(path, utils.CopyEnvMap(secretsMap), debug)
-						if err != nil {
-							errChan <- err
-						} else {
-							close(doneChan)
-						}
-					}()
-
-					// Wait for either completion, error, or timeout
-					select {
-					case <-doneChan:
-						success = true
-						utils.PrintInfo(fmt.Sprintf("Processed '%s'", filepath.Base(path)))
-					case err := <-errChan:
-						lastErr = err
-						utils.PrintInfo(fmt.Sprintf("(attempt %d/%d)", attempt+1, maxRetries))
-					case <-ctx.Done():
-						lastErr = fmt.Errorf("timeout after %v", timeout)
-						utils.PrintRed(fmt.Sprintf("Timeout processing %s after %v (attempt %d/%d)",
-							path, timeout, attempt+1, maxRetries))
-					}
-					// Always cancel the context created with timeout
-					cancel()
-				}
-
-				if !success {
-					utils.PrintRed(fmt.Sprintf("Failed to process %s after %d attempts: %v",
-						path, maxRetries, lastErr))
-				}
-			}
-		}(i)
-	}
-	// Wait for all workers to finish
-	wg.Wait()
-}
-
-// processTask handles a single task, separated to simplify the worker logic
-func processTask(path string, secretsMap map[string]any, debug bool) error {
-	// Parse the configuration for the file
-	config, err := yamlparser.ParseConfig(path, secretsMap)
-	if err != nil {
-		errMsg := fmt.Sprintf("failed to parse config %v", err)
-		return utils.ColorError(errMsg)
-	}
-
-	// Handle different kinds based on the yaml 'kind' we get
-	switch {
-	case config.IsAuth():
-		return features.SendAPIRequestForAuth2(secretsMap, path, debug)
-	case (config.IsAPI() || config.IsGraphql()):
-		return apicalls.SendAndSaveAPIRequest(secretsMap, path, debug)
-	default:
-		return fmt.Errorf("unsupported kind in file: %s", path)
-	}
-}
-
-/*
- things we could optiize for but is probably too much here
- Rate limiting an API.
- Priority Queues: For mixed task types with different priorities
- Result Collection: Add a results channel to collect success/failure statistics.
- Graceful Shutdown: Add signal handling to cancel in-progress tasks if the program is terminated.
-*/
-
-// DiscoverFilePaths collects all file paths from -f, -fp, -dir, and -dirseq flags.
-// Returns three slices: files from -f/-fp, concurrent dir files, and sequential dir files.
-func DiscoverFilePaths(
+// discoverFilePaths collects all file paths from -f, -fp, -dir, and -dirseq flags.
+func discoverFilePaths(
 	fileName, fp, dir, dirseq string,
 	hasDirFlags bool,
 ) (fileList, concurrentDir, sequentialDir []string) {
@@ -173,9 +109,8 @@ func DiscoverFilePaths(
 	return fileList, concurrentDir, sequentialDir
 }
 
-// HandleAPIRequests processes API requests from pre-discovered file lists.
-// concurrentFiles are processed via worker pool, sequentialFiles one-by-one.
-func HandleAPIRequests(
+// handleAPIRequests processes API requests from pre-discovered file lists.
+func handleAPIRequests(
 	secrets map[string]any,
 	debug bool,
 	concurrentFiles []string,
@@ -203,11 +138,101 @@ func HandleAPIRequests(
 	}
 }
 
-// processFilesSequentially handles files one by one in a sequential manner
+// runTasks manages the go tasks with a limited worker pool
+func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp string) {
+	maxWorkers := utils.GetWorkers(nil)
+	maxRetries := 3
+	timeout := 60 * time.Second
+
+	if fp != "" {
+		maxRetries = 1
+	}
+
+	var wg sync.WaitGroup
+	taskChan := make(chan string, len(filePathList))
+
+	for _, path := range filePathList {
+		taskChan <- path
+	}
+	close(taskChan)
+
+	for i := range maxWorkers {
+		wg.Add(1)
+		go func(_ int) {
+			defer wg.Done()
+
+			for path := range taskChan {
+				success := false
+				var lastErr error
+
+				for attempt := 0; attempt < maxRetries && !success; attempt++ {
+					if attempt > 0 {
+						backoffDuration := time.Duration(1<<(attempt-1)) * time.Second
+						utils.PrintWarning(fmt.Sprintf("Retrying %s (attempt %d/%d) after %v",
+							path, attempt+1, maxRetries, backoffDuration))
+						time.Sleep(backoffDuration)
+					}
+
+					ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+					doneChan := make(chan struct{})
+					errChan := make(chan error, 1)
+
+					go func() {
+						err := processTask(path, utils.CopyEnvMap(secretsMap), debug)
+						if err != nil {
+							errChan <- err
+						} else {
+							close(doneChan)
+						}
+					}()
+
+					select {
+					case <-doneChan:
+						success = true
+						utils.PrintInfo(fmt.Sprintf("Processed '%s'", filepath.Base(path)))
+					case err := <-errChan:
+						lastErr = err
+						utils.PrintInfo(fmt.Sprintf("(attempt %d/%d)", attempt+1, maxRetries))
+					case <-ctx.Done():
+						lastErr = fmt.Errorf("timeout after %v", timeout)
+						utils.PrintRed(fmt.Sprintf("Timeout processing %s after %v (attempt %d/%d)",
+							path, timeout, attempt+1, maxRetries))
+					}
+					cancel()
+				}
+
+				if !success {
+					utils.PrintRed(fmt.Sprintf("Failed to process %s after %d attempts: %v",
+						path, maxRetries, lastErr))
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// processTask handles a single task
+func processTask(path string, secretsMap map[string]any, debug bool) error {
+	config, err := yamlparser.ParseConfig(path, secretsMap)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to parse config %v", err)
+		return utils.ColorError(errMsg)
+	}
+
+	switch {
+	case config.IsAuth():
+		return features.SendAPIRequestForAuth2(secretsMap, path, debug)
+	case (config.IsAPI() || config.IsGraphql()):
+		return apicalls.SendAndSaveAPIRequest(secretsMap, path, debug)
+	default:
+		return fmt.Errorf("unsupported kind in file: %s", path)
+	}
+}
+
+// processFilesSequentially handles files one by one
 func processFilesSequentially(filePaths []string, secretsMap map[string]any, debug bool) {
 	for _, path := range filePaths {
-
-		// Create a fresh copy of the environment for each file
 		fileEnv := utils.CopyEnvMap(secretsMap)
 
 		err := processTask(path, fileEnv, debug)
@@ -222,19 +247,16 @@ func processFilesSequentially(filePaths []string, secretsMap map[string]any, deb
 func generateFilePathList(fileName string, fp string) ([]string, error) {
 	standardErrMsg := "to send api request(s), please provide a valid file name with \n'-f fileName' flag or  \n'-fp file/path/' "
 
-	// Both inputs are empty, return an error
 	if fileName == "" && fp == "" {
 		return nil, utils.ColorError(standardErrMsg)
 	}
 
 	var filePathList []string
 
-	// Add file path from -fp flag if provided
 	if fp != "" {
 		filePathList = append(filePathList, fp)
 	}
 
-	// Add matching paths for -f flag if provided
 	if fileName != "" {
 		if matchingPaths, err := utils.ListMatchingFiles(fileName); err != nil {
 			utils.PrintRed(utils.ErrFilePathCollection + ": " + err.Error())

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -1,0 +1,181 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateFilePathList_FpOnly(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.hk.yaml")
+	if err := os.WriteFile(tmpFile, []byte("method: GET\nurl: http://example.com"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	list, err := generateFilePathList("", tmpFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(list) != 1 || list[0] != tmpFile {
+		t.Errorf("expected [%s], got %v", tmpFile, list)
+	}
+}
+
+func TestGenerateFilePathList_BothEmpty(t *testing.T) {
+	_, err := generateFilePathList("", "")
+	if err == nil {
+		t.Fatal("expected error when both fileName and fp are empty")
+	}
+}
+
+func TestDiscoverFilePaths_FpReturnsFileList(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "req.hk.yaml")
+	if err := os.WriteFile(tmpFile, []byte("method: GET\nurl: http://example.com"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fileList, concurrent, sequential := discoverFilePaths(
+		"",      // fileName
+		tmpFile, // fp
+		"",      // dir
+		"",      // dirseq
+		false,   // hasDirFlags
+	)
+
+	if len(fileList) != 1 || fileList[0] != tmpFile {
+		t.Errorf("fileList = %v, want [%s]", fileList, tmpFile)
+	}
+	if len(concurrent) != 0 {
+		t.Errorf("concurrent should be empty, got %v", concurrent)
+	}
+	if len(sequential) != 0 {
+		t.Errorf("sequential should be empty, got %v", sequential)
+	}
+}
+
+func TestDiscoverFilePaths_DirReturnsConcurrent(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, name := range []string{"a.yaml", "b.yaml"} {
+		content := "method: GET\nurl: http://example.com"
+		if err := os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fileList, concurrent, sequential := discoverFilePaths(
+		"",     // fileName
+		"",     // fp
+		tmpDir, // dir
+		"",     // dirseq
+		true,   // hasDirFlags
+	)
+
+	if len(fileList) != 0 {
+		t.Errorf("fileList should be empty, got %v", fileList)
+	}
+	if len(concurrent) != 2 {
+		t.Errorf("expected 2 concurrent files, got %d: %v", len(concurrent), concurrent)
+	}
+	if len(sequential) != 0 {
+		t.Errorf("sequential should be empty, got %v", sequential)
+	}
+}
+
+func TestDiscoverFilePaths_DirseqReturnsSequential(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, name := range []string{"a.yaml", "b.yaml"} {
+		content := "method: GET\nurl: http://example.com"
+		if err := os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fileList, concurrent, sequential := discoverFilePaths(
+		"",     // fileName
+		"",     // fp
+		"",     // dir
+		tmpDir, // dirseq
+		true,   // hasDirFlags
+	)
+
+	if len(fileList) != 0 {
+		t.Errorf("fileList should be empty, got %v", fileList)
+	}
+	if len(concurrent) != 0 {
+		t.Errorf("concurrent should be empty, got %v", concurrent)
+	}
+	if len(sequential) != 2 {
+		t.Errorf("expected 2 sequential files, got %d: %v", len(sequential), sequential)
+	}
+}
+
+func TestContainsTemplateVars_NoTemplates(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "plain.yaml")
+	if err := os.WriteFile(tmpFile, []byte("method: GET\nurl: http://example.com"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if containsTemplateVars([]string{tmpFile}) {
+		t.Error("expected false for file without template vars")
+	}
+}
+
+func TestContainsTemplateVars_WithTemplates(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "templated.yaml")
+	if err := os.WriteFile(tmpFile, []byte("method: GET\nurl: '{{.apiUrl}}'"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if !containsTemplateVars([]string{tmpFile}) {
+		t.Error("expected true for file with template vars")
+	}
+}
+
+func TestContainsTemplateVars_EmptyList(t *testing.T) {
+	if containsTemplateVars(nil) {
+		t.Error("expected false for empty list")
+	}
+}
+
+func TestDiscoverFilePaths_EmptyInputs(t *testing.T) {
+	fileList, concurrent, sequential := discoverFilePaths(
+		"", "", "", "", false,
+	)
+
+	if len(fileList) != 0 {
+		t.Errorf("fileList should be empty, got %v", fileList)
+	}
+	if len(concurrent) != 0 {
+		t.Errorf("concurrent should be empty, got %v", concurrent)
+	}
+	if len(sequential) != 0 {
+		t.Errorf("sequential should be empty, got %v", sequential)
+	}
+}
+
+func TestDiscoverFilePaths_FpAndDirTogether(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "single.yaml")
+	content := "method: GET\nurl: http://example.com"
+	if err := os.WriteFile(tmpFile, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fileList, concurrent, sequential := discoverFilePaths(
+		"",      // fileName
+		tmpFile, // fp
+		tmpDir,  // dir
+		"",      // dirseq
+		true,    // hasDirFlags
+	)
+
+	if len(fileList) != 1 {
+		t.Errorf("fileList should have 1 entry, got %v", fileList)
+	}
+	if len(concurrent) != 1 {
+		t.Errorf("concurrent should have 1 entry from dir, got %v", concurrent)
+	}
+	if len(sequential) != 0 {
+		t.Errorf("sequential should be empty, got %v", sequential)
+	}
+}

--- a/pkg/userFlags/cli_contract_test.go
+++ b/pkg/userFlags/cli_contract_test.go
@@ -1,8 +1,13 @@
 package userflags
 
 import (
+	"errors"
 	"flag"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/xaaha/hulak/pkg/utils"
 )
 
 // TestSubCommandsExist verifies every expected subcommand is registered.
@@ -10,7 +15,7 @@ import (
 func TestSubCommandsExist(t *testing.T) {
 	root := subCommands()
 
-	expected := []string{"version", "init", "migrate", "doctor", "gql", "env", "help"}
+	expected := []string{"run", "version", "init", "migrate", "doctor", "gql", "env", "help"}
 	for _, name := range expected {
 		if root.findSub(name) == nil {
 			t.Errorf("expected subcommand %q to exist", name)
@@ -91,6 +96,264 @@ func TestFlagAliasesShareVariable(t *testing.T) {
 		// Restore original values to avoid leaking state to other tests
 		_ = short.Value.Set(origShort)
 		_ = long.Value.Set(origLong)
+	}
+}
+
+// TestRunSubcommandFlags verifies the run subcommand has all expected flags.
+func TestRunSubcommandFlags(t *testing.T) {
+	root := subCommands()
+	runCmd := root.findSub("run")
+	if runCmd == nil {
+		t.Fatal("expected run subcommand to exist")
+	}
+
+	for _, name := range []string{"env", "environment", "sequential", "seq", "debug"} {
+		if runCmd.Flags.Lookup(name) == nil {
+			t.Errorf("run subcommand should have --%s flag", name)
+		}
+	}
+}
+
+// TestRunFlagAliasesShareVariable verifies that run's flag aliases
+// point to the same underlying variable.
+func TestRunFlagAliasesShareVariable(t *testing.T) {
+	root := subCommands()
+	runCmd := root.findSub("run")
+	if runCmd == nil {
+		t.Fatal("expected run subcommand to exist")
+	}
+
+	tests := []struct {
+		short string
+		long  string
+		val   string // test value to set (must be valid for the flag type)
+	}{
+		{"env", "environment", "alias-test"},
+		{"seq", "sequential", "true"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.short+"/"+tc.long, func(t *testing.T) {
+			short := runCmd.Flags.Lookup(tc.short)
+			long := runCmd.Flags.Lookup(tc.long)
+			if short == nil || long == nil {
+				t.Fatalf("missing flag: short=%v long=%v", short, long)
+			}
+
+			if err := runCmd.Flags.Set(tc.long, tc.val); err != nil {
+				t.Fatalf("failed to set --%s: %v", tc.long, err)
+			}
+			if short.Value.String() != tc.val {
+				t.Errorf("--%s = %q, want %q (should share variable with --%s)",
+					tc.short, short.Value.String(), tc.val, tc.long)
+			}
+		})
+	}
+}
+
+// TestRunSubcommandHasRunHandler verifies the run subcommand has a Run handler.
+func TestRunSubcommandHasRunHandler(t *testing.T) {
+	root := subCommands()
+	runCmd := root.findSub("run")
+	if runCmd == nil {
+		t.Fatal("expected run subcommand to exist")
+	}
+	if runCmd.Run == nil {
+		t.Error("run subcommand is missing a Run handler")
+	}
+}
+
+// TestRunHandlerSetsFilePath verifies that passing a file path sets FilePath
+// in the AllFlags result.
+func TestRunHandlerSetsFilePath(t *testing.T) {
+	root := subCommands()
+	runCmd := root.findSub("run")
+	if runCmd == nil {
+		t.Fatal("expected run subcommand to exist")
+	}
+
+	tmpFile := filepath.Join(t.TempDir(), "test.hk.yaml")
+	if err := os.WriteFile(tmpFile, []byte("kind: API"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runCmd.Run([]string{tmpFile})
+	if !errors.Is(err, errRunSubcommand) {
+		t.Fatalf("expected errRunSubcommand, got %v", err)
+	}
+	if runResult == nil {
+		t.Fatal("runResult should be set")
+	}
+	defer func() { runResult = nil }()
+
+	if runResult.FilePath != tmpFile {
+		t.Errorf("FilePath = %q, want %q", runResult.FilePath, tmpFile)
+	}
+	if runResult.Dir != "" || runResult.Dirseq != "" {
+		t.Error("Dir/Dirseq should be empty for a file path")
+	}
+}
+
+// TestRunHandlerSetsDir verifies that passing a directory sets Dir (concurrent).
+func TestRunHandlerSetsDir(t *testing.T) {
+	root := subCommands()
+	runCmd := root.findSub("run")
+	if runCmd == nil {
+		t.Fatal("expected run subcommand to exist")
+	}
+
+	tmpDir := t.TempDir()
+
+	err := runCmd.Run([]string{tmpDir})
+	if !errors.Is(err, errRunSubcommand) {
+		t.Fatalf("expected errRunSubcommand, got %v", err)
+	}
+	if runResult == nil {
+		t.Fatal("runResult should be set")
+	}
+	defer func() { runResult = nil }()
+
+	if runResult.Dir != tmpDir {
+		t.Errorf("Dir = %q, want %q", runResult.Dir, tmpDir)
+	}
+	if runResult.Dirseq != "" {
+		t.Error("Dirseq should be empty without --sequential")
+	}
+	if runResult.FilePath != "" {
+		t.Error("FilePath should be empty for a directory")
+	}
+}
+
+// TestRunHandlerTrailingFlags verifies that flags after the positional
+// argument are still parsed correctly.
+func TestRunHandlerTrailingFlags(t *testing.T) {
+	root := subCommands()
+	runCmd := root.findSub("run")
+	if runCmd == nil {
+		t.Fatal("expected run subcommand to exist")
+	}
+
+	tmpFile := filepath.Join(t.TempDir(), "test.hk.yaml")
+	if err := os.WriteFile(tmpFile, []byte("kind: API"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runCmd.Run([]string{tmpFile, "--debug", "--env", "staging"})
+	if !errors.Is(err, errRunSubcommand) {
+		t.Fatalf("expected errRunSubcommand, got %v", err)
+	}
+	if runResult == nil {
+		t.Fatal("runResult should be set")
+	}
+	defer func() { runResult = nil }()
+
+	if !runResult.Debug {
+		t.Error("Debug should be true when --debug is passed after the path")
+	}
+	if runResult.Env != "staging" {
+		t.Errorf("Env = %q, want %q", runResult.Env, "staging")
+	}
+	if !runResult.EnvSet {
+		t.Error("EnvSet should be true when --env is provided")
+	}
+}
+
+// TestRunHandlerSequentialDir verifies --sequential after a directory
+// sets Dirseq instead of Dir.
+func TestRunHandlerSequentialDir(t *testing.T) {
+	root := subCommands()
+	runCmd := root.findSub("run")
+	if runCmd == nil {
+		t.Fatal("expected run subcommand to exist")
+	}
+
+	tmpDir := t.TempDir()
+
+	err := runCmd.Run([]string{tmpDir, "--sequential"})
+	if !errors.Is(err, errRunSubcommand) {
+		t.Fatalf("expected errRunSubcommand, got %v", err)
+	}
+	if runResult == nil {
+		t.Fatal("runResult should be set")
+	}
+	defer func() { runResult = nil }()
+
+	if runResult.Dirseq != tmpDir {
+		t.Errorf("Dirseq = %q, want %q", runResult.Dirseq, tmpDir)
+	}
+	if runResult.Dir != "" {
+		t.Error("Dir should be empty when --sequential is set")
+	}
+}
+
+// TestRunHandlerBadPath verifies that a nonexistent path returns an error.
+func TestRunHandlerBadPath(t *testing.T) {
+	root := subCommands()
+	runCmd := root.findSub("run")
+	if runCmd == nil {
+		t.Fatal("expected run subcommand to exist")
+	}
+
+	err := runCmd.Run([]string{"/nonexistent/path.yaml"})
+	if err == nil {
+		t.Fatal("expected an error for nonexistent path")
+	}
+	if errors.Is(err, errRunSubcommand) {
+		t.Error("should not return errRunSubcommand for a bad path")
+	}
+}
+
+// TestRunHandlerUnknownTrailingFlag verifies that an unknown flag after
+// the path produces a parse error, not a silent pass.
+func TestRunHandlerUnknownTrailingFlag(t *testing.T) {
+	root := subCommands()
+	runCmd := root.findSub("run")
+	if runCmd == nil {
+		t.Fatal("expected run subcommand to exist")
+	}
+
+	tmpFile := filepath.Join(t.TempDir(), "test.hk.yaml")
+	if err := os.WriteFile(tmpFile, []byte("kind: API"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runCmd.Run([]string{tmpFile, "--bogus"})
+	if err == nil {
+		t.Fatal("expected an error for unknown trailing flag")
+	}
+	if errors.Is(err, errRunSubcommand) {
+		t.Error("should not return errRunSubcommand for an unknown flag")
+	}
+}
+
+// TestRunHandlerDefaultEnv verifies that when no --env is passed,
+// the default environment is used.
+func TestRunHandlerDefaultEnv(t *testing.T) {
+	root := subCommands()
+	runCmd := root.findSub("run")
+	if runCmd == nil {
+		t.Fatal("expected run subcommand to exist")
+	}
+
+	tmpFile := filepath.Join(t.TempDir(), "test.hk.yaml")
+	if err := os.WriteFile(tmpFile, []byte("kind: API"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runCmd.Run([]string{tmpFile})
+	if !errors.Is(err, errRunSubcommand) {
+		t.Fatalf("expected errRunSubcommand, got %v", err)
+	}
+	if runResult == nil {
+		t.Fatal("runResult should be set")
+	}
+	defer func() { runResult = nil }()
+
+	if runResult.Env != utils.DefaultEnvVal {
+		t.Errorf("Env = %q, want default %q", runResult.Env, utils.DefaultEnvVal)
+	}
+	if runResult.EnvSet {
+		t.Error("EnvSet should be false when no --env is provided")
 	}
 }
 

--- a/pkg/userFlags/cli_contract_test.go
+++ b/pkg/userFlags/cli_contract_test.go
@@ -1,14 +1,28 @@
 package userflags
 
 import (
-	"errors"
 	"flag"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/xaaha/hulak/pkg/utils"
 )
+
+// newTestRunFlagSet creates a fresh FlagSet with the same flags as the run
+// subcommand, returning the pointers tests need to pass to parseRunArgs.
+func newTestRunFlagSet() (fs *flag.FlagSet, envVal *string, seq *bool, debug *bool) {
+	fs = flag.NewFlagSet("run", flag.ContinueOnError)
+	fs.Usage = func() {}
+	fs.SetOutput(io.Discard)
+	envVal = registerEnvFlag(fs, "", "Environment to use")
+	var s, d bool
+	fs.BoolVar(&s, "sequential", false, "")
+	fs.BoolVar(&s, "seq", false, "")
+	fs.BoolVar(&d, "debug", false, "")
+	return fs, envVal, &s, &d
+}
 
 // TestSubCommandsExist verifies every expected subcommand is registered.
 // If a subcommand is removed or renamed, this test fails.
@@ -163,196 +177,139 @@ func TestRunSubcommandHasRunHandler(t *testing.T) {
 	}
 }
 
-// TestRunHandlerSetsFilePath verifies that passing a file path sets FilePath
-// in the AllFlags result.
-func TestRunHandlerSetsFilePath(t *testing.T) {
-	root := subCommands()
-	runCmd := root.findSub("run")
-	if runCmd == nil {
-		t.Fatal("expected run subcommand to exist")
-	}
+// TestParseRunArgsSetsFilePath verifies that passing a file path sets FilePath.
+func TestParseRunArgsSetsFilePath(t *testing.T) {
+	fs, envVal, seq, debug := newTestRunFlagSet()
 
 	tmpFile := filepath.Join(t.TempDir(), "test.hk.yaml")
 	if err := os.WriteFile(tmpFile, []byte("kind: API"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	err := runCmd.Run([]string{tmpFile})
-	if !errors.Is(err, errRunSubcommand) {
-		t.Fatalf("expected errRunSubcommand, got %v", err)
+	f, err := parseRunArgs(fs, envVal, seq, debug, []string{tmpFile})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if runResult == nil {
-		t.Fatal("runResult should be set")
-	}
-	defer func() { runResult = nil }()
 
-	if runResult.FilePath != tmpFile {
-		t.Errorf("FilePath = %q, want %q", runResult.FilePath, tmpFile)
+	if f.FilePath != tmpFile {
+		t.Errorf("FilePath = %q, want %q", f.FilePath, tmpFile)
 	}
-	if runResult.Dir != "" || runResult.Dirseq != "" {
+	if f.Dir != "" || f.Dirseq != "" {
 		t.Error("Dir/Dirseq should be empty for a file path")
 	}
 }
 
-// TestRunHandlerSetsDir verifies that passing a directory sets Dir (concurrent).
-func TestRunHandlerSetsDir(t *testing.T) {
-	root := subCommands()
-	runCmd := root.findSub("run")
-	if runCmd == nil {
-		t.Fatal("expected run subcommand to exist")
-	}
-
+// TestParseRunArgsSetsDir verifies that passing a directory sets Dir (concurrent).
+func TestParseRunArgsSetsDir(t *testing.T) {
+	fs, envVal, seq, debug := newTestRunFlagSet()
 	tmpDir := t.TempDir()
 
-	err := runCmd.Run([]string{tmpDir})
-	if !errors.Is(err, errRunSubcommand) {
-		t.Fatalf("expected errRunSubcommand, got %v", err)
+	f, err := parseRunArgs(fs, envVal, seq, debug, []string{tmpDir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if runResult == nil {
-		t.Fatal("runResult should be set")
-	}
-	defer func() { runResult = nil }()
 
-	if runResult.Dir != tmpDir {
-		t.Errorf("Dir = %q, want %q", runResult.Dir, tmpDir)
+	if f.Dir != tmpDir {
+		t.Errorf("Dir = %q, want %q", f.Dir, tmpDir)
 	}
-	if runResult.Dirseq != "" {
+	if f.Dirseq != "" {
 		t.Error("Dirseq should be empty without --sequential")
 	}
-	if runResult.FilePath != "" {
+	if f.FilePath != "" {
 		t.Error("FilePath should be empty for a directory")
 	}
 }
 
-// TestRunHandlerTrailingFlags verifies that flags after the positional
+// TestParseRunArgsTrailingFlags verifies that flags after the positional
 // argument are still parsed correctly.
-func TestRunHandlerTrailingFlags(t *testing.T) {
-	root := subCommands()
-	runCmd := root.findSub("run")
-	if runCmd == nil {
-		t.Fatal("expected run subcommand to exist")
-	}
+func TestParseRunArgsTrailingFlags(t *testing.T) {
+	fs, envVal, seq, debug := newTestRunFlagSet()
 
 	tmpFile := filepath.Join(t.TempDir(), "test.hk.yaml")
 	if err := os.WriteFile(tmpFile, []byte("kind: API"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	err := runCmd.Run([]string{tmpFile, "--debug", "--env", "staging"})
-	if !errors.Is(err, errRunSubcommand) {
-		t.Fatalf("expected errRunSubcommand, got %v", err)
+	f, err := parseRunArgs(fs, envVal, seq, debug, []string{tmpFile, "--debug", "--env", "staging"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if runResult == nil {
-		t.Fatal("runResult should be set")
-	}
-	defer func() { runResult = nil }()
 
-	if !runResult.Debug {
+	if !f.Debug {
 		t.Error("Debug should be true when --debug is passed after the path")
 	}
-	if runResult.Env != "staging" {
-		t.Errorf("Env = %q, want %q", runResult.Env, "staging")
+	if f.Env != "staging" {
+		t.Errorf("Env = %q, want %q", f.Env, "staging")
 	}
-	if !runResult.EnvSet {
+	if !f.EnvSet {
 		t.Error("EnvSet should be true when --env is provided")
 	}
 }
 
-// TestRunHandlerSequentialDir verifies --sequential after a directory
+// TestParseRunArgsSequentialDir verifies --sequential after a directory
 // sets Dirseq instead of Dir.
-func TestRunHandlerSequentialDir(t *testing.T) {
-	root := subCommands()
-	runCmd := root.findSub("run")
-	if runCmd == nil {
-		t.Fatal("expected run subcommand to exist")
-	}
-
+func TestParseRunArgsSequentialDir(t *testing.T) {
+	fs, envVal, seq, debug := newTestRunFlagSet()
 	tmpDir := t.TempDir()
 
-	err := runCmd.Run([]string{tmpDir, "--sequential"})
-	if !errors.Is(err, errRunSubcommand) {
-		t.Fatalf("expected errRunSubcommand, got %v", err)
+	f, err := parseRunArgs(fs, envVal, seq, debug, []string{tmpDir, "--sequential"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if runResult == nil {
-		t.Fatal("runResult should be set")
-	}
-	defer func() { runResult = nil }()
 
-	if runResult.Dirseq != tmpDir {
-		t.Errorf("Dirseq = %q, want %q", runResult.Dirseq, tmpDir)
+	if f.Dirseq != tmpDir {
+		t.Errorf("Dirseq = %q, want %q", f.Dirseq, tmpDir)
 	}
-	if runResult.Dir != "" {
+	if f.Dir != "" {
 		t.Error("Dir should be empty when --sequential is set")
 	}
 }
 
-// TestRunHandlerBadPath verifies that a nonexistent path returns an error.
-func TestRunHandlerBadPath(t *testing.T) {
-	root := subCommands()
-	runCmd := root.findSub("run")
-	if runCmd == nil {
-		t.Fatal("expected run subcommand to exist")
-	}
+// TestParseRunArgsBadPath verifies that a nonexistent path returns an error.
+func TestParseRunArgsBadPath(t *testing.T) {
+	fs, envVal, seq, debug := newTestRunFlagSet()
 
-	err := runCmd.Run([]string{"/nonexistent/path.yaml"})
+	_, err := parseRunArgs(fs, envVal, seq, debug, []string{"/nonexistent/path.yaml"})
 	if err == nil {
 		t.Fatal("expected an error for nonexistent path")
 	}
-	if errors.Is(err, errRunSubcommand) {
-		t.Error("should not return errRunSubcommand for a bad path")
-	}
 }
 
-// TestRunHandlerUnknownTrailingFlag verifies that an unknown flag after
+// TestParseRunArgsUnknownTrailingFlag verifies that an unknown flag after
 // the path produces a parse error, not a silent pass.
-func TestRunHandlerUnknownTrailingFlag(t *testing.T) {
-	root := subCommands()
-	runCmd := root.findSub("run")
-	if runCmd == nil {
-		t.Fatal("expected run subcommand to exist")
-	}
+func TestParseRunArgsUnknownTrailingFlag(t *testing.T) {
+	fs, envVal, seq, debug := newTestRunFlagSet()
 
 	tmpFile := filepath.Join(t.TempDir(), "test.hk.yaml")
 	if err := os.WriteFile(tmpFile, []byte("kind: API"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	err := runCmd.Run([]string{tmpFile, "--bogus"})
+	_, err := parseRunArgs(fs, envVal, seq, debug, []string{tmpFile, "--bogus"})
 	if err == nil {
 		t.Fatal("expected an error for unknown trailing flag")
 	}
-	if errors.Is(err, errRunSubcommand) {
-		t.Error("should not return errRunSubcommand for an unknown flag")
-	}
 }
 
-// TestRunHandlerDefaultEnv verifies that when no --env is passed,
+// TestParseRunArgsDefaultEnv verifies that when no --env is passed,
 // the default environment is used.
-func TestRunHandlerDefaultEnv(t *testing.T) {
-	root := subCommands()
-	runCmd := root.findSub("run")
-	if runCmd == nil {
-		t.Fatal("expected run subcommand to exist")
-	}
+func TestParseRunArgsDefaultEnv(t *testing.T) {
+	fs, envVal, seq, debug := newTestRunFlagSet()
 
 	tmpFile := filepath.Join(t.TempDir(), "test.hk.yaml")
 	if err := os.WriteFile(tmpFile, []byte("kind: API"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	err := runCmd.Run([]string{tmpFile})
-	if !errors.Is(err, errRunSubcommand) {
-		t.Fatalf("expected errRunSubcommand, got %v", err)
+	f, err := parseRunArgs(fs, envVal, seq, debug, []string{tmpFile})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if runResult == nil {
-		t.Fatal("runResult should be set")
-	}
-	defer func() { runResult = nil }()
 
-	if runResult.Env != utils.DefaultEnvVal {
-		t.Errorf("Env = %q, want default %q", runResult.Env, utils.DefaultEnvVal)
+	if f.Env != utils.DefaultEnvVal {
+		t.Errorf("Env = %q, want default %q", f.Env, utils.DefaultEnvVal)
 	}
-	if runResult.EnvSet {
+	if f.EnvSet {
 		t.Error("EnvSet should be false when no --env is provided")
 	}
 }

--- a/pkg/userFlags/command.go
+++ b/pkg/userFlags/command.go
@@ -3,6 +3,7 @@ package userflags
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"slices"
 	"strings"
@@ -88,8 +89,13 @@ func (cmd *command) Execute(args []string) error {
 			cmd.Flags.BoolVar(&helpFlag, "h", false, "Show help for this command")
 		}
 
+		// Suppress Go's default usage dump so we can show hulak-styled errors
+		cmd.Flags.Usage = func() {}
+		cmd.Flags.SetOutput(io.Discard)
+
 		if err := cmd.Flags.Parse(args); err != nil {
-			return err
+			utils.PrintRed(fmt.Sprintf("%s\nSee 'hulak %s --help' for usage", err, cmd.Name))
+			os.Exit(1)
 		}
 
 		if helpFlag {

--- a/pkg/userFlags/command.go
+++ b/pkg/userFlags/command.go
@@ -94,8 +94,7 @@ func (cmd *command) Execute(args []string) error {
 		cmd.Flags.SetOutput(io.Discard)
 
 		if err := cmd.Flags.Parse(args); err != nil {
-			utils.PrintRed(fmt.Sprintf("%s\nSee 'hulak %s --help' for usage", err, cmd.Name))
-			os.Exit(1)
+			return fmt.Errorf("%s\nSee 'hulak %s --help' for usage", err, cmd.Name)
 		}
 
 		if helpFlag {

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/xaaha/hulak/pkg/envparser"
 	"github.com/xaaha/hulak/pkg/migration"
+	"github.com/xaaha/hulak/pkg/runner"
 	"github.com/xaaha/hulak/pkg/tui/gqlexplorer"
 	"github.com/xaaha/hulak/pkg/utils"
 )
@@ -253,48 +254,66 @@ func newRunCmd() *command {
 			runCmd.printHelp()
 			return nil
 		}
-		path := args[0]
 
-		// Go's flag package stops at the first non-flag argument, so
-		// "run file.yaml --debug" leaves --debug unparsed. Re-parse
-		// the remaining args to pick up trailing flags.
-		if len(args) > 1 {
-			if err := fs.Parse(args[1:]); err != nil {
-				return fmt.Errorf("%w\nSee 'hulak run --help' for usage", err)
-			}
-		}
-
-		info, err := os.Stat(path)
+		f, err := parseRunArgs(fs, envFlagVal, &sequential, &debug, args)
 		if err != nil {
-			return fmt.Errorf("cannot access %q: %w", path, err)
+			return err
 		}
 
-		result := &AllFlags{
-			Debug: debug,
-		}
-
-		if *envFlagVal != "" {
-			result.Env = *envFlagVal
-			result.EnvSet = true
-		} else {
-			result.Env = utils.DefaultEnvVal
-		}
-
-		if info.IsDir() {
-			if sequential {
-				result.Dirseq = path
-			} else {
-				result.Dir = path
-			}
-		} else {
-			result.FilePath = path
-		}
-
-		runResult = result
-		return errRunSubcommand
+		runner.Execute(f)
+		return nil
 	}
 
 	return runCmd
+}
+
+// parseRunArgs resolves the positional path and trailing flags into runner.Flags.
+// Extracted so tests can verify flag parsing without triggering runner.Execute.
+func parseRunArgs(
+	fs *flag.FlagSet,
+	envFlagVal *string,
+	sequential *bool,
+	debug *bool,
+	args []string,
+) (*runner.Flags, error) {
+	path := args[0]
+
+	// Go's flag package stops at the first non-flag argument, so
+	// "run file.yaml --debug" leaves --debug unparsed. Re-parse
+	// the remaining args to pick up trailing flags.
+	if len(args) > 1 {
+		if err := fs.Parse(args[1:]); err != nil {
+			return nil, fmt.Errorf("%w\nSee 'hulak run --help' for usage", err)
+		}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot access %q: %w", path, err)
+	}
+
+	f := &runner.Flags{
+		Debug: *debug,
+	}
+
+	if *envFlagVal != "" {
+		f.Env = *envFlagVal
+		f.EnvSet = true
+	} else {
+		f.Env = utils.DefaultEnvVal
+	}
+
+	if info.IsDir() {
+		if *sequential {
+			f.Dirseq = path
+		} else {
+			f.Dir = path
+		}
+	} else {
+		f.FilePath = path
+	}
+
+	return f, nil
 }
 
 func newEnvCmd() *command {

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -229,9 +229,18 @@ func newRunCmd() *command {
 			"Directories run concurrently by default; use --sequential for ordered execution.",
 		Examples: []*utils.CommandHelp{
 			{Command: "hulak run path/to/file.yaml", Description: "Run a single request file"},
-			{Command: "hulak run path/to/file.yaml --env staging", Description: "Run with a specific environment"},
-			{Command: "hulak run path/to/dir/", Description: "Run all files in a directory concurrently"},
-			{Command: "hulak run path/to/dir/ --sequential", Description: "Run directory files sequentially"},
+			{
+				Command:     "hulak run path/to/file.yaml --env staging",
+				Description: "Run with a specific environment",
+			},
+			{
+				Command:     "hulak run path/to/dir/",
+				Description: "Run all files in a directory concurrently",
+			},
+			{
+				Command:     "hulak run path/to/dir/ --sequential",
+				Description: "Run directory files sequentially",
+			},
 		},
 		Flags: fs,
 		Args: []argDef{
@@ -422,8 +431,10 @@ func newEnvCmd() *command {
 			Short: "Import an age identity file",
 			Long:  "Import an age private key from a file or stdin into the hulak config directory.",
 			Flags: importKeyFs,
-			Args:  []argDef{{Name: "path", Desc: "Path to the identity file (omit to read from stdin)"}},
-			Run:   notImplemented("import-key"),
+			Args: []argDef{
+				{Name: "path", Desc: "Path to the identity file (omit to read from stdin)"},
+			},
+			Run: notImplemented("import-key"),
 		},
 		{
 			Name:  "export-key",

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -3,7 +3,6 @@ package userflags
 import (
 	"flag"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/xaaha/hulak/pkg/envparser"
@@ -213,8 +212,6 @@ func newGQLCmd() *command {
 
 func newRunCmd() *command {
 	fs := flag.NewFlagSet("run", flag.ContinueOnError)
-	fs.Usage = func() {}
-	fs.SetOutput(io.Discard)
 	envFlagVal := registerEnvFlag(fs, "", "Environment to use")
 	var sequential bool
 	var debug bool

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -3,12 +3,24 @@ package userflags
 import (
 	"flag"
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/xaaha/hulak/pkg/envparser"
 	"github.com/xaaha/hulak/pkg/migration"
 	"github.com/xaaha/hulak/pkg/tui/gqlexplorer"
 	"github.com/xaaha/hulak/pkg/utils"
 )
+
+// registerEnvFlag adds both --env and --environment aliases to a FlagSet,
+// pointing to the same underlying variable, and returns a pointer so
+// Run handlers can read the parsed value.
+func registerEnvFlag(fs *flag.FlagSet, defaultVal string, usage string) *string {
+	var envVal string
+	fs.StringVar(&envVal, "env", defaultVal, usage)
+	fs.StringVar(&envVal, "environment", defaultVal, usage)
+	return &envVal
+}
 
 // subCommands builds the full sub-command tree for hulak
 func subCommands() *command {
@@ -42,6 +54,7 @@ func subCommands() *command {
 	}
 
 	root.SubCommands = []*command{
+		newRunCmd(),
 		newVersionCmd(),
 		newInitCmd(),
 		newMigrateCmd(),
@@ -148,9 +161,7 @@ func newDoctorCmd() *command {
 
 func newGQLCmd() *command {
 	fs := flag.NewFlagSet("gql", flag.ContinueOnError)
-	var envFlagVal string
-	fs.StringVar(&envFlagVal, "env", "", "Environment to use (skips interactive selector)")
-	fs.StringVar(&envFlagVal, "environment", "", "Environment to use (skips interactive selector)")
+	envFlagVal := registerEnvFlag(fs, "", "Environment to use (skips interactive selector)")
 
 	gqlCmd := &command{
 		Name:    "gql",
@@ -186,7 +197,7 @@ func newGQLCmd() *command {
 			gqlCmd.printHelp()
 			return nil
 		}
-		data, refreshFn, warnings := loadGraphQLOperations(args[0], envFlagVal)
+		data, refreshFn, warnings := loadGraphQLOperations(args[0], *envFlagVal)
 		if data.Operations == nil {
 			return nil
 		}
@@ -197,6 +208,84 @@ func newGQLCmd() *command {
 	}
 
 	return gqlCmd
+}
+
+func newRunCmd() *command {
+	fs := flag.NewFlagSet("run", flag.ContinueOnError)
+	fs.Usage = func() {}
+	fs.SetOutput(io.Discard)
+	envFlagVal := registerEnvFlag(fs, "", "Environment to use")
+	var sequential bool
+	var debug bool
+	fs.BoolVar(&sequential, "sequential", false, "Run directory files sequentially")
+	fs.BoolVar(&sequential, "seq", false, "Run directory files sequentially")
+	fs.BoolVar(&debug, "debug", false, "Enable debug mode")
+
+	runCmd := &command{
+		Name:  "run",
+		Short: "Run API request file(s) or directory",
+		Long: "Execute one or more API request files.\n\n" +
+			"Pass a file path to run a single request, or a directory to run all files in it.\n" +
+			"Directories run concurrently by default; use --sequential for ordered execution.",
+		Examples: []*utils.CommandHelp{
+			{Command: "hulak run path/to/file.yaml", Description: "Run a single request file"},
+			{Command: "hulak run path/to/file.yaml --env staging", Description: "Run with a specific environment"},
+			{Command: "hulak run path/to/dir/", Description: "Run all files in a directory concurrently"},
+			{Command: "hulak run path/to/dir/ --sequential", Description: "Run directory files sequentially"},
+		},
+		Flags: fs,
+		Args: []argDef{
+			{Name: "path", Required: true, Desc: "File or directory to run"},
+		},
+	}
+
+	runCmd.Run = func(args []string) error {
+		if len(args) == 0 {
+			runCmd.printHelp()
+			return nil
+		}
+		path := args[0]
+
+		// Go's flag package stops at the first non-flag argument, so
+		// "run file.yaml --debug" leaves --debug unparsed. Re-parse
+		// the remaining args to pick up trailing flags.
+		if len(args) > 1 {
+			if err := fs.Parse(args[1:]); err != nil {
+				return fmt.Errorf("%w\nSee 'hulak run --help' for usage", err)
+			}
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("cannot access %q: %w", path, err)
+		}
+
+		result := &AllFlags{
+			Debug: debug,
+		}
+
+		if *envFlagVal != "" {
+			result.Env = *envFlagVal
+			result.EnvSet = true
+		} else {
+			result.Env = utils.DefaultEnvVal
+		}
+
+		if info.IsDir() {
+			if sequential {
+				result.Dirseq = path
+			} else {
+				result.Dir = path
+			}
+		} else {
+			result.FilePath = path
+		}
+
+		runResult = result
+		return errRunSubcommand
+	}
+
+	return runCmd
 }
 
 func newEnvCmd() *command {
@@ -230,43 +319,31 @@ func newEnvCmd() *command {
 		},
 	}
 
-	// use utils.DefaultEnvVal if user does not provide env
-
-	// registerEnvFlag adds both -env and --environment aliases to a FlagSet,
-	// pointing to the same underlying variable, and returns a pointer so
-	// Run handlers can read the parsed value.
-	registerEnvFlag := func(fs *flag.FlagSet) *string {
-		var envVal string
-		fs.StringVar(&envVal, "env", utils.DefaultEnvVal, "Environment to operate on")
-		fs.StringVar(&envVal, "environment", utils.DefaultEnvVal, "Environment to operate on")
-		return &envVal
-	}
-
 	// set — store a key-value pair
 	setFs := flag.NewFlagSet("env set", flag.ContinueOnError)
-	_ = registerEnvFlag(setFs)
+	_ = registerEnvFlag(setFs, utils.DefaultEnvVal, "Environment to operate on")
 	setFs.Bool("stdin", false, "Read value from stdin")
 
 	// get — retrieve a value by key
 	getFs := flag.NewFlagSet("env get", flag.ContinueOnError)
-	_ = registerEnvFlag(getFs)
+	_ = registerEnvFlag(getFs, utils.DefaultEnvVal, "Environment to operate on")
 
 	// list — show all key-value pairs
 	listFs := flag.NewFlagSet("env list", flag.ContinueOnError)
-	_ = registerEnvFlag(listFs)
+	_ = registerEnvFlag(listFs, utils.DefaultEnvVal, "Environment to operate on")
 
 	// keys — list keys only
 	keysFs := flag.NewFlagSet("env keys", flag.ContinueOnError)
-	_ = registerEnvFlag(keysFs)
+	_ = registerEnvFlag(keysFs, utils.DefaultEnvVal, "Environment to operate on")
 	keysFs.Bool("show", false, "Show actual values instead of masked output")
 
 	// delete — remove a key
 	deleteFs := flag.NewFlagSet("env delete", flag.ContinueOnError)
-	_ = registerEnvFlag(deleteFs)
+	_ = registerEnvFlag(deleteFs, utils.DefaultEnvVal, "Environment to operate on")
 
 	// edit — interactive editor
 	editFs := flag.NewFlagSet("env edit", flag.ContinueOnError)
-	_ = registerEnvFlag(editFs)
+	_ = registerEnvFlag(editFs, utils.DefaultEnvVal, "Environment to operate on")
 
 	// import-key — import an age identity
 	importKeyFs := flag.NewFlagSet("env import-key", flag.ContinueOnError)

--- a/pkg/userFlags/userflags.go
+++ b/pkg/userFlags/userflags.go
@@ -2,6 +2,7 @@
 package userflags
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -10,6 +11,13 @@ import (
 
 	"github.com/xaaha/hulak/pkg/utils"
 )
+
+// errRunSubcommand is a sentinel returned by the run handler to signal
+// that ParseFlagsSubcmds should return AllFlags instead of exiting.
+var errRunSubcommand = errors.New("run subcommand")
+
+// runResult holds the AllFlags populated by the run handler.
+var runResult *AllFlags
 
 // AllFlags  All user flags and subcommands
 type AllFlags struct {
@@ -37,6 +45,11 @@ func ParseFlagsSubcmds() (*AllFlags, error) {
 		switch {
 		case subCmds.findSub(first) != nil:
 			if err := subCmds.Execute(os.Args[1:]); err != nil {
+				if errors.Is(err, errRunSubcommand) {
+					result := runResult
+					runResult = nil
+					return result, nil
+				}
 				return nil, err
 			}
 			os.Exit(0)

--- a/pkg/userFlags/userflags.go
+++ b/pkg/userFlags/userflags.go
@@ -2,22 +2,15 @@
 package userflags
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
+	"github.com/xaaha/hulak/pkg/runner"
 	"github.com/xaaha/hulak/pkg/utils"
 )
-
-// errRunSubcommand is a sentinel returned by the run handler to signal
-// that ParseFlagsSubcmds should return AllFlags instead of exiting.
-var errRunSubcommand = errors.New("run subcommand")
-
-// runResult holds the AllFlags populated by the run handler.
-var runResult *AllFlags
 
 // AllFlags  All user flags and subcommands
 type AllFlags struct {
@@ -30,7 +23,9 @@ type AllFlags struct {
 	Dirseq   string
 }
 
-// ParseFlagsSubcmds Exports necessary flags and subcommands for main runner
+// ParseFlagsSubcmds dispatches subcommands and root flags.
+// Subcommands and root file/dir flags handle execution directly.
+// Returns only for interactive mode (no file/dir targets were given).
 func ParseFlagsSubcmds() (*AllFlags, error) {
 	subCmds := subCommands()
 
@@ -45,11 +40,6 @@ func ParseFlagsSubcmds() (*AllFlags, error) {
 		switch {
 		case subCmds.findSub(first) != nil:
 			if err := subCmds.Execute(os.Args[1:]); err != nil {
-				if errors.Is(err, errRunSubcommand) {
-					result := runResult
-					runResult = nil
-					return result, nil
-				}
 				return nil, err
 			}
 			os.Exit(0)
@@ -66,12 +56,34 @@ func ParseFlagsSubcmds() (*AllFlags, error) {
 				subCmds.printHelp()
 				os.Exit(0)
 			}
+
+			// Root flags with file/dir targets: execute directly
+			if flagFP != "" || flagF != "" || flagDir != "" || flagDirseq != "" {
+				envSet := false
+				flag.Visit(func(f *flag.Flag) {
+					if f.Name == "env" || f.Name == "environment" {
+						envSet = true
+					}
+				})
+				runner.Execute(&runner.Flags{
+					Env:      flagEnv,
+					EnvSet:   envSet,
+					FilePath: flagFP,
+					File:     flagF,
+					Debug:    flagDebug,
+					Dir:      flagDir,
+					Dirseq:   flagDirseq,
+				})
+				os.Exit(0)
+			}
 		default:
 			utils.PrintRed(fmt.Sprintf("unknown command %q. See 'hulak help'", first))
 			os.Exit(1)
 		}
 	}
 
+	// Interactive mode: no subcommand, no file/dir flags.
+	// Return just enough state for the TUI flow.
 	envSet := false
 	flag.Visit(func(f *flag.Flag) {
 		if f.Name == "env" || f.Name == "environment" {
@@ -80,12 +92,8 @@ func ParseFlagsSubcmds() (*AllFlags, error) {
 	})
 
 	return &AllFlags{
-		Env:      flagEnv,
-		EnvSet:   envSet,
-		FilePath: flagFP,
-		File:     flagF,
-		Debug:    flagDebug,
-		Dir:      flagDir,
-		Dirseq:   flagDirseq,
+		Env:    flagEnv,
+		EnvSet: envSet,
+		Debug:  flagDebug,
 	}, nil
 }


### PR DESCRIPTION
## Summary

Closes #163

- Added `hulak run <path>` subcommand as the primary way to execute request files
- Supports file paths (`hulak run file.yaml`) and directories (`hulak run dir/`)
- Flags: `--env`/`--environment`, `--debug`, `--sequential`/`--seq`
- Flags work before or after the positional path arg (`hulak run file.yaml --debug`)
- Sentinel error pattern (`errRunSubcommand`) returns control to `main.go` so the existing execution pipeline handles everything — zero changes to `main.go`
- Extracted `registerEnvFlag()` as shared helper used by `run`, `gql`, and all `env` subcommands
- Suppressed Go's raw flag usage dump for all subcommands — unknown flags now show hulak-styled errors with help hints
- 10 contract + handler tests covering: flags, aliases, file/dir detection, trailing flag parsing, error paths, default env

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `hulak run path/to/file.yaml` runs single file
- [x] `hulak run path/to/file.yaml --debug` produces same output as `hulak -fp path/to/file.yaml --debug`
- [x] `hulak run path/to/file.yaml --env staging` sets environment
- [x] `hulak run path/to/dir/` runs directory concurrently
- [x] `hulak run path/to/dir/ --sequential` runs directory sequentially
- [x] `hulak run --help` shows help
- [x] `hulak help` lists `run` subcommand
- [x] `hulak run file.yaml --bogus` shows styled error
- [x] `hulak gql --bogus .` also shows styled error (fixed for all subcommands)