### PR TITLE
envparser: integrate encrypted store for environment loading

### DIFF
--- a/pkg/envparser/envparser.go
+++ b/pkg/envparser/envparser.go
@@ -188,9 +188,15 @@ func loadSecretsFromVault(envName string) (map[string]any, error) {
 	}
 	resultMap := utils.CopyEnvMap(globalMap)
 
-	if custom := store.GetEnv(envName); custom != nil {
-		maps.Copy(resultMap, custom)
+	if envName == "" || strings.EqualFold(envName, utils.DefaultEnvVal) {
+		return resultMap, nil
 	}
+
+	custom := store.GetEnv(envName)
+	if custom == nil {
+		return nil, fmt.Errorf("environment %q not found in vault store", envName)
+	}
+	maps.Copy(resultMap, custom)
 	return resultMap, nil
 }
 

--- a/pkg/envparser/envparser.go
+++ b/pkg/envparser/envparser.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
 )
 
 /*
@@ -168,6 +169,31 @@ func inferType(val string, wasTrimmed bool) any {
 	return val
 }
 
+// loadSecretsFromVault decrypts the store and returns merged env vars.
+// Uses the same merge pattern as classic: global base + custom overlay.
+func loadSecretsFromVault(envName string) (map[string]any, error) {
+	identity, err := vault.LoadIdentity()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load identity: %w", err)
+	}
+
+	store, err := vault.ReadStore(identity)
+	if err != nil {
+		return nil, err
+	}
+
+	globalMap := store.GetEnv(utils.DefaultEnvVal)
+	if globalMap == nil {
+		globalMap = make(map[string]any)
+	}
+	resultMap := utils.CopyEnvMap(globalMap)
+
+	if custom := store.GetEnv(envName); custom != nil {
+		maps.Copy(resultMap, custom)
+	}
+	return resultMap, nil
+}
+
 /*
 GenerateSecretsMap creates final map of environment variables and it's values
 User's Choice > Global.
@@ -175,6 +201,13 @@ When user has custom env they want to use, it merges custom with global env.
 Replaces global key with custom when keys repeat
 */
 func GenerateSecretsMap(envFromFlag string, isCli bool) (map[string]any, error) {
+	if vault.DetectStore() == vault.StoreAge {
+		if isCli {
+			utils.PrintGreen("Environment: " + envFromFlag)
+		}
+		return loadSecretsFromVault(envFromFlag)
+	}
+
 	skipped, err := setEnvironment(envFromFlag, isCli)
 	if err != nil {
 		return nil, utils.ColorError("error while setting environment: %w", err)
@@ -248,6 +281,10 @@ func mergeCustomEnvVars(
 // Use this for TUI flows where environment selection has already been handled separately.
 // Creates global.env if it doesn't exist.
 func LoadSecretsMap(envName string) (map[string]any, error) {
+	if vault.DetectStore() == vault.StoreAge {
+		return loadSecretsFromVault(envName)
+	}
+
 	// Ensure global.env exists (create if missing)
 	if err := CreateDefaultEnvs(nil); err != nil {
 		return nil, utils.ColorError("failed to create global.env", err)

--- a/pkg/envparser/envparser_test.go
+++ b/pkg/envparser/envparser_test.go
@@ -2,7 +2,14 @@ package envparser
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"filippo.io/age"
+
+	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
 )
 
 func TestTrimQuotes(t *testing.T) {
@@ -82,4 +89,101 @@ KEY3='value3'
 			t.Errorf("Expected key %s to have value %s, got %s", key, val, result[key])
 		}
 	}
+}
+
+func setupVaultProject(t *testing.T, store *vault.Store) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	hulakDir := filepath.Join(tmpDir, utils.HiddenProjectName)
+	if err := os.Mkdir(hulakDir, utils.DirPer); err != nil {
+		t.Fatal(err)
+	}
+
+	configTmp := t.TempDir()
+	configTmp, _ = filepath.EvalSymlinks(configTmp)
+	t.Setenv("XDG_CONFIG_HOME", configTmp)
+
+	configDir, err := utils.UserConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(configDir, utils.DirPer); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	id, _ := age.GenerateX25519Identity()
+	if err := vault.SetIdentity(id.String()); err != nil {
+		t.Fatalf("SetIdentity error: %v", err)
+	}
+	if err := vault.WriteStore(store, id.Recipient()); err != nil {
+		t.Fatalf("WriteStore error: %v", err)
+	}
+}
+
+func TestLoadSecretsFromVault(t *testing.T) {
+	t.Run("merges global and custom env", func(t *testing.T) {
+		setupVaultProject(t, &vault.Store{Envs: map[string]vault.Env{
+			"global": {"URL": "https://example.com", "DEBUG": true},
+			"prod":   {"URL": "https://prod.example.com", "API_KEY": "sk-xxx"},
+		}})
+
+		got, err := loadSecretsFromVault("prod")
+		if err != nil {
+			t.Fatalf("loadSecretsFromVault error: %v", err)
+		}
+
+		// Custom overrides global
+		if got["URL"] != "https://prod.example.com" {
+			t.Errorf("URL = %v, want prod override", got["URL"])
+		}
+		// Global preserved when not overridden
+		if got["DEBUG"] != true {
+			t.Errorf("DEBUG = %v, want true (from global)", got["DEBUG"])
+		}
+		// Custom-only key present
+		if got["API_KEY"] != "sk-xxx" {
+			t.Errorf("API_KEY = %v, want sk-xxx", got["API_KEY"])
+		}
+	})
+
+	t.Run("returns global only when envName is global", func(t *testing.T) {
+		setupVaultProject(t, &vault.Store{Envs: map[string]vault.Env{
+			"global": {"URL": "https://example.com"},
+		}})
+
+		got, err := loadSecretsFromVault(utils.DefaultEnvVal)
+		if err != nil {
+			t.Fatalf("loadSecretsFromVault error: %v", err)
+		}
+		if got["URL"] != "https://example.com" {
+			t.Errorf("URL = %v, want global value", got["URL"])
+		}
+	})
+
+	t.Run("errors when non-global env is missing", func(t *testing.T) {
+		setupVaultProject(t, &vault.Store{Envs: map[string]vault.Env{
+			"global": {"URL": "https://example.com"},
+		}})
+
+		_, err := loadSecretsFromVault("staging")
+		if err == nil {
+			t.Fatal("expected error for missing env, got nil")
+		}
+		if !strings.Contains(err.Error(), "staging") {
+			t.Errorf("error = %q, want it to mention 'staging'", err.Error())
+		}
+	})
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/xaaha/hulak/pkg/features"
 	"github.com/xaaha/hulak/pkg/tui/envselect"
 	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
 	"github.com/xaaha/hulak/pkg/yamlparser"
 )
 
@@ -85,9 +86,12 @@ func containsTemplateVars(paths []string) bool {
 }
 
 // InitializeProject creates the env setup and returns the secrets map.
+// In vault mode (.hulak/store.age), skips creating the legacy env/ folder.
 func InitializeProject(env string, isCli bool) map[string]any {
-	if err := envparser.CreateDefaultEnvs(nil); err != nil {
-		utils.PanicRedAndExit("%v", err)
+	if vault.DetectStore() != vault.StoreAge {
+		if err := envparser.CreateDefaultEnvs(nil); err != nil {
+			utils.PanicRedAndExit("%v", err)
+		}
 	}
 	envMap, err := envparser.GenerateSecretsMap(env, isCli)
 	if err != nil {

--- a/pkg/tui/envselect/envselect.go
+++ b/pkg/tui/envselect/envselect.go
@@ -33,10 +33,12 @@ func EnvItems() []string {
 	if vault.DetectStore() == vault.StoreAge {
 		identity, err := vault.LoadIdentity()
 		if err != nil {
+			utils.PrintRed(fmt.Sprintf("vault: %v", err))
 			return nil
 		}
 		store, err := vault.ReadStore(identity)
 		if err != nil {
+			utils.PrintRed(fmt.Sprintf("vault: failed to read store: %v", err))
 			return nil
 		}
 		return store.ListEnvs()

--- a/pkg/tui/envselect/envselect.go
+++ b/pkg/tui/envselect/envselect.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/xaaha/hulak/pkg/tui"
 	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
 )
 
 // NoEnvFilesError returns a formatted error for missing env files.
@@ -26,8 +27,21 @@ Possible solutions:
 	return utils.ColorError(errMsg)
 }
 
-// EnvItems returns available environment names without the .env suffix.
+// EnvItems returns available environment names.
+// Reads from encrypted store when available, otherwise from env/ directory.
 func EnvItems() []string {
+	if vault.DetectStore() == vault.StoreAge {
+		identity, err := vault.LoadIdentity()
+		if err != nil {
+			return nil
+		}
+		store, err := vault.ReadStore(identity)
+		if err != nil {
+			return nil
+		}
+		return store.ListEnvs()
+	}
+
 	var items []string
 	if files, err := utils.GetEnvFiles(); err == nil {
 		for _, file := range files {

--- a/pkg/tui/envselect/envselect.go
+++ b/pkg/tui/envselect/envselect.go
@@ -9,8 +9,20 @@ import (
 	"github.com/xaaha/hulak/pkg/vault"
 )
 
-// NoEnvFilesError returns a formatted error for missing env files.
+// NoEnvFilesError returns a formatted error for missing environments.
+// The message adapts to the active backend (vault or classic env/).
 func NoEnvFilesError() error {
+	if vault.DetectStore() == vault.StoreAge {
+		return utils.ColorError(
+			`no environments found in encrypted store
+
+Possible causes:
+  - The store has no environments yet — add one with "hulak secret set"
+  - Identity file is missing or unreadable (check ~/.config/hulak/identity.txt)
+  - Store decryption failed (wrong identity for this store)`,
+		)
+	}
+
 	errMsg := fmt.Sprintf(
 		`no '%s' files found in "%s/" directory
 

--- a/pkg/tui/envselect/envselect.go
+++ b/pkg/tui/envselect/envselect.go
@@ -9,39 +9,45 @@ import (
 	"github.com/xaaha/hulak/pkg/vault"
 )
 
-// NoEnvFilesError returns a formatted error for missing environments.
+// noEnvFilesError returns a formatted error for missing environments.
 // The message adapts to the active backend (vault or classic env/).
-func NoEnvFilesError() error {
+func noEnvFilesError() error {
 	if vault.DetectStore() == vault.StoreAge {
-		return utils.ColorError(
-			`no environments found in encrypted store
-
-Possible causes:
-  - The store has no environments yet — add one with "hulak secret set"
-  - Identity file is missing or unreadable (check ~/.config/hulak/identity.txt)
-  - Store decryption failed (wrong identity for this store)`,
+		return utils.HelpfulError(
+			"no environments found in encrypted store",
+			"Possible causes",
+			[]string{
+				`The store has no environments yet — add one with "hulak secret set"`,
+				"Identity file is missing or unreadable (check ~/.config/hulak/identity.txt)",
+				"Store decryption failed (wrong identity for this store)",
+			},
 		)
 	}
 
-	errMsg := fmt.Sprintf(
-		`no '%s' files found in "%s/" directory
-
-Possible solutions:
-  - Create an env file: echo "KEY=value" > %s/dev%s
-  - Run "hulak init" to create the %s directory structure`,
-		utils.DefaultEnvFileSuffix,
-		utils.EnvironmentFolder,
-		utils.EnvironmentFolder,
-		utils.DefaultEnvFileSuffix,
-		utils.EnvironmentFolder,
+	return utils.HelpfulError(
+		fmt.Sprintf(
+			`no '%s' files found in "%s/" directory`,
+			utils.DefaultEnvFileSuffix,
+			utils.EnvironmentFolder,
+		),
+		"Possible solutions",
+		[]string{
+			fmt.Sprintf(
+				`Create an env file: echo "KEY=value" > %s/dev%s`,
+				utils.EnvironmentFolder,
+				utils.DefaultEnvFileSuffix,
+			),
+			fmt.Sprintf(
+				`Run "hulak init" to create the %s directory structure`,
+				utils.EnvironmentFolder,
+			),
+		},
 	)
-
-	return utils.ColorError(errMsg)
 }
 
-// EnvItems returns available environment names.
+// envItems returns available environment names.
 // Reads from encrypted store when available, otherwise from env/ directory.
-func EnvItems() []string {
+func envItems() []string {
 	if vault.DetectStore() == vault.StoreAge {
 		identity, err := vault.LoadIdentity()
 		if err != nil {
@@ -69,5 +75,5 @@ func EnvItems() []string {
 
 // RunEnvSelector runs the environment selector and returns the selected environment.
 func RunEnvSelector() (string, error) {
-	return tui.RunSelector(EnvItems(), "Select Environment: ", NoEnvFilesError())
+	return tui.RunSelector(envItems(), "Select Environment: ", noEnvFilesError())
 }

--- a/pkg/tui/envselect/envselect_test.go
+++ b/pkg/tui/envselect/envselect_test.go
@@ -45,7 +45,7 @@ func TestEnvItemsWithEnvFiles(t *testing.T) {
 	cleanup := setupTestEnvDir(t, []string{"dev.env", "prod.env", "staging.env"})
 	defer cleanup()
 
-	items := EnvItems()
+	items := envItems()
 
 	if len(items) != 3 {
 		t.Errorf("expected 3 items, got %d", len(items))
@@ -63,7 +63,7 @@ func TestEnvItemsWithNoEnvFiles(t *testing.T) {
 	cleanup := setupTestEnvDir(t, []string{})
 	defer cleanup()
 
-	items := EnvItems()
+	items := envItems()
 
 	if len(items) != 0 {
 		t.Errorf("expected 0 items, got %d", len(items))
@@ -74,7 +74,7 @@ func TestEnvItemsIgnoresNonEnvFiles(t *testing.T) {
 	cleanup := setupTestEnvDir(t, []string{"dev.env", "readme.txt", "config.yaml"})
 	defer cleanup()
 
-	items := EnvItems()
+	items := envItems()
 
 	if len(items) != 1 {
 		t.Errorf("expected 1 item, got %d", len(items))
@@ -138,7 +138,7 @@ func TestEnvItemsFromVault(t *testing.T) {
 		t.Fatalf("WriteStore() error: %v", err)
 	}
 
-	items := EnvItems()
+	items := envItems()
 
 	if len(items) != 3 {
 		t.Fatalf("EnvItems() len = %d, want 3", len(items))
@@ -152,7 +152,7 @@ func TestEnvItemsFromVault(t *testing.T) {
 }
 
 func TestNoEnvFilesError(t *testing.T) {
-	err := NoEnvFilesError()
+	err := noEnvFilesError()
 
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -191,7 +191,7 @@ func TestNoEnvFilesErrorVaultMode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gotErr := NoEnvFilesError()
+	gotErr := noEnvFilesError()
 	if gotErr == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/pkg/tui/envselect/envselect_test.go
+++ b/pkg/tui/envselect/envselect_test.go
@@ -166,3 +166,41 @@ func TestNoEnvFilesError(t *testing.T) {
 		t.Error("error should include possible solutions")
 	}
 }
+
+func TestNoEnvFilesErrorVaultMode(t *testing.T) {
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	hulakDir := filepath.Join(tmpDir, utils.HiddenProjectName)
+	if err := os.Mkdir(hulakDir, utils.DirPer); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hulakDir, utils.StoreFile), []byte("encrypted"), utils.SecretPer); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	gotErr := NoEnvFilesError()
+	if gotErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	errStr := gotErr.Error()
+	if !strings.Contains(errStr, "encrypted store") {
+		t.Errorf("vault error should mention encrypted store, got: %s", errStr)
+	}
+	if strings.Contains(errStr, "hulak init") {
+		t.Errorf("vault error should not mention 'hulak init', got: %s", errStr)
+	}
+}

--- a/pkg/tui/envselect/envselect_test.go
+++ b/pkg/tui/envselect/envselect_test.go
@@ -5,6 +5,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"filippo.io/age"
+
+	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
 )
 
 func setupTestEnvDir(t *testing.T, envFiles []string) func() {
@@ -76,6 +81,73 @@ func TestEnvItemsIgnoresNonEnvFiles(t *testing.T) {
 	}
 	if items[0] != "dev" {
 		t.Errorf("expected 'dev', got '%s'", items[0])
+	}
+}
+
+func TestEnvItemsFromVault(t *testing.T) {
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	hulakDir := filepath.Join(tmpDir, utils.HiddenProjectName)
+	if err := os.Mkdir(hulakDir, utils.DirPer); err != nil {
+		t.Fatal(err)
+	}
+
+	oldXDG := os.Getenv("XDG_CONFIG_HOME")
+	configTmp := t.TempDir()
+	configTmp, _ = filepath.EvalSymlinks(configTmp)
+	t.Setenv("XDG_CONFIG_HOME", configTmp)
+	t.Cleanup(func() {
+		if err := os.Setenv("XDG_CONFIG_HOME", oldXDG); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	configDir, err := utils.UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir() error: %v", err)
+	}
+	if err := os.MkdirAll(configDir, utils.DirPer); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	id, _ := age.GenerateX25519Identity()
+	if err := vault.SetIdentity(id.String()); err != nil {
+		t.Fatalf("SetIdentity() error: %v", err)
+	}
+
+	store := &vault.Store{Envs: map[string]vault.Env{
+		"global":  {"URL": "https://example.com"},
+		"prod":    {"API_KEY": "sk-xxx"},
+		"staging": {"API_KEY": "sk-staging"},
+	}}
+	if err := vault.WriteStore(store, id.Recipient()); err != nil {
+		t.Fatalf("WriteStore() error: %v", err)
+	}
+
+	items := EnvItems()
+
+	if len(items) != 3 {
+		t.Fatalf("EnvItems() len = %d, want 3", len(items))
+	}
+	expected := []string{"global", "prod", "staging"}
+	for i, want := range expected {
+		if items[i] != want {
+			t.Errorf("EnvItems()[%d] = %q, want %q", i, items[i], want)
+		}
 	}
 }
 

--- a/pkg/tui/fileselect.go
+++ b/pkg/tui/fileselect.go
@@ -13,13 +13,14 @@ import (
 // TUI flows but are not standalone Bubble Tea models.
 
 func NoFilesError() error {
-	errMsg := `no '.yaml' or '.yml' files found in current directory
-
-Possible solutions:
-  - Create an API file: echo "method: GET" > api.yaml
-  - Check that files are not inside the 'env/' directory`
-
-	return utils.ColorError(errMsg)
+	return utils.HelpfulError(
+		"no '.yaml' or '.yml' files found in current directory",
+		"Possible solutions",
+		[]string{
+			`Create an API file: echo "method: GET" > api.yaml`,
+			"Check that files are not inside the 'env/' directory",
+		},
+	)
 }
 
 func FileItems() ([]string, error) {

--- a/pkg/tui/focus.go
+++ b/pkg/tui/focus.go
@@ -74,10 +74,6 @@ func (f *FocusRing) SetTyping(v bool) {
 	f.typing = v
 }
 
-// TODO-gql: gqlexplorer.handleKey duplicates Esc/Tab/Enter/number-key logic
-// instead of delegating to HandleKey. Consolidate in Phase 3 when multiple
-// editable panels make the duplication painful.
-//
 // HandleKey processes focus-related keys. Returns two bools:
 //   - consumed: true if the key was handled (caller should not process it further)
 //   - quit: true if Esc was pressed while already not typing (caller should exit)

--- a/pkg/tui/gqlexplorer/model.go
+++ b/pkg/tui/gqlexplorer/model.go
@@ -357,7 +357,6 @@ func (m *Model) Init() tea.Cmd {
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tui.CopiedMsg:
-		// TODO: surface clipboard errors via a status flash once one exists.
 		return m, nil
 	case refreshLoadedMsg:
 		m.refreshing = false

--- a/pkg/utils/printing.go
+++ b/pkg/utils/printing.go
@@ -91,3 +91,17 @@ func WriteCommandHelp(commands []*CommandHelp) error {
 	}
 	return w.Flush()
 }
+
+// HelpfulError formats a multi-line error with a title, a section heading, and a
+// bullet list, then wraps it via ColorError. Use for user-facing errors that
+// should suggest remediation steps (e.g. "no env files found" → list of fixes).
+func HelpfulError(title, heading string, bullets []string) error {
+	var b strings.Builder
+	fmt.Fprintln(&b, title)
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "%s:\n", heading)
+	for _, item := range bullets {
+		fmt.Fprintf(&b, "  - %s\n", item)
+	}
+	return ColorError(strings.TrimRight(b.String(), "\n"))
+}

--- a/pkg/utils/project.go
+++ b/pkg/utils/project.go
@@ -7,7 +7,7 @@ import (
 )
 
 // FindProjectRoot walks up from the current working directory looking for
-// the root marker, .hulak/, similar to how git searches for .git/.
+// the root marker, env/ similar to how git searches for .git/.
 // It stops at the user's home directory. Returns the project root path and true if found, or user home dir and false otherwise.
 func FindProjectRoot() (string, bool) {
 	cwd, err := os.Getwd()

--- a/pkg/utils/project.go
+++ b/pkg/utils/project.go
@@ -7,7 +7,7 @@ import (
 )
 
 // FindProjectRoot walks up from the current working directory looking for
-// the root marker, env/ similar to how git searches for .git/.
+// root markers: .hulak/ (primary) or env/ (legacy), similar to how git searches for .git/.
 // It stops at the user's home directory. Returns the project root path and true if found, or user home dir and false otherwise.
 func FindProjectRoot() (string, bool) {
 	cwd, err := os.Getwd()
@@ -22,9 +22,12 @@ func FindProjectRoot() (string, bool) {
 
 	dir := cwd
 	for home == "" || dir != home {
-		candidate := filepath.Join(dir, EnvironmentFolder)
-		info, err := os.Stat(candidate)
-		if err == nil && info.IsDir() {
+		// .hulak/ is the primary marker (encrypted store)
+		if DirExists(filepath.Join(dir, HiddenProjectName)) {
+			return dir, true
+		}
+		// env/ is the legacy marker (plaintext .env files)
+		if DirExists(filepath.Join(dir, EnvironmentFolder)) {
 			return dir, true
 		}
 

--- a/pkg/utils/project.go
+++ b/pkg/utils/project.go
@@ -8,7 +8,8 @@ import (
 
 // FindProjectRoot walks up from the current working directory looking for
 // root markers: .hulak/ (primary) or env/ (legacy), similar to how git searches for .git/.
-// It stops at the user's home directory. Returns the project root path and true if found, or user home dir and false otherwise.
+// It stops at the user's home directory. Returns the project root path and true if found,
+// or the original current working directory and false otherwise.
 func FindProjectRoot() (string, bool) {
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/pkg/utils/project_test.go
+++ b/pkg/utils/project_test.go
@@ -32,7 +32,16 @@ func TestIsHulakProject(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "returns false when env directory does not exist",
+			name: "returns true when .hulak directory exists",
+			setup: func(t *testing.T, dir string) {
+				if err := os.Mkdir(filepath.Join(dir, HiddenProjectName), DirPer); err != nil {
+					t.Fatal(err)
+				}
+			},
+			expected: true,
+		},
+		{
+			name:     "returns false when neither marker exists",
 			setup:    func(_ *testing.T, _ string) {},
 			expected: false,
 		},
@@ -64,4 +73,61 @@ func TestIsHulakProject(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFindProjectRootPriority(t *testing.T) {
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	t.Run(".hulak found before env when both exist in parent", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+		if err := os.Mkdir(filepath.Join(tmpDir, HiddenProjectName), DirPer); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(filepath.Join(tmpDir, EnvironmentFolder), DirPer); err != nil {
+			t.Fatal(err)
+		}
+
+		subDir := filepath.Join(tmpDir, "subdir")
+		if err := os.Mkdir(subDir, DirPer); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(subDir); err != nil {
+			t.Fatal(err)
+		}
+
+		root, found := FindProjectRoot()
+		if !found {
+			t.Fatal("FindProjectRoot() not found, want found")
+		}
+		if root != tmpDir {
+			t.Errorf("FindProjectRoot() = %q, want %q", root, tmpDir)
+		}
+	})
+
+	t.Run(".hulak only project is found", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+		if err := os.Mkdir(filepath.Join(tmpDir, HiddenProjectName), DirPer); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, found := FindProjectRoot()
+		if !found {
+			t.Error("FindProjectRoot() should find .hulak-only project")
+		}
+	})
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -264,19 +264,18 @@ func MergeMaps(main, sec map[string]string) map[string]string {
 	return main
 }
 
-// FileExists checks if a file exists and is accessible at the given path
+// stat checks if a file exists and is accessible at the given path
+func stat(path string) (os.FileInfo, error) {
+	return os.Stat(filepath.Clean(path))
+}
+
 // Returns true if the file exists and is readable, false otherwise
 func FileExists(path string) bool {
-	// Clean the path to remove redundancies
-	cleanPath := filepath.Clean(path)
+	info, err := stat(path)
+	return err == nil && !info.IsDir()
+}
 
-	// Check if file exists and is accessible
-	info, err := os.Stat(cleanPath)
-	if err != nil {
-		// File doesn't exist or cannot be accessed
-		return false
-	}
-
-	// Make sure it's a file and not a directory
-	return !info.IsDir()
+func DirExists(path string) bool {
+	info, err := stat(path)
+	return info.IsDir() && err == nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -277,5 +277,5 @@ func FileExists(path string) bool {
 
 func DirExists(path string) bool {
 	info, err := stat(path)
-	return info.IsDir() && err == nil
+	return err == nil && info.IsDir()
 }

--- a/pkg/vault/crypto.go
+++ b/pkg/vault/crypto.go
@@ -6,6 +6,8 @@ import (
 	"filippo.io/age"
 )
 
+// Contains low-level age encryption and decryption stream helpers.
+
 // Encrypt reads plaintext from r, encrypts it for the given recipients, and writes ciphertext to w.
 func Encrypt(r io.Reader, w io.Writer, recipients ...age.Recipient) error {
 	ew, err := age.Encrypt(w, recipients...)

--- a/pkg/vault/keys.go
+++ b/pkg/vault/keys.go
@@ -49,6 +49,16 @@ func GetIdentity() (string, error) {
 	return string(byt), nil
 }
 
+// LoadIdentity reads and parses the existing identity file.
+// Unlike EnsureKeypair, this never creates keys — it errors if the identity is missing.
+func LoadIdentity() (*age.X25519Identity, error) {
+	raw, err := GetIdentity()
+	if err != nil {
+		return nil, fmt.Errorf("no identity found: %w", err)
+	}
+	return age.ParseX25519Identity(strings.TrimSpace(raw))
+}
+
 // SetIdentity writes the private key to the global config identity file.
 func SetIdentity(privateKey string) error {
 	identityFilePath, err := getIdentityFilePath()

--- a/pkg/vault/keys.go
+++ b/pkg/vault/keys.go
@@ -56,7 +56,11 @@ func LoadIdentity() (*age.X25519Identity, error) {
 	if err != nil {
 		return nil, fmt.Errorf("no identity found: %w", err)
 	}
-	return age.ParseX25519Identity(strings.TrimSpace(raw))
+	identity, err := age.ParseX25519Identity(strings.TrimSpace(raw))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse identity: %w", err)
+	}
+	return identity, nil
 }
 
 // SetIdentity writes the private key to the global config identity file.

--- a/pkg/vault/keys_test.go
+++ b/pkg/vault/keys_test.go
@@ -274,3 +274,31 @@ func TestEnsureKeypairDetectsMismatch(t *testing.T) {
 		t.Errorf("error = %q, want it to contain 'mismatch'", err.Error())
 	}
 }
+
+func TestLoadIdentity(t *testing.T) {
+	t.Run("loads existing identity", func(t *testing.T) {
+		setupConfigDir(t)
+
+		id, _ := age.GenerateX25519Identity()
+		if err := SetIdentity(id.String()); err != nil {
+			t.Fatalf("SetIdentity() error: %v", err)
+		}
+
+		got, err := LoadIdentity()
+		if err != nil {
+			t.Fatalf("LoadIdentity() error: %v", err)
+		}
+		if got.String() != id.String() {
+			t.Errorf("LoadIdentity() = %q, want %q", got.String(), id.String())
+		}
+	})
+
+	t.Run("errors when no identity exists", func(t *testing.T) {
+		setupConfigDir(t)
+
+		_, err := LoadIdentity()
+		if err == nil {
+			t.Error("LoadIdentity() should error when identity is missing")
+		}
+	})
+}

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -13,6 +13,8 @@ import (
 	"github.com/xaaha/hulak/pkg/utils"
 )
 
+// Contains encrypted store persistence and environment secret key management.
+
 // Env is the user's environment like 'staging', 'prod',
 type Env map[string]any
 

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -149,17 +149,24 @@ const (
 // we need to update this function as well. FindProjectRoot should also look for
 // .hulak/store.age file
 
-// func DetectStore(projectRoot string) StoreType {
-//
-//
-// 	fileExists := utils.FileExists(path)
-// 	if fileExists {
-// 		return StoreAge
-// 	}
-//
-// 	dirExists := utils.DirExists(path)
-// 	if dirExists {
-// 		return StoreClassic
-// 	}
-// 	return StoreNone
-// }
+// DetectStore checks which storage backend is available.
+// .hulak/store.age takes priority over env/ if both exist.
+func DetectStore() StoreType {
+	projectRoot, ok := utils.FindProjectRoot()
+	if !ok {
+		return StoreNone
+	}
+
+	ageFile := filepath.Join(projectRoot, utils.HiddenProjectName)
+	fileExists := utils.FileExists(ageFile)
+	if fileExists {
+		return StoreAge
+	}
+
+	envDir := filepath.Join(projectRoot, utils.EnvironmentFolder)
+	envDirExists := utils.DirExists(envDir)
+	if envDirExists {
+		return StoreClassic
+	}
+	return StoreNone
+}

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -135,3 +135,31 @@ func WriteStore(store *Store, recipients ...age.Recipient) error {
 
 	return nil
 }
+
+type StoreType int
+
+const (
+	StoreNone StoreType = iota
+	StoreAge
+	StoreClassic
+)
+
+// TODO:  pkg/utils/project.go has FindProjectRoot but it's misleading
+// It's looking for env folder but the description says, it's .hulak/
+// we need to update this function as well. FindProjectRoot should also look for
+// .hulak/store.age file
+
+// func DetectStore(projectRoot string) StoreType {
+//
+//
+// 	fileExists := utils.FileExists(path)
+// 	if fileExists {
+// 		return StoreAge
+// 	}
+//
+// 	dirExists := utils.DirExists(path)
+// 	if dirExists {
+// 		return StoreClassic
+// 	}
+// 	return StoreNone
+// }

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -144,28 +144,20 @@ const (
 	StoreClassic
 )
 
-// TODO:  pkg/utils/project.go has FindProjectRoot but it's misleading
-// It's looking for env folder but the description says, it's .hulak/
-// we need to update this function as well. FindProjectRoot should also look for
-// .hulak/store.age file
-
 // DetectStore checks which storage backend is available.
 // .hulak/store.age takes priority over env/ if both exist.
 func DetectStore() StoreType {
+	if path, err := storePath(); err == nil && utils.FileExists(path) {
+		return StoreAge
+	}
+
 	projectRoot, ok := utils.FindProjectRoot()
 	if !ok {
 		return StoreNone
 	}
 
-	ageFile := filepath.Join(projectRoot, utils.HiddenProjectName)
-	fileExists := utils.FileExists(ageFile)
-	if fileExists {
-		return StoreAge
-	}
-
 	envDir := filepath.Join(projectRoot, utils.EnvironmentFolder)
-	envDirExists := utils.DirExists(envDir)
-	if envDirExists {
+	if utils.DirExists(envDir) {
 		return StoreClassic
 	}
 	return StoreNone

--- a/pkg/vault/store_test.go
+++ b/pkg/vault/store_test.go
@@ -338,6 +338,104 @@ func TestReadStoreWrongIdentity(t *testing.T) {
 	}
 }
 
+func TestDetectStore(t *testing.T) {
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	t.Run("returns StoreAge when store.age exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+		hulakDir := filepath.Join(tmpDir, utils.HiddenProjectName)
+		if err := os.Mkdir(hulakDir, utils.DirPer); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(hulakDir, utils.StoreFile), []byte("encrypted"), utils.SecretPer); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		if got := DetectStore(); got != StoreAge {
+			t.Errorf("DetectStore() = %v, want StoreAge", got)
+		}
+	})
+
+	t.Run("returns StoreClassic when only env/ exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+		if err := os.Mkdir(filepath.Join(tmpDir, utils.EnvironmentFolder), utils.DirPer); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		if got := DetectStore(); got != StoreClassic {
+			t.Errorf("DetectStore() = %v, want StoreClassic", got)
+		}
+	})
+
+	t.Run("returns StoreNone when neither exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		if got := DetectStore(); got != StoreNone {
+			t.Errorf("DetectStore() = %v, want StoreNone", got)
+		}
+	})
+
+	t.Run("StoreAge takes priority over env/", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+		hulakDir := filepath.Join(tmpDir, utils.HiddenProjectName)
+		if err := os.Mkdir(hulakDir, utils.DirPer); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(hulakDir, utils.StoreFile), []byte("encrypted"), utils.SecretPer); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(filepath.Join(tmpDir, utils.EnvironmentFolder), utils.DirPer); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		if got := DetectStore(); got != StoreAge {
+			t.Errorf("DetectStore() = %v, want StoreAge when both exist", got)
+		}
+	})
+
+	t.Run("returns StoreNone when .hulak is dir but no store.age", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+		if err := os.Mkdir(filepath.Join(tmpDir, utils.HiddenProjectName), utils.DirPer); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		if got := DetectStore(); got != StoreNone {
+			t.Errorf("DetectStore() = %v, want StoreNone when .hulak has no store.age", got)
+		}
+	})
+}
+
 func TestWriteStoreAtomicCleanup(t *testing.T) {
 	projectDir := setupHulakProject(t)
 	id, _ := age.GenerateX25519Identity()

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -10,6 +10,8 @@ import (
 	"github.com/xaaha/hulak/pkg/utils"
 )
 
+// Contains keypair generation, persistence, and age text encryption helpers.
+
 // AgeKey holds a matched age X25519 keypair.
 type AgeKey struct {
 	Recipient *age.X25519Recipient


### PR DESCRIPTION
## Summary

Closes #127. Part of #125 (Phase 2).

- `FindProjectRoot()` now detects `.hulak/` (primary) and `env/` (legacy)
- `DetectStore()` routes to encrypted store vs classic env files
- `GenerateSecretsMap()` and `LoadSecretsMap()` load from vault when `store.age` exists
- `EnvItems()` lists environments from vault for the TUI selector
- Added `LoadIdentity()` — read-only key loading, no side-effect key creation on read paths
- Fixed latent nil-dereference in `DirExists()` (wrong short-circuit order)
- Fixed `DetectStore()` bug: was checking `.hulak` as file instead of `.hulak/store.age`

## Backward compatibility

- All vault checks are early returns — classic `env/` flow is untouched
- `runner.go`, `graphql.go`, `main.go` require zero changes
- Projects without `.hulak/store.age` behave exactly as before

## Test plan

- [x] `FindProjectRoot` detects `.hulak/` directory, `.hulak`-only projects, priority over `env/`
- [x] `DetectStore` returns correct `StoreType` for all combinations
- [x] `LoadIdentity` reads existing identity, errors when missing
- [x] `EnvItems` reads from encrypted vault store
- [x] All existing tests pass (`go test ./... -count=1`)
- [x] `golangci-lint run ./...` — 0 issues