### PR TITLE
Don't default to Global

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -5,6 +5,7 @@ package runner
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"sync"
@@ -13,9 +14,14 @@ import (
 	apicalls "github.com/xaaha/hulak/pkg/apiCalls"
 	"github.com/xaaha/hulak/pkg/envparser"
 	"github.com/xaaha/hulak/pkg/features"
+	"github.com/xaaha/hulak/pkg/tui/envselect"
 	"github.com/xaaha/hulak/pkg/utils"
 	"github.com/xaaha/hulak/pkg/yamlparser"
 )
+
+// envSelector is the function used to show the interactive environment picker.
+// Package-level var so tests can replace it without TUI dependencies.
+var envSelector = envselect.RunEnvSelector
 
 // Flags holds parsed CLI flags needed by the execution pipeline.
 type Flags struct {
@@ -44,6 +50,16 @@ func Execute(f *Flags) {
 	if containsTemplateVars(allPaths) {
 		if !utils.IsHulakProject() {
 			utils.PanicRedAndExit("fatal: not a hulak project \n\nRun 'hulak init' to set up")
+		}
+		if !f.EnvSet {
+			selectedEnv, err := envSelector()
+			if err != nil {
+				utils.PanicRedAndExit("Environment selector error: %v", err)
+			}
+			if selectedEnv == "" {
+				os.Exit(0)
+			}
+			f.Env = selectedEnv
 		}
 		envMap = InitializeProject(f.Env, true)
 	}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -153,6 +153,113 @@ func TestDiscoverFilePaths_EmptyInputs(t *testing.T) {
 	}
 }
 
+// --- envSelector tests ---
+
+func TestExecute_EnvNotSet_CallsSelector(t *testing.T) {
+	orig := envSelector
+	defer func() { envSelector = orig }()
+
+	called := false
+	envSelector = func() (string, error) {
+		called = true
+		return "picked-env", nil
+	}
+
+	// File with template vars
+	tmpFile := filepath.Join(t.TempDir(), "tmpl.hk.yaml")
+	if err := os.WriteFile(tmpFile, []byte("url: '{{.apiUrl}}'"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	f := &Flags{
+		Env:      "global",
+		EnvSet:   false,
+		FilePath: tmpFile,
+	}
+
+	// Execute will call IsHulakProject which will be false in test context,
+	// so it would PanicRedAndExit. We only need to verify the selector is
+	// called BEFORE that point. Use recover to catch the exit.
+	func() {
+		defer func() { _ = recover() }()
+		Execute(f)
+	}()
+
+	if !called {
+		t.Error("envSelector should be called when EnvSet is false and files have template vars")
+	}
+	if f.Env != "picked-env" {
+		t.Errorf("Env = %q, want %q", f.Env, "picked-env")
+	}
+}
+
+func TestExecute_EnvSet_SkipsSelector(t *testing.T) {
+	orig := envSelector
+	defer func() { envSelector = orig }()
+
+	called := false
+	envSelector = func() (string, error) {
+		called = true
+		return "should-not-be-used", nil
+	}
+
+	// File with template vars
+	tmpFile := filepath.Join(t.TempDir(), "tmpl.hk.yaml")
+	if err := os.WriteFile(tmpFile, []byte("url: '{{.apiUrl}}'"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	f := &Flags{
+		Env:      "staging",
+		EnvSet:   true,
+		FilePath: tmpFile,
+	}
+
+	func() {
+		defer func() { _ = recover() }()
+		Execute(f)
+	}()
+
+	if called {
+		t.Error("envSelector should NOT be called when EnvSet is true")
+	}
+	if f.Env != "staging" {
+		t.Errorf("Env = %q, want %q (should remain unchanged)", f.Env, "staging")
+	}
+}
+
+func TestExecute_NoTemplateVars_SkipsSelector(t *testing.T) {
+	orig := envSelector
+	defer func() { envSelector = orig }()
+
+	called := false
+	envSelector = func() (string, error) {
+		called = true
+		return "should-not-be-used", nil
+	}
+
+	// File WITHOUT template vars
+	tmpFile := filepath.Join(t.TempDir(), "plain.hk.yaml")
+	if err := os.WriteFile(tmpFile, []byte("method: GET\nurl: http://example.com"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	f := &Flags{
+		Env:      "global",
+		EnvSet:   false,
+		FilePath: tmpFile,
+	}
+
+	func() {
+		defer func() { _ = recover() }()
+		Execute(f)
+	}()
+
+	if called {
+		t.Error("envSelector should NOT be called when files have no template vars")
+	}
+}
+
 func TestDiscoverFilePaths_FpAndDirTogether(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "single.yaml")


### PR DESCRIPTION
When user's don't provide the -env flag while running an api requests, don't default to Global. This was an original behavior but we need to show the env picker and the run deleberate