### PR TITLE
feat(env): full CRUD command tree, vault prerequisites, table renderer (#142)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Start here for the full reference:
 - [Request Body](./docs/body.md)
 - [Actions](./docs/actions.md)
 - [Environment Secrets](./docs/environment.md)
+- [Encrypted Store](./docs/store.md)
 - [Response Files](./docs/response.md)
 - [GraphQL Explorer](./docs/graphql-explorer.md)
 - [Auth2.0](./docs/auth20.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,9 +64,14 @@ Running `hulak` with no file or directory target opens the interactive picker.
 
 ### Environment selection
 
-- The default environment is `global`.
-- Environment selection only matters when the request needs template resolution.
-- `run` and `gql` support `--env` / `--environment` to skip the environment picker.
+When `--env` is omitted, behavior depends on the command:
+
+- **`run` and `gql`**: open the interactive picker if the request files reference environment variables (`{{.key}}`). If a request needs no env, no picker.
+- **`hulak env edit`**: always opens the picker — no default. Pass `--env <name>` (including for new envs you want to create).
+- **`hulak env set`, `get`, `delete`, `keys`**: default to `global`. These are non-interactive operations on a known env; the default keeps scripts terse.
+- **`hulak env list`**: takes no `--env` (it lists envs themselves).
+
+All commands above accept `--env` / `--environment` to bypass any picker or default explicitly.
 
 ## Commands
 
@@ -162,28 +167,32 @@ Read the full guide in [graphql-explorer.md](./graphql-explorer.md).
 
 ### `env`
 
-The `env` command tree is exposed in the CLI for encrypted environment-secret management.
+The `env` command tree manages secrets in the encrypted vault (`.hulak/store.age`). See [docs/store.md](./store.md) for the full encryption model and team-sharing flows.
 
 ```bash
 hulak env --help
 hulak env set API_KEY value --env prod
-hulak env list --env staging
-hulak env keys --env prod
+hulak env list
+hulak env keys --env prod --show
+hulak env get DB_URL --env staging        # raw to stdout — $(...) safe
+hulak env edit                            # picks env interactively, no --env default
 ```
 
-Subcommands currently shown by the CLI:
+| Subcommand                | Notes                                                                                         |
+| ------------------------- | --------------------------------------------------------------------------------------------- |
+| `set` (`add`)             | Positional VALUE, secure prompt fallback, `--stdin` for scripts                               |
+| `get`                     | Raw stdout, exit non-zero on missing key                                                      |
+| `list` (`ls`)             | Environment names; styled header in TTY, plain when piped                                     |
+| `keys` (`key`)            | Masked by default, `--show`, `--search` (substring or glob)                                   |
+| `delete` (`rm`, `remove`) | Errors on missing key                                                                         |
+| `edit`                    | TUI env picker if `--env` omitted; no global default; pass `--env <name>` to create a new env |
+| `import-key`              | Import an age identity from a file or stdin                                                   |
+| `export-key`              | Print or save your private key                                                                |
+| `add-recipient`           | Authorize a new public key                                                                    |
+| `remove-recipient`        | Revoke a public key                                                                           |
+| `list-recipients`         | Show all authorized public keys                                                               |
 
-- `set` (`add`)
-- `get`
-- `list` (`ls`)
-- `keys` (`key`)
-- `delete` (`rm`, `remove`)
-- `edit`
-- `import-key`
-- `export-key`
-- `add-recipient`
-- `remove-recipient`
-- `list-recipients`
+**GUI editors** for `edit`: pass the wait flag in `$EDITOR` so hulak blocks until you save. e.g. `EDITOR="zed --wait"` or `EDITOR="code -w"`. Without it, the editor returns immediately and the file is read back unchanged.
 
 ### `help`
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,5 +1,8 @@
 # Environment Secrets
 
+> [!Note]
+> This page documents the legacy `env/` backend. For new projects, prefer the encrypted store — see [docs/store.md](./store.md). Hulak supports both; if `.hulak/store.age` exists, it takes priority over `env/`.
+
 - Environment secrets files (for example `global.env`) live in the `env/` folder at the project root.
 - The `env/` setup is required only for requests that use environment template vars like `{{.key}}`.
 - If a selected request needs environment vars and `env/global.env` is missing, Hulak asks to initialize the project setup at runtime.

--- a/docs/store.md
+++ b/docs/store.md
@@ -206,6 +206,9 @@ hulak env remove-recipient age1ql3z...
 | `hulak env rotate-key`                               | Generate a new identity, re-encrypt                    |
 | `hulak migrate env`                                  | Convert `env/*.env` to `store.age`                     |
 
+> [!Tip]
+> Need a snapshot of `store.age`? Just `cp .hulak/store.age my-backup.age`. The file is already encrypted — copy it anywhere. To restore, copy it back. No dedicated subcommand needed.
+
 > [!Note]
 > `hulak env edit` opens an interactive picker when `--env` is omitted — the same flow as `hulak run`. There is no silent "global" default for edit. Pass `--env <name>` (including for new envs you want to create).
 
@@ -232,24 +235,6 @@ git commit
 
 > [!Tip]
 > For frequent recipient churn (large teams), consider squashing multiple `add-recipient` / `remove-recipient` commits into one to reduce merge surface area.
-
-## Passphrase-protected identity (advanced)
-
-age supports passphrase-encrypting the identity file itself: instead of `~/.config/hulak/identity.txt` containing a plaintext `AGE-SECRET-KEY-1...` line, it can be an age-encrypted blob requiring a passphrase to unlock.
-
-This is a layer of defense on top of file permissions and disk encryption — useful for shared workstations or laptops without full-disk encryption. The trade-off: every hulak command that needs to decrypt prompts for the passphrase (or you cache it in a key agent).
-
-To create a passphrase-protected identity:
-
-```bash
-# Generate (or take an existing identity) and re-encrypt it with a passphrase
-hulak env export-key | age -p > ~/.config/hulak/identity.txt
-chmod 600 ~/.config/hulak/identity.txt
-# age will prompt for a passphrase on every decrypt
-```
-
-> [!Note]
-> Passphrase-encrypted identities don't work well with CI — there's no one to type the passphrase. Use `HULAK_MASTER_KEY` (the raw key as an env var) for non-interactive contexts. First-class hulak support for this flow is tracked as a future enhancement.
 
 ## CI / scripts
 
@@ -314,12 +299,7 @@ This is the same playbook as SOPS, GPG, and git-crypt. Encryption can't un-show 
 
 ## Privacy
 
-hulak makes no network calls except when you explicitly opt in:
-
-- `hulak env add-recipient --github <user>` — fetches keys from `https://github.com/<user>.keys`
-- Any HTTP request you've defined in a `.hk.yaml` file — that's the whole product, obviously
-
-There is no telemetry, no analytics, no version-check ping, no error reporting. The CLI runs entirely against local files and the requests you author. If you observe a network call from hulak that isn't covered above, that's a bug — please file it.
+hulak makes no network calls except for the HTTP requests you author in your `.hk.yaml` files — that's the whole product. There is no telemetry, no analytics, no version-check ping, no error reporting. The CLI runs entirely against local files and the requests you author. If you observe a network call from hulak outside of running your own request files, that's a bug — please file it.
 
 ## FAQ
 
@@ -334,7 +314,7 @@ If you have no backup and no second recipient, the data is gone. Mitigations:
 
 - `hulak env export-key` → save in a password manager
 - `hulak env add-recipient <backup-key>` → second recipient as redundancy
-- `hulak env backup` → snapshot the encrypted store (still requires a key to decrypt)
+- `cp .hulak/store.age my-backup.age` → snapshot the encrypted store (still needs a key to decrypt)
 
 **Can I have both `env/` and `store.age`?**
 Yes, during migration. Vault takes priority. After verifying everything works, delete `env/`.
@@ -342,5 +322,5 @@ Yes, during migration. Vault takes priority. After verifying everything works, d
 **How big can a single value be?**
 Functionally, anything. Practically, hulak warns at 64 KB and recommends `{{getFile "path"}}` for large blobs (certs, JSON fixtures) — those are read from disk on demand instead of decrypted on every invocation.
 
-**Does this work with hardware security keys?**
-Not yet. age supports SSH ed25519 keys, which would let `~/.ssh/id_ed25519` double as a hulak identity. Tracking as a future enhancement.
+**Does this work with hardware security keys / SSH keys?**
+Not yet. age supports SSH ed25519 keys natively, which would let `~/.ssh/id_ed25519` double as a hulak identity. Tracked in [#170](https://github.com/xaaha/hulak/issues/170).

--- a/docs/store.md
+++ b/docs/store.md
@@ -188,23 +188,26 @@ hulak env remove-recipient age1ql3z...
 
 ## Commands
 
-| Command                                     | Purpose                                         |
-| ------------------------------------------- | ----------------------------------------------- |
-| `hulak init`                                | Generate keypair, write `recipients.txt`        |
-| `hulak env set KEY [VALUE] [--env name]`    | Set a secret (interactive prompt if no value)   |
-| `hulak env get KEY [--env name]`            | Print a value to stdout                         |
-| `hulak env list`                            | List environment names                          |
-| `hulak env keys --env name [--show]`        | List keys in an environment (masked by default) |
-| `hulak env delete KEY [--env name]`         | Remove a key                                    |
-| `hulak env edit [--env name]`               | Open `$EDITOR` on the decrypted env section     |
-| `hulak env export-key [--out path]`         | Print or save your private key                  |
-| `hulak env import-key path [--force]`       | Restore an identity from a file                 |
-| `hulak env add-recipient KEY [--name n]`    | Authorize a new public key                      |
-| `hulak env remove-recipient KEY [--name n]` | Revoke a public key                             |
-| `hulak env list-recipients`                 | Show all authorized public keys                 |
-| `hulak env backup [--out path]`             | Snapshot `store.age`                            |
-| `hulak env restore path`                    | Restore from a snapshot                         |
-| `hulak migrate env`                         | Convert `env/*.env` to `store.age`              |
+| Command                                              | Purpose                                                |
+| ---------------------------------------------------- | ------------------------------------------------------ |
+| `hulak init`                                         | Generate keypair, write `recipients.txt`               |
+| `hulak env set KEY [VALUE] [--env name] [--stdin]`   | Set a secret (interactive prompt if no value)          |
+| `hulak env get KEY [--env name]`                     | Print a value to stdout (raw, scriptable)              |
+| `hulak env list`                                     | List environment names                                 |
+| `hulak env keys [--env name] [--show] [--search p]`  | List keys, masked by default; substring/glob filter    |
+| `hulak env delete KEY [--env name]`                  | Remove a key                                           |
+| `hulak env edit [--env name]`                        | Open `$EDITOR` on the env (TUI picker if no `--env`)   |
+| `hulak env export-key [--out path]`                  | Print or save your private key                         |
+| `hulak env import-key path [--force]`                | Restore an identity from a file                        |
+| `hulak env add-recipient KEY [--name n]`             | Authorize a new public key                             |
+| `hulak env remove-recipient KEY [--name n]`          | Revoke a public key                                    |
+| `hulak env list-recipients`                          | Show all authorized public keys                        |
+| `hulak env rotate`                                   | Re-encrypt to the current recipient set                |
+| `hulak env rotate-key`                               | Generate a new identity, re-encrypt                    |
+| `hulak migrate env`                                  | Convert `env/*.env` to `store.age`                     |
+
+> [!Note]
+> `hulak env edit` opens an interactive picker when `--env` is omitted — the same flow as `hulak run`. There is no silent "global" default for edit. Pass `--env <name>` (including for new envs you want to create).
 
 ## Merge conflicts on `recipients.txt` and `store.age`
 

--- a/docs/store.md
+++ b/docs/store.md
@@ -1,0 +1,343 @@
+# Encrypted Store
+
+Hulak supports two backends for storing environment variables:
+
+| Backend | Layout                             | When                                   |
+| ------- | ---------------------------------- | -------------------------------------- |
+| Classic | `env/global.env`, `env/<name>.env` | Default for existing projects (legacy) |
+| Vault   | `.hulak/store.age` (age-encrypted) | Recommended — encrypted at rest        |
+
+If `.hulak/store.age` exists, hulak uses the vault. Otherwise it falls back to `env/`. You can have both during a migration period; vault always wins.
+
+## Layout
+
+```text
+my-project/
+├── .hulak/
+│   ├── store.age          # encrypted secrets (safe to commit)
+│   └── recipients.txt     # list of public keys that can decrypt (safe to commit)
+├── env/                   # legacy, optional (vault takes priority if both exist)
+│   └── global.env
+└── requests/
+    └── create_user.hk.yaml
+
+~/.config/hulak/
+└── identity.txt           # YOUR PRIVATE KEY — never commit
+```
+
+| File                           | Contains                             | Commit? |
+| ------------------------------ | ------------------------------------ | ------- |
+| `.hulak/store.age`             | Encrypted secrets blob               | Yes     |
+| `.hulak/recipients.txt`        | Public keys of authorized decryptors | Yes     |
+| `~/.config/hulak/identity.txt` | Your age private key                 | **No**  |
+
+## How encryption works
+
+Hulak uses [age](https://age-encryption.org/) — a modern, file-based encryption tool with simple X25519 keys.
+
+- Each user generates an age **keypair** (one public key, one private key)
+- The **public key** can be shared freely — it only encrypts
+- The **private key** decrypts ciphertext encrypted to your public key — keep it secret
+- A single `store.age` file can be encrypted to **multiple public keys** at once. Any one of the corresponding private keys can decrypt it. This is what makes team sharing possible.
+
+## `recipients.txt` format
+
+```
+# .hulak/recipients.txt
+# Alice (added 2026-03-15)
+age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
+
+# Bob (added 2026-03-20)
+age1yr5tpz76yxqeg5ktrp7g2wgkxfmq9rmef0gxhvsky2pyv6lsf8msgmd00n
+```
+
+- **One age public key per line.**
+- **`#` comments are supported.** Use them to label keys (name, date added, role).
+- **Blank lines are ignored.**
+- Same format as the `-R` flag in the `age` CLI — tooling-compatible.
+
+> [!Tip]
+> Add a comment above each key with the person's name and the date you added them. Future-you will thank present-you when someone asks "wait, who is `age1ql3z...`?".
+
+## Quick start
+
+### Create a new vault project
+
+```bash
+mkdir my-apis && cd my-apis
+hulak init
+# ✓ Identity saved to ~/.config/hulak/identity.txt
+# ✓ Recipients file written to .hulak/recipients.txt (1 recipient: you)
+
+hulak env set API_KEY --env prod
+# Enter value for API_KEY: ▊
+# ✓ Set API_KEY in prod
+
+hulak run requests/create_user.yaml --env prod
+```
+
+> [!Important]
+> Your private key in `~/.config/hulak/identity.txt` is the **only** way to decrypt `store.age`. If you lose it without a backup or another recipient, the encrypted data is unrecoverable.
+
+### Migrate an existing classic project
+
+```bash
+hulak migrate env
+# ✓ Migrated global.env → store.age[global] (3 keys)
+# ✓ Migrated prod.env → store.age[prod] (5 keys)
+# ⚠ Save this recovery key somewhere safe (you won't see it again):
+#   AGE-SECRET-KEY-1QF...
+```
+
+The legacy `env/` directory is left in place. Vault takes priority while both exist. Delete `env/` once you're confident.
+
+## Identity backup
+
+The single biggest pitfall is losing your private key. Two ways to protect against it:
+
+### 1. Export to a password manager
+
+```bash
+hulak env export-key
+# AGE-SECRET-KEY-1QF...
+# (paste into 1Password / Bitwarden / etc.)
+```
+
+### 2. Add a second recipient
+
+A second recipient (a backup keypair you keep on a USB stick, or a teammate) means losing one identity isn't fatal. See [team sharing](#team-sharing) below.
+
+To restore on a new machine:
+
+```bash
+hulak env import-key ~/Downloads/identity-backup.txt
+# ✓ Identity imported to ~/.config/hulak/identity.txt
+```
+
+## Team sharing
+
+A single `store.age` can be encrypted to many recipients. Each teammate has their own private key; any of them can decrypt the shared file.
+
+### Joining a team
+
+```bash
+# === New member's machine ===
+hulak init
+# Generates the new member's own keypair locally
+cat .hulak/recipients.txt | tail -1
+# age1bob...
+```
+
+The new member sends their **public key** (`age1bob...`) to an existing team member via Slack, email, or a PR. **Public keys are not secret.** Never share the private key from `~/.config/hulak/identity.txt`.
+
+```bash
+# === Existing team member ===
+hulak env add-recipient age1bob... --name "Bob"
+# ✓ Added Bob to .hulak/recipients.txt
+# ✓ Re-encrypted store.age for 3 recipients
+
+git add .hulak/recipients.txt .hulak/store.age
+git commit -m "add Bob as recipient"
+git push
+
+# === New member ===
+git pull
+hulak env list   # ✓ works — Bob's identity can decrypt
+```
+
+### Leaving a team
+
+```bash
+hulak env remove-recipient --name "Alice"
+# ✓ Removed Alice from .hulak/recipients.txt
+# ✓ Re-encrypted store.age for 2 recipients
+#
+# ⚠ Reminder: Alice may have already read any secrets in this store.
+#   remove-recipient only prevents FUTURE access. To fully revoke:
+#     1. Rotate the actual secret values upstream (API keys, passwords, etc.)
+#     2. hulak env set <KEY> <new-value> for each rotated secret
+#     3. Commit and push
+```
+
+### Why rotation matters
+
+Removing a recipient prevents them from decrypting **future** versions of `store.age`. They can still decrypt any copy they already have — local clones, old git commits, backups they made.
+
+To truly revoke access:
+
+1. `hulak env remove-recipient <pubkey>`
+2. Rotate every secret the leaver could have read (API keys, DB passwords, OAuth client secrets, etc.) on the upstream service
+3. `hulak env set <KEY> <new-value>` for each rotated secret
+4. Commit and push
+
+This is a fundamental property of asymmetric encryption — true of age, GPG, SOPS, git-crypt, and every similar tool. There is no scheme that can un-show plaintext.
+
+### Self-removal guard
+
+You cannot remove yourself if you are the only recipient — that would brick the store.
+
+```bash
+hulak env remove-recipient age1ql3z...
+# error: cannot remove the last recipient — this would brick the store.
+#
+#   Add another recipient first:
+#     hulak env add-recipient <new-public-key>
+#
+#   Or, if you intended to delete the project, remove .hulak/store.age manually.
+```
+
+## Commands
+
+| Command                                     | Purpose                                         |
+| ------------------------------------------- | ----------------------------------------------- |
+| `hulak init`                                | Generate keypair, write `recipients.txt`        |
+| `hulak env set KEY [VALUE] [--env name]`    | Set a secret (interactive prompt if no value)   |
+| `hulak env get KEY [--env name]`            | Print a value to stdout                         |
+| `hulak env list`                            | List environment names                          |
+| `hulak env keys --env name [--show]`        | List keys in an environment (masked by default) |
+| `hulak env delete KEY [--env name]`         | Remove a key                                    |
+| `hulak env edit [--env name]`               | Open `$EDITOR` on the decrypted env section     |
+| `hulak env export-key [--out path]`         | Print or save your private key                  |
+| `hulak env import-key path [--force]`       | Restore an identity from a file                 |
+| `hulak env add-recipient KEY [--name n]`    | Authorize a new public key                      |
+| `hulak env remove-recipient KEY [--name n]` | Revoke a public key                             |
+| `hulak env list-recipients`                 | Show all authorized public keys                 |
+| `hulak env backup [--out path]`             | Snapshot `store.age`                            |
+| `hulak env restore path`                    | Restore from a snapshot                         |
+| `hulak migrate env`                         | Convert `env/*.env` to `store.age`              |
+
+## Merge conflicts on `recipients.txt` and `store.age`
+
+Two teammates may add or remove recipients on parallel branches. The merge behavior:
+
+- **`recipients.txt` is plain text.** Git merges it like any source file. If both branches added different recipients, you'll get a clean three-way merge. If both added a recipient at the same line, you'll get a textual conflict — resolve by keeping both lines.
+- **`store.age` is a binary blob.** Git can't merge it. Whichever branch's `store.age` you accept will be encrypted to **only that branch's recipient set** — the other branch's added recipient is silently dropped.
+
+### How to resolve
+
+After merging the text side cleanly, regenerate `store.age` to match the merged recipient list:
+
+```bash
+# Resolve recipients.txt manually so it's the union you want
+git checkout --theirs .hulak/store.age   # pick one ciphertext to start from
+hulak env rotate                          # re-encrypt to the current (merged) recipients.txt
+git add .hulak/store.age .hulak/recipients.txt
+git commit
+```
+
+`hulak env rotate` (see #144) re-encrypts the store to the current `recipients.txt` without changing keys — exactly what you need after a merge.
+
+> [!Tip]
+> For frequent recipient churn (large teams), consider squashing multiple `add-recipient` / `remove-recipient` commits into one to reduce merge surface area.
+
+## Passphrase-protected identity (advanced)
+
+age supports passphrase-encrypting the identity file itself: instead of `~/.config/hulak/identity.txt` containing a plaintext `AGE-SECRET-KEY-1...` line, it can be an age-encrypted blob requiring a passphrase to unlock.
+
+This is a layer of defense on top of file permissions and disk encryption — useful for shared workstations or laptops without full-disk encryption. The trade-off: every hulak command that needs to decrypt prompts for the passphrase (or you cache it in a key agent).
+
+To create a passphrase-protected identity:
+
+```bash
+# Generate (or take an existing identity) and re-encrypt it with a passphrase
+hulak env export-key | age -p > ~/.config/hulak/identity.txt
+chmod 600 ~/.config/hulak/identity.txt
+# age will prompt for a passphrase on every decrypt
+```
+
+> [!Note]
+> Passphrase-encrypted identities don't work well with CI — there's no one to type the passphrase. Use `HULAK_MASTER_KEY` (the raw key as an env var) for non-interactive contexts. First-class hulak support for this flow is tracked as a future enhancement.
+
+## CI / scripts
+
+For non-interactive use (CI, scripts), set the master key as an environment variable:
+
+```bash
+export HULAK_MASTER_KEY="AGE-SECRET-KEY-1QF..."
+hulak run requests/create_user.yaml --env prod
+```
+
+`HULAK_MASTER_KEY` takes precedence over `~/.config/hulak/identity.txt`. Store the value in your CI provider's secret manager (GitHub Actions secrets, GitLab CI variables, etc.).
+
+> [!Caution]
+> Environment variables are visible to other processes running as the same user. On Linux, `ps -e auxe` shows the env table for any process owned by you. In CI this is fine — the runner is single-tenant. On a shared workstation (e.g., a build server with multiple users sharing one account), prefer the file-based identity at `~/.config/hulak/identity.txt` instead of `HULAK_MASTER_KEY`.
+
+### CI templates
+
+**GitHub Actions:**
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      HULAK_MASTER_KEY: ${{ secrets.HULAK_MASTER_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: brew install xaaha/tap/hulak # or download from releases
+      - run: hulak run requests/smoke.yaml --env staging
+```
+
+**GitLab CI:**
+
+```yaml
+test:
+  variables:
+    HULAK_MASTER_KEY: $HULAK_MASTER_KEY # set in project CI/CD variables, masked
+  script:
+    - hulak run requests/smoke.yaml --env staging
+```
+
+Mark `HULAK_MASTER_KEY` as a **masked** / **protected** variable in both systems so the value is redacted from build logs.
+
+## If your identity is compromised
+
+Treat a leaked private key (laptop stolen, accidental commit, etc.) like a leaked database password — assume the worst and rotate. Steps:
+
+1. **Generate a new identity.** On a clean machine: `hulak init` (this creates a fresh keypair).
+2. **Add the new key as a recipient before removing the old one.** From any machine that still has access:
+   ```bash
+   hulak env add-recipient <new-public-key> --name "you-rotated-YYYY-MM-DD"
+   ```
+3. **Remove the compromised key.**
+   ```bash
+   hulak env remove-recipient <old-public-key>
+   ```
+4. **Rotate every secret in the store upstream.** API keys, DB passwords, OAuth client secrets — anything the leaker may have read. The leaker still has copies of `store.age` and the old identity from before the removal; the only way to invalidate that data is to make it useless by changing the upstream values.
+5. **Force teammates to pull.** They need the re-encrypted `store.age` so their next decrypt uses the new recipient list.
+6. **Audit history.** `git log -- .hulak/store.age` shows when ciphertexts changed; cross-reference with whatever you know about when the leak happened.
+
+This is the same playbook as SOPS, GPG, and git-crypt. Encryption can't un-show plaintext, but a fast rotation + upstream secret change is the standard mitigation.
+
+## Privacy
+
+hulak makes no network calls except when you explicitly opt in:
+
+- `hulak env add-recipient --github <user>` — fetches keys from `https://github.com/<user>.keys`
+- Any HTTP request you've defined in a `.hk.yaml` file — that's the whole product, obviously
+
+There is no telemetry, no analytics, no version-check ping, no error reporting. The CLI runs entirely against local files and the requests you author. If you observe a network call from hulak that isn't covered above, that's a bug — please file it.
+
+## FAQ
+
+**Is it safe to commit `store.age` and `recipients.txt`?**
+Yes. `store.age` is an encrypted blob; without a private key in the recipient list, it's opaque. `recipients.txt` contains public keys only.
+
+**Is it safe to commit `~/.config/hulak/identity.txt`?**
+**No.** This is your private key. Anyone with it can decrypt every `store.age` you have access to. The file is created with mode `0600` for this reason. Don't include `~/.config/` in dotfile repos that are pushed publicly.
+
+**What if I lose my private key?**
+If you have no backup and no second recipient, the data is gone. Mitigations:
+
+- `hulak env export-key` → save in a password manager
+- `hulak env add-recipient <backup-key>` → second recipient as redundancy
+- `hulak env backup` → snapshot the encrypted store (still requires a key to decrypt)
+
+**Can I have both `env/` and `store.age`?**
+Yes, during migration. Vault takes priority. After verifying everything works, delete `env/`.
+
+**How big can a single value be?**
+Functionally, anything. Practically, hulak warns at 64 KB and recommends `{{getFile "path"}}` for large blobs (certs, JSON fixtures) — those are read from disk on demand instead of decrypted on every invocation.
+
+**Does this work with hardware security keys?**
+Not yet. age supports SSH ed25519 keys, which would let `~/.ssh/id_ed25519` double as a hulak identity. Tracking as a future enhancement.

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.246
 	golang.org/x/net v0.47.0
 	golang.org/x/sys v0.38.0
+	golang.org/x/term v0.37.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/muesli/termenv v0.16.0
 	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.246
 	golang.org/x/net v0.47.0
+	golang.org/x/sys v0.38.0
 )
 
 require (
@@ -39,7 +40,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/crypto v0.45.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.37.0 h1:8EGAD0qCmHYZg6J17DvsMy9/wJ7/D/4pV/wfnld5lTU=
+golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
 golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=
 golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
 golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da h1:noIWHXmPHxILtqtCOPIhSt0ABwskkZKjD3bXGnZGpNY=

--- a/pkg/userFlags/cli_contract_test.go
+++ b/pkg/userFlags/cli_contract_test.go
@@ -2,27 +2,12 @@ package userflags
 
 import (
 	"flag"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/xaaha/hulak/pkg/utils"
 )
-
-// newTestRunFlagSet creates a fresh FlagSet with the same flags as the run
-// subcommand, returning the pointers tests need to pass to parseRunArgs.
-func newTestRunFlagSet() (fs *flag.FlagSet, envVal *string, seq *bool, debug *bool) {
-	fs = flag.NewFlagSet("run", flag.ContinueOnError)
-	fs.Usage = func() {}
-	fs.SetOutput(io.Discard)
-	envVal = registerEnvFlag(fs, "", "Environment to use")
-	var s, d bool
-	fs.BoolVar(&s, "sequential", false, "")
-	fs.BoolVar(&s, "seq", false, "")
-	fs.BoolVar(&d, "debug", false, "")
-	return fs, envVal, &s, &d
-}
 
 // TestSubCommandsExist verifies every expected subcommand is registered.
 // If a subcommand is removed or renamed, this test fails.
@@ -179,14 +164,12 @@ func TestRunSubcommandHasRunHandler(t *testing.T) {
 
 // TestParseRunArgsSetsFilePath verifies that passing a file path sets FilePath.
 func TestParseRunArgsSetsFilePath(t *testing.T) {
-	fs, envVal, seq, debug := newTestRunFlagSet()
-
 	tmpFile := filepath.Join(t.TempDir(), "test.hk.yaml")
 	if err := os.WriteFile(tmpFile, []byte("kind: API"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	f, err := parseRunArgs(fs, envVal, seq, debug, []string{tmpFile})
+	f, err := parseRunArgs("", false, false, []string{tmpFile})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -201,10 +184,9 @@ func TestParseRunArgsSetsFilePath(t *testing.T) {
 
 // TestParseRunArgsSetsDir verifies that passing a directory sets Dir (concurrent).
 func TestParseRunArgsSetsDir(t *testing.T) {
-	fs, envVal, seq, debug := newTestRunFlagSet()
 	tmpDir := t.TempDir()
 
-	f, err := parseRunArgs(fs, envVal, seq, debug, []string{tmpDir})
+	f, err := parseRunArgs("", false, false, []string{tmpDir})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -220,39 +202,37 @@ func TestParseRunArgsSetsDir(t *testing.T) {
 	}
 }
 
-// TestParseRunArgsTrailingFlags verifies that flags after the positional
-// argument are still parsed correctly.
-func TestParseRunArgsTrailingFlags(t *testing.T) {
-	fs, envVal, seq, debug := newTestRunFlagSet()
-
+// TestParseRunArgsRoutesFlags verifies that parsed flag values map to the
+// right runner.Flags fields. Flag parsing itself is the framework's job —
+// this test only checks the path → Flags translation.
+func TestParseRunArgsRoutesFlags(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "test.hk.yaml")
 	if err := os.WriteFile(tmpFile, []byte("kind: API"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	f, err := parseRunArgs(fs, envVal, seq, debug, []string{tmpFile, "--debug", "--env", "staging"})
+	f, err := parseRunArgs("staging", false, true, []string{tmpFile})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if !f.Debug {
-		t.Error("Debug should be true when --debug is passed after the path")
+		t.Error("Debug should mirror the debug arg")
 	}
 	if f.Env != "staging" {
 		t.Errorf("Env = %q, want %q", f.Env, "staging")
 	}
 	if !f.EnvSet {
-		t.Error("EnvSet should be true when --env is provided")
+		t.Error("EnvSet should be true when an env is provided")
 	}
 }
 
-// TestParseRunArgsSequentialDir verifies --sequential after a directory
-// sets Dirseq instead of Dir.
+// TestParseRunArgsSequentialDir verifies sequential=true on a directory
+// routes to Dirseq instead of Dir.
 func TestParseRunArgsSequentialDir(t *testing.T) {
-	fs, envVal, seq, debug := newTestRunFlagSet()
 	tmpDir := t.TempDir()
 
-	f, err := parseRunArgs(fs, envVal, seq, debug, []string{tmpDir, "--sequential"})
+	f, err := parseRunArgs("", true, false, []string{tmpDir})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -261,47 +241,27 @@ func TestParseRunArgsSequentialDir(t *testing.T) {
 		t.Errorf("Dirseq = %q, want %q", f.Dirseq, tmpDir)
 	}
 	if f.Dir != "" {
-		t.Error("Dir should be empty when --sequential is set")
+		t.Error("Dir should be empty when sequential is true")
 	}
 }
 
 // TestParseRunArgsBadPath verifies that a nonexistent path returns an error.
 func TestParseRunArgsBadPath(t *testing.T) {
-	fs, envVal, seq, debug := newTestRunFlagSet()
-
-	_, err := parseRunArgs(fs, envVal, seq, debug, []string{"/nonexistent/path.yaml"})
+	_, err := parseRunArgs("", false, false, []string{"/nonexistent/path.yaml"})
 	if err == nil {
 		t.Fatal("expected an error for nonexistent path")
 	}
 }
 
-// TestParseRunArgsUnknownTrailingFlag verifies that an unknown flag after
-// the path produces a parse error, not a silent pass.
-func TestParseRunArgsUnknownTrailingFlag(t *testing.T) {
-	fs, envVal, seq, debug := newTestRunFlagSet()
-
-	tmpFile := filepath.Join(t.TempDir(), "test.hk.yaml")
-	if err := os.WriteFile(tmpFile, []byte("kind: API"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err := parseRunArgs(fs, envVal, seq, debug, []string{tmpFile, "--bogus"})
-	if err == nil {
-		t.Fatal("expected an error for unknown trailing flag")
-	}
-}
-
-// TestParseRunArgsDefaultEnv verifies that when no --env is passed,
-// the default environment is used.
+// TestParseRunArgsDefaultEnv verifies that an empty envFlagVal falls back to
+// the default environment.
 func TestParseRunArgsDefaultEnv(t *testing.T) {
-	fs, envVal, seq, debug := newTestRunFlagSet()
-
 	tmpFile := filepath.Join(t.TempDir(), "test.hk.yaml")
 	if err := os.WriteFile(tmpFile, []byte("kind: API"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	f, err := parseRunArgs(fs, envVal, seq, debug, []string{tmpFile})
+	f, err := parseRunArgs("", false, false, []string{tmpFile})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -310,7 +270,7 @@ func TestParseRunArgsDefaultEnv(t *testing.T) {
 		t.Errorf("Env = %q, want default %q", f.Env, utils.DefaultEnvVal)
 	}
 	if f.EnvSet {
-		t.Error("EnvSet should be false when no --env is provided")
+		t.Error("EnvSet should be false when no env is provided")
 	}
 }
 

--- a/pkg/userFlags/cli_contract_test.go
+++ b/pkg/userFlags/cli_contract_test.go
@@ -306,10 +306,11 @@ func TestEnvAliases(t *testing.T) {
 		name    string
 		aliases []string
 	}{
-		{"list", []string{"ls"}},
+		{"list", []string{"ls", "l"}},
 		{"set", []string{"add"}},
+		{"get", []string{"g", "show", "view"}},
 		{"keys", []string{"key"}},
-		{"delete", []string{"rm", "remove"}},
+		{"delete", []string{"rm", "remove", "del"}},
 	}
 
 	for _, tc := range tests {
@@ -319,6 +320,29 @@ func TestEnvAliases(t *testing.T) {
 					t.Errorf("expected env subcommand %q to resolve (alias of %q)", alias, tc.name)
 				}
 			})
+		}
+	}
+}
+
+// TestEnvSubcommandAliasesUnique guards against accidentally registering the
+// same name or alias under two env subcommands. findSub does first-match wins,
+// so a duplicate would silently shadow whichever command is later in the slice.
+func TestEnvSubcommandAliasesUnique(t *testing.T) {
+	root := subCommands()
+	envCmd := root.findSub("env")
+	if envCmd == nil {
+		t.Fatal("expected env subcommand to exist")
+	}
+
+	seen := map[string]string{} // identifier → owner name
+	for _, sub := range envCmd.SubCommands {
+		ids := append([]string{sub.Name}, sub.Aliases...)
+		for _, id := range ids {
+			if owner, dup := seen[id]; dup {
+				t.Errorf("identifier %q is claimed by both %q and %q", id, owner, sub.Name)
+				continue
+			}
+			seen[id] = sub.Name
 		}
 	}
 }

--- a/pkg/userFlags/cli_contract_test.go
+++ b/pkg/userFlags/cli_contract_test.go
@@ -373,7 +373,8 @@ func TestEnvSubCommandsHaveFlags(t *testing.T) {
 	}
 
 	// Subcommands that target a specific environment
-	needsEnvFlag := []string{"set", "get", "list", "keys", "delete", "edit"}
+	// list does not take --env (it lists environment names themselves)
+	needsEnvFlag := []string{"set", "get", "keys", "delete", "edit"}
 	for _, name := range needsEnvFlag {
 		sub := envCmd.findSub(name)
 		if sub == nil {
@@ -399,7 +400,8 @@ func TestEnvSubCommandsHaveEnvironmentAlias(t *testing.T) {
 		t.Fatal("expected env subcommand to exist")
 	}
 
-	needsEnvFlag := []string{"set", "get", "list", "keys", "delete", "edit"}
+	// list does not take --env (it lists environment names themselves)
+	needsEnvFlag := []string{"set", "get", "keys", "delete", "edit"}
 	for _, name := range needsEnvFlag {
 		sub := envCmd.findSub(name)
 		if sub == nil {
@@ -431,6 +433,7 @@ func TestEnvSubCommandSpecificFlags(t *testing.T) {
 	}{
 		{"set", "stdin"},
 		{"keys", "show"},
+		{"keys", "search"},
 		{"import-key", "stdin"},
 		{"export-key", "armor"},
 	}

--- a/pkg/userFlags/command.go
+++ b/pkg/userFlags/command.go
@@ -93,16 +93,27 @@ func (cmd *command) Execute(args []string) error {
 		cmd.Flags.Usage = func() {}
 		cmd.Flags.SetOutput(io.Discard)
 
-		if err := cmd.Flags.Parse(args); err != nil {
-			return fmt.Errorf("%s\nSee 'hulak %s --help' for usage", err, cmd.Name)
+		// Iterative parse: stdlib flag.Parse stops at the first non-flag argument,
+		// so `hulak set FOO bar --env prod` would leave '--env prod' unparsed.
+		// Loop, peeling off one positional per iteration, until all flags (in any position) are consumed.
+		// After this, args holds only positionals.
+		var positionals []string
+		remaining := args
+		for {
+			if err := cmd.Flags.Parse(remaining); err != nil {
+				return fmt.Errorf("%s\nSee 'hulak %s --help' for usage", err, cmd.Name)
+			}
+			if helpFlag {
+				cmd.printHelp()
+				return nil
+			}
+			if cmd.Flags.NArg() == 0 {
+				break
+			}
+			positionals = append(positionals, cmd.Flags.Arg(0))
+			remaining = cmd.Flags.Args()[1:]
 		}
-
-		if helpFlag {
-			cmd.printHelp()
-			return nil
-		}
-
-		args = cmd.Flags.Args()
+		args = positionals
 	}
 
 	if cmd.Run == nil {

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -380,10 +380,12 @@ func filterKeys(keys []string, pattern string) ([]string, error) {
 }
 
 // formatTableValue renders a stored value for inline (one-line) display.
-// Strings show raw with newlines escaped to "\n"; other types JSON-encode.
+// Strings show raw with control characters escaped (\n, \r, \t, etc.) so a
+// value containing a newline or carriage return can't shift later rows or
+// blank out the line via \r. Other types JSON-encode.
 func formatTableValue(v any) string {
 	if s, ok := v.(string); ok {
-		return strings.ReplaceAll(s, "\n", `\n`)
+		return escapeControlChars(s)
 	}
 	b, err := json.Marshal(v)
 	if err != nil {
@@ -392,11 +394,73 @@ func formatTableValue(v any) string {
 	return string(b)
 }
 
+// escapeControlChars rewrites ASCII control characters to a visible escape
+// form so a stored value can't manipulate the terminal when printed in a
+// table row. Concretely:
+//
+//   - \n would push the rest of the row onto a new line, breaking column
+//     alignment for everything that follows.
+//   - \r would rewind the cursor and overwrite the start of the line — a
+//     subsequent value could blank out the key column entirely.
+//   - \t expands to the next tab stop, which varies by terminal.
+//   - other control bytes (BEL 0x07, ESC 0x1B, etc.) can ring the bell or
+//     start an escape sequence we never intended.
+//
+// All ASCII control chars are 0x00–0x1F plus 0x7F (DEL). Any byte >= 0x80
+// belongs to a multi-byte UTF-8 sequence (continuation bytes are 0x80–0xBF,
+// leading bytes are 0xC0+); none of those are control chars, so we can scan
+// byte-by-byte without ever splitting a rune.
+//
+// \n, \r, \t get the familiar two-char escapes; the rest fall back to \xNN
+// hex so the output always stays printable ASCII.
+func escapeControlChars(s string) string {
+	// Fast path: most values have no control bytes (URLs, tokens, IDs).
+	// Scan once and bail out without allocating if there's nothing to escape.
+	hasControl := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 0x20 || c == 0x7F {
+			hasControl = true
+			break
+		}
+	}
+	if !hasControl {
+		return s
+	}
+
+	// Slow path: at least one control byte. Pre-size the builder to the
+	// input length — a lower bound, since each escape grows the output.
+	var sb strings.Builder
+	sb.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '\n':
+			sb.WriteString(`\n`)
+		case c == '\r':
+			sb.WriteString(`\r`)
+		case c == '\t':
+			sb.WriteString(`\t`)
+		case c < 0x20 || c == 0x7F:
+			// Catch-all for BEL, ESC, NUL, DEL, etc. Hex form keeps the
+			// output unambiguous and printable on every terminal.
+			fmt.Fprintf(&sb, `\x%02x`, c)
+		default:
+			// Printable ASCII (0x20–0x7E) and UTF-8 bytes (>= 0x80) pass
+			// through untouched — emojis, accents, CJK all render normally.
+			sb.WriteByte(c)
+		}
+	}
+	return sb.String()
+}
+
 // --- EDIT ---
 
 // runEnvEdit handles `hulak env edit`. Decrypts the named environment to a
 // temporary 0600 JSON file, opens it in $EDITOR (or vi), then validates and
-// merges the result back. Editor non-zero exit or unchanged content → no write.
+// writes the result back. The saved JSON REPLACES the environment wholesale —
+// keys removed in the editor are removed from the store. Other environments in
+// the store are untouched. Editor non-zero exit or unchanged content → no write.
 //
 // When envName is empty, the user is prompted via the env picker TUI — the
 // same flow as `hulak run`. Edit deliberately does NOT default to "global":

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 
 	"golang.org/x/term"
@@ -13,6 +15,19 @@ import (
 	"github.com/xaaha/hulak/pkg/utils"
 	"github.com/xaaha/hulak/pkg/vault"
 )
+
+// maskedValue is what `keys` prints in place of secret values when --show is off.
+const maskedValue = "••••"
+
+// stdoutHeaders returns headers when stdout is a TTY, nil when piped.
+// Hiding headers under pipe redirection keeps scripts like
+// `for env in $(hulak env list)` clean — the same convention as kubectl / mise.
+func stdoutHeaders(headers []string) []string {
+	if term.IsTerminal(int(os.Stdout.Fd())) { //nolint:gosec // G115 fd is small non-neg
+		return headers
+	}
+	return nil
+}
 
 // ---- SET ----
 
@@ -121,7 +136,7 @@ func promptSecretValue(key string) (string, error) {
 			"no value provided and stdin is not a terminal — pass VALUE positionally or use --stdin",
 		)
 	}
-	fmt.Fprintf(os.Stderr, "Enter value for %s: ", key)
+	fmt.Fprintf(os.Stderr, "Enter value for %s: ", key) //nolint:gosec // G705 TTY prompt, no taint sink
 	// read input without echo
 	bytes, err := term.ReadPassword(stdinFd)
 	// newline to stderr
@@ -261,8 +276,108 @@ func runEnvList(args []string) error {
 		return err
 	}
 
-	for _, name := range store.ListEnvs() {
-		fmt.Println(name)
+	names := store.ListEnvs()
+	rows := make([][]string, len(names))
+	for i, name := range names {
+		rows[i] = []string{name}
 	}
-	return nil
+	return utils.PrintTable(os.Stdout, stdoutHeaders([]string{"ENVIRONMENT"}), rows, 0)
+}
+
+// --- KEYS ---
+
+// runEnvKeys handles `hulak env keys`. Lists keys within an environment.
+//
+// Values are masked (••••) unless --show is set. --search filters keys by
+// glob pattern (when the pattern contains '*', '?', or '[') or by
+// case-insensitive substring otherwise.
+func runEnvKeys(args []string, envName, search string, show bool) error {
+	if len(args) > 0 {
+		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
+	}
+	if err := utils.ValidateEnvName(envName); err != nil {
+		return err
+	}
+
+	identity, err := vault.LoadIdentity()
+	if err != nil {
+		return fmt.Errorf("failed to load identity: %w", err)
+	}
+
+	store, err := vault.ReadStore(identity)
+	if err != nil {
+		return err
+	}
+
+	env := store.GetEnv(envName)
+	if env == nil {
+		return fmt.Errorf("environment %q not found in vault store", envName)
+	}
+
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	if search != "" {
+		keys, err = filterKeys(keys, search)
+		if err != nil {
+			return err
+		}
+	}
+
+	rows := make([][]string, 0, len(keys))
+	for _, k := range keys {
+		val := maskedValue
+		if show {
+			val = formatTableValue(env[k])
+		}
+		rows = append(rows, []string{k, val})
+	}
+	return utils.PrintTable(
+		os.Stdout,
+		stdoutHeaders([]string{"KEY", "VALUE"}),
+		rows,
+		utils.DefaultTableMaxCellWidth,
+	)
+}
+
+// filterKeys returns the subset of keys matching pattern. Glob mode (filepath.Match)
+// is used when pattern contains '*', '?', or '['; otherwise case-insensitive
+// substring match.
+func filterKeys(keys []string, pattern string) ([]string, error) {
+	isGlob := strings.ContainsAny(pattern, "*?[")
+	lowered := strings.ToLower(pattern)
+
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		var match bool
+		if isGlob {
+			ok, err := filepath.Match(pattern, k)
+			if err != nil {
+				return nil, fmt.Errorf("invalid glob pattern %q: %w", pattern, err)
+			}
+			match = ok
+		} else {
+			match = strings.Contains(strings.ToLower(k), lowered)
+		}
+		if match {
+			out = append(out, k)
+		}
+	}
+	return out, nil
+}
+
+// formatTableValue renders a stored value for inline (one-line) display.
+// Strings show raw with newlines escaped to "\n"; other types JSON-encode.
+func formatTableValue(v any) string {
+	if s, ok := v.(string); ok {
+		return strings.ReplaceAll(s, "\n", `\n`)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
 }

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -1,0 +1,130 @@
+package userflags
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+
+	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
+)
+
+// MaxValueSizeWarnBytes is the soft per-value size threshold at `set` time.
+// Above this, the user is warned and pointed at {{getFile "path"}} for blobs.
+// Not a hard limit — the value is still written.
+const MaxValueSizeWarnBytes = 64 << 10 // 64 KiB
+
+// runEnvSet handles `hulak env set KEY [VALUE]`.
+//
+// Resolution order for the value:
+//  1. --stdin flag → read all of stdin
+//  2. positional VALUE → use as-is
+//  3. interactive prompt with no echo (only if stdin is a TTY)
+//
+// The read-modify-write of store.age is wrapped in WithStoreLock so concurrent
+// `hulak env set` invocations cannot lose each other's edits.
+func runEnvSet(args []string, envName string, useStdin bool) error {
+	if len(args) == 0 {
+		return errors.New("missing required argument: KEY")
+	}
+	key := args[0]
+
+	if err := utils.ValidateEnvName(envName); err != nil {
+		return err
+	}
+
+	value, err := resolveSetValue(args, useStdin, key)
+	if err != nil {
+		return err
+	}
+
+	if len(value) > MaxValueSizeWarnBytes {
+		utils.PrintWarningStderr(fmt.Sprintf(
+			"value for %q is %.1f KB — consider {{getFile \"path\"}} for large blobs",
+			key, float64(len(value))/1024,
+		))
+	}
+
+	// acquire lock
+	return vault.WithStoreLock(func() error {
+		// load identity
+		ageKey, err := vault.EnsureKeypair()
+		if err != nil {
+			return fmt.Errorf("failed to load keypair: %w", err)
+		}
+
+		// read
+		store, err := vault.ReadStore(ageKey.Identity)
+		if err != nil {
+			return err
+		}
+
+		// modify in memory
+		store.SetKey(envName, key, value)
+
+		// write  (atomic .tmp+rename)
+		if err := vault.WriteStore(store, ageKey.Recipient); err != nil {
+			return err
+		}
+
+		utils.PrintGreen(fmt.Sprintf("%s Set %s in %s", utils.CheckMark, key, envName))
+		return nil
+	})
+}
+
+// resolveSetValue returns the value to store, picking from --stdin, a positional
+// argument, or an interactive prompt. Trailing newlines are stripped from stdin
+// reads so 'echo "x" | hulak env set FOO --stdin' stores "x" not 'x\n'.
+//
+// Multi-word values must be quoted (e.g. `hulak env set MOTD "hello world"`).
+// More than one VALUE positional is rejected so a typo like
+// `hulak env set FOO bar baz` doesn't silently store "bar baz".
+func resolveSetValue(args []string, useStdin bool, key string) (string, error) {
+	switch {
+	case useStdin:
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("failed to read stdin: %w", err)
+		}
+		return strings.TrimRight(string(data), "\r\n"), nil
+
+	case len(args) > 2:
+		return "", fmt.Errorf(
+			"too many arguments: got %d, expected KEY [VALUE]; quote multi-word values: hulak env set %s \"...\"",
+			len(args),
+			key,
+		)
+
+	case len(args) == 2:
+		return args[1], nil
+
+	default:
+		return promptSecretValue(key)
+	}
+}
+
+// promptSecretValue reads a value from the terminal with no echo, no shell
+// history. The prompt and trailing newline go to stderr so a misuse like
+// `FOO=$(hulak env set BAR)` never captures them into the variable.
+func promptSecretValue(key string) (string, error) {
+	stdinFd := int(os.Stdin.Fd()) //nolint:gosec // G115 fd is small non-neg
+	// ensure intput is coming from terminal
+	if !term.IsTerminal(stdinFd) {
+		return "", errors.New(
+			"no value provided and stdin is not a terminal — pass VALUE positionally or use --stdin",
+		)
+	}
+	fmt.Fprintf(os.Stderr, "Enter value for %s: ", key)
+	// read input without echo
+	bytes, err := term.ReadPassword(stdinFd)
+	// newline to stderr
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return "", fmt.Errorf("failed to read input: %w", err)
+	}
+	return string(bytes), nil
+}

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -1,23 +1,32 @@
 package userflags
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	"golang.org/x/term"
 
+	"github.com/xaaha/hulak/pkg/tui/envselect"
 	"github.com/xaaha/hulak/pkg/utils"
 	"github.com/xaaha/hulak/pkg/vault"
 )
 
 // maskedValue is what `keys` prints in place of secret values when --show is off.
 const maskedValue = "••••"
+
+// envPicker is the function called to interactively pick an environment when
+// the user omits --env on `hulak env edit`. Indirected as a package variable
+// so tests can stub it out — calling the real selector would open a TUI on
+// /dev/tty and wait for keypress, hanging non-interactive test runs.
+var envPicker = envselect.RunEnvSelector
 
 // stdoutHeaders returns headers when stdout is a TTY, nil when piped.
 // Hiding headers under pipe redirection keeps scripts like
@@ -136,7 +145,8 @@ func promptSecretValue(key string) (string, error) {
 			"no value provided and stdin is not a terminal — pass VALUE positionally or use --stdin",
 		)
 	}
-	fmt.Fprintf(os.Stderr, "Enter value for %s: ", key) //nolint:gosec // G705 TTY prompt, no taint sink
+	//nolint:gosec // G705 TTY prompt, no taint sink
+	fmt.Fprintf(os.Stderr, "Enter value for %s: ", key)
 	// read input without echo
 	bytes, err := term.ReadPassword(stdinFd)
 	// newline to stderr
@@ -380,4 +390,145 @@ func formatTableValue(v any) string {
 		return fmt.Sprintf("%v", v)
 	}
 	return string(b)
+}
+
+// --- EDIT ---
+
+// runEnvEdit handles `hulak env edit`. Decrypts the named environment to a
+// temporary 0600 JSON file, opens it in $EDITOR (or vi), then validates and
+// merges the result back. Editor non-zero exit or unchanged content → no write.
+//
+// When envName is empty, the user is prompted via the env picker TUI — the
+// same flow as `hulak run`. Edit deliberately does NOT default to "global":
+// editing is destructive enough that we want explicit selection. To create or
+// edit a brand-new env, pass it explicitly: `hulak env edit --env staging`.
+//
+// The whole read/edit/validate/write cycle is wrapped in WithStoreLock so an
+// edit cannot race with a parallel set/delete.
+func runEnvEdit(args []string, envName string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
+	}
+
+	if envName == "" {
+		picked, err := envPicker()
+		if err != nil {
+			return err
+		}
+		envName = picked
+	}
+
+	if err := utils.ValidateEnvName(envName); err != nil {
+		return err
+	}
+
+	return vault.WithStoreLock(func() error {
+		ageKey, err := vault.EnsureKeypair()
+		if err != nil {
+			return fmt.Errorf("failed to load keypair: %w", err)
+		}
+		store, err := vault.ReadStore(ageKey.Identity)
+		if err != nil {
+			return err
+		}
+
+		// Marshal the env (or {} if the env doesn't exist yet — edit creates it).
+		env := store.GetEnv(envName)
+		if env == nil {
+			env = make(vault.Env)
+		}
+		original, err := json.MarshalIndent(env, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal env: %w", err)
+		}
+
+		// Temp file inside .hulak/ keeps plaintext on the same filesystem
+		// (same security boundary as store.age). The name encodes the env so
+		// users see "edit-prod.json" in their editor's title bar — much nicer
+		// than a random suffix. Safe to use a deterministic name because:
+		//   - we're inside WithStoreLock (no concurrent edit)
+		//   - ValidateEnvName already restricts to [a-zA-Z0-9_-] (no path tricks)
+		//   - O_TRUNC overwrites any leftover from a previous crashed run
+		markerPath, err := utils.GetProjectMarker()
+		if err != nil {
+			return err
+		}
+		tmpPath := filepath.Join(markerPath, "edit-"+envName+".json")
+		tmpFile, err := os.OpenFile(
+			tmpPath,
+			os.O_RDWR|os.O_CREATE|os.O_TRUNC,
+			utils.SecretPer,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create temp file: %w", err)
+		}
+		// Always remove the plaintext temp — even on editor crash, invalid
+		// JSON, or panic up the stack.
+		defer os.Remove(tmpPath)
+
+		if _, err := tmpFile.Write(original); err != nil {
+			_ = tmpFile.Close()
+			return fmt.Errorf("failed to write temp file: %w", err)
+		}
+		if err := tmpFile.Close(); err != nil {
+			return fmt.Errorf("failed to close temp file: %w", err)
+		}
+
+		if err := launchEditor(tmpPath); err != nil {
+			return err
+		}
+
+		edited, err := os.ReadFile(tmpPath)
+		if err != nil {
+			return fmt.Errorf("failed to read edited file: %w", err)
+		}
+
+		if bytes.Equal(original, edited) {
+			utils.PrintGreen(fmt.Sprintf("%s No changes to %s", utils.CheckMark, envName))
+			return nil
+		}
+
+		var newEnv vault.Env
+		dec := json.NewDecoder(bytes.NewReader(edited))
+		dec.UseNumber()
+		if err := dec.Decode(&newEnv); err != nil {
+			return fmt.Errorf("invalid JSON in edited file (store unchanged): %w", err)
+		}
+
+		store.Envs[envName] = newEnv
+
+		if err := vault.WriteStore(store, ageKey.Recipient); err != nil {
+			return err
+		}
+
+		utils.PrintGreen(fmt.Sprintf("%s Updated %s", utils.CheckMark, envName))
+		return nil
+	})
+}
+
+// launchEditor runs $EDITOR (or vi if unset) with path appended as its last
+// argument. Stdin/Stdout/Stderr are wired to the parent terminal so the user
+// interacts directly with the editor.
+//
+// $EDITOR is whitespace-split into argv (handles "code -w", "nvim --clean")
+// but NOT shell-parsed — quotes and shell metachars in $EDITOR are not
+// interpreted. Users with exotic editor invocations should write a wrapper
+// script and point $EDITOR at it.
+func launchEditor(path string) error {
+	editor := strings.TrimSpace(os.Getenv("EDITOR"))
+	if editor == "" {
+		editor = utils.Editor
+	}
+	parts := strings.Fields(editor)
+	parts = append(parts, path)
+
+	//nolint:gosec // G204 $EDITOR is user-controlled by design — that's the contract.
+	cmd := exec.Command(parts[0], parts[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("editor failed: %w", err)
+	}
+	return nil
 }

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -188,3 +188,56 @@ func printValue(value any) error {
 	fmt.Println(string(b))
 	return nil
 }
+
+// --- DELETE ---
+
+// runEnvDelete handles 'hulak env delete KEY'.
+// Removes the key from the given environment under the file lock.
+// Exits non-zero if the key (or env) is missing
+// — a missing key is reported, not silently treated as success.
+//
+// Unlike set, this uses LoadIdentity (not EnsureKeypair) so running delete in a
+// fresh project errors with "no identity found" instead of generating spurious
+// keys. There's nothing to delete if no store exists.
+func runEnvDelete(args []string, envName string) error {
+	if len(args) == 0 {
+		return errors.New("missing required argument: KEY")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments: got %d, expected KEY", len(args))
+	}
+	key := args[0]
+
+	if err := utils.ValidateEnvName(envName); err != nil {
+		return err
+	}
+
+	return vault.WithStoreLock(func() error {
+		identity, err := vault.LoadIdentity()
+		if err != nil {
+			return fmt.Errorf("failed to load identity: %w", err)
+		}
+
+		store, err := vault.ReadStore(identity)
+		if err != nil {
+			return err
+		}
+
+		env := store.GetEnv(envName)
+		if env == nil {
+			return fmt.Errorf("environment %q not found in vault store", envName)
+		}
+		if _, ok := env[key]; !ok {
+			return fmt.Errorf("key %q not found in environment %q", key, envName)
+		}
+
+		store.DeleteKey(envName, key)
+
+		if err := vault.WriteStore(store, identity.Recipient()); err != nil {
+			return err
+		}
+
+		utils.PrintGreen(fmt.Sprintf("%s Deleted %s from %s", utils.CheckMark, key, envName))
+		return nil
+	})
+}

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -1,6 +1,7 @@
 package userflags
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -127,4 +128,61 @@ func promptSecretValue(key string) (string, error) {
 		return "", fmt.Errorf("failed to read input: %w", err)
 	}
 	return string(bytes), nil
+}
+
+// --- GET ---
+
+// runEnvGet handles `hulak env get KEY`. Prints the raw value to stdout
+// (suitable for $(...) capture) and returns a non-zero error if the key
+// or environment is missing.
+func runEnvGet(args []string, envName string) error {
+	if len(args) == 0 {
+		return errors.New("missing required argument: KEY")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments: got %d, expected KEY", len(args))
+	}
+	key := args[0]
+
+	if err := utils.ValidateEnvName(envName); err != nil {
+		return err
+	}
+
+	identity, err := vault.LoadIdentity()
+	if err != nil {
+		return fmt.Errorf("failed to load identity: %w", err)
+	}
+
+	store, err := vault.ReadStore(identity)
+	if err != nil {
+		return err
+	}
+
+	env := store.GetEnv(envName)
+	if env == nil {
+		return fmt.Errorf("environment %q not found in vault store", envName)
+	}
+
+	value, ok := env[key]
+	if !ok {
+		return fmt.Errorf("key %q not found in environment %q", key, envName)
+	}
+
+	return printValue(value)
+}
+
+// printValue writes a stored value to stdout in a script-friendly form.
+// Strings print raw; other types are JSON-encoded so numbers/bools/objects
+// round-trip predictably (e.g. json.Number("8000") prints as 8000, not "8000").
+func printValue(value any) error {
+	if s, ok := value.(string); ok {
+		fmt.Println(s)
+		return nil
+	}
+	b, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("failed to format value: %w", err)
+	}
+	fmt.Println(string(b))
+	return nil
 }

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -14,6 +14,8 @@ import (
 	"github.com/xaaha/hulak/pkg/vault"
 )
 
+// ---- SET ----
+
 // MaxValueSizeWarnBytes is the soft per-value size threshold at `set` time.
 // Above this, the user is warned and pointed at {{getFile "path"}} for blobs.
 // Not a hard limit — the value is still written.

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -241,3 +241,28 @@ func runEnvDelete(args []string, envName string) error {
 		return nil
 	})
 }
+
+// --- LIST ---
+
+// runEnvList handles `hulak env list`. Prints environment names — one per line,
+// sorted, no decoration — so output is friendly to `for env in $(hulak env list)`.
+func runEnvList(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
+	}
+
+	identity, err := vault.LoadIdentity()
+	if err != nil {
+		return fmt.Errorf("failed to load identity: %w", err)
+	}
+
+	store, err := vault.ReadStore(identity)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range store.ListEnvs() {
+		fmt.Println(name)
+	}
+	return nil
+}

--- a/pkg/userFlags/env_test.go
+++ b/pkg/userFlags/env_test.go
@@ -1,0 +1,184 @@
+package userflags
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
+)
+
+// setupVaultProject prepares an isolated hulak project + config dir for tests.
+// It chdirs into a fresh temp dir and points XDG_CONFIG_HOME at another temp dir
+// so vault.EnsureKeypair stores the identity outside the user's real config.
+func setupVaultProject(t *testing.T) string {
+	t.Helper()
+
+	configDir := t.TempDir()
+	configDir, err := filepath.EvalSymlinks(configDir)
+	if err != nil {
+		t.Fatalf("resolve symlinks: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+
+	projectDir := t.TempDir()
+	projectDir, err = filepath.EvalSymlinks(projectDir)
+	if err != nil {
+		t.Fatalf("resolve symlinks: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, utils.HiddenProjectName), utils.DirPer); err != nil {
+		t.Fatalf("mkdir .hulak: %v", err)
+	}
+
+	t.Cleanup(chdirTemp(t, projectDir))
+	return projectDir
+}
+
+// readStoredValue decrypts the store and returns the value at envName/key.
+func readStoredValue(t *testing.T, envName, key string) any {
+	t.Helper()
+	id, err := vault.LoadIdentity()
+	if err != nil {
+		t.Fatalf("LoadIdentity: %v", err)
+	}
+	store, err := vault.ReadStore(id)
+	if err != nil {
+		t.Fatalf("ReadStore: %v", err)
+	}
+	env := store.GetEnv(envName)
+	if env == nil {
+		t.Fatalf("env %q not found in store", envName)
+	}
+	return env[key]
+}
+
+func TestRunEnvSet_PositionalValue(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runEnvSet([]string{"API_KEY", "sk-123"}, "global", false); err != nil {
+		t.Fatalf("runEnvSet: %v", err)
+	}
+
+	if got := readStoredValue(t, "global", "API_KEY"); got != "sk-123" {
+		t.Errorf("stored value = %v, want %q", got, "sk-123")
+	}
+}
+
+func TestRunEnvSet_StdinValue(t *testing.T) {
+	setupVaultProject(t)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := w.WriteString("stdin-secret\n"); err != nil {
+		t.Fatalf("write pipe: %v", err)
+	}
+	_ = w.Close()
+
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = orig })
+
+	if err := runEnvSet([]string{"TOKEN"}, "global", true); err != nil {
+		t.Fatalf("runEnvSet: %v", err)
+	}
+
+	if got := readStoredValue(t, "global", "TOKEN"); got != "stdin-secret" {
+		t.Errorf("stored value = %v, want %q (trailing newline should be trimmed)", got, "stdin-secret")
+	}
+}
+
+func TestRunEnvSet_CustomEnv(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runEnvSet([]string{"DB_URL", "postgres://x"}, "prod", false); err != nil {
+		t.Fatalf("runEnvSet: %v", err)
+	}
+
+	if got := readStoredValue(t, "prod", "DB_URL"); got != "postgres://x" {
+		t.Errorf("stored value = %v, want %q", got, "postgres://x")
+	}
+}
+
+func TestRunEnvSet_Upsert(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runEnvSet([]string{"K", "v1"}, "global", false); err != nil {
+		t.Fatalf("set v1: %v", err)
+	}
+	if err := runEnvSet([]string{"K", "v2"}, "global", false); err != nil {
+		t.Fatalf("set v2: %v", err)
+	}
+
+	if got := readStoredValue(t, "global", "K"); got != "v2" {
+		t.Errorf("stored value = %v, want %q (upsert failed)", got, "v2")
+	}
+}
+
+func TestRunEnvSet_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		envName     string
+		stdin       bool
+		errContains string
+	}{
+		{"missing key", []string{}, "global", false, "missing required argument"},
+		{"invalid env name (space)", []string{"K", "v"}, "bad name", false, "invalid"},
+		{"invalid env name (empty)", []string{"K", "v"}, "", false, "empty"},
+		{"invalid env name (reserved prefix)", []string{"K", "v"}, "_internal", false, "reserved"},
+		{"too many positionals", []string{"K", "hello", "world"}, "global", false, "too many arguments"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setupVaultProject(t)
+			err := runEnvSet(tc.args, tc.envName, tc.stdin)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.errContains) {
+				t.Errorf("error %q should contain %q", err.Error(), tc.errContains)
+			}
+		})
+	}
+}
+
+func TestRunEnvSet_LargeValueWarning(t *testing.T) {
+	setupVaultProject(t)
+
+	// Replace stderr with a pipe so we can capture the warning.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	big := strings.Repeat("a", MaxValueSizeWarnBytes+1024)
+	done := make(chan string, 1)
+	go func() {
+		var b strings.Builder
+		_, _ = io.Copy(&b, r)
+		done <- b.String()
+	}()
+
+	if err := runEnvSet([]string{"BIG", big}, "global", false); err != nil {
+		t.Fatalf("runEnvSet: %v", err)
+	}
+	_ = w.Close()
+	stderr := <-done
+
+	if !strings.Contains(stderr, "warning") || !strings.Contains(stderr, "KB") {
+		t.Errorf("expected size warning on stderr, got %q", stderr)
+	}
+	// Value still written despite warning.
+	if got := readStoredValue(t, "global", "BIG"); got != big {
+		t.Error("large value should still be written")
+	}
+}

--- a/pkg/userFlags/env_test.go
+++ b/pkg/userFlags/env_test.go
@@ -324,6 +324,65 @@ func TestRunEnvDelete_Errors(t *testing.T) {
 	}
 }
 
+func TestRunEnvList_PrintsSortedNames(t *testing.T) {
+	setupVaultProject(t)
+
+	// Seed: prod, global, staging — listing should sort alphabetically.
+	for _, env := range []string{"prod", "global", "staging"} {
+		if err := runEnvSet([]string{"K", "v"}, env, false); err != nil {
+			t.Fatalf("seed %s: %v", env, err)
+		}
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runEnvList(nil)
+	})
+	if runErr != nil {
+		t.Fatalf("runEnvList: %v", runErr)
+	}
+
+	want := "global\nprod\nstaging\n"
+	if out != want {
+		t.Errorf("stdout = %q, want %q", out, want)
+	}
+}
+
+func TestRunEnvList_EmptyStore(t *testing.T) {
+	setupVaultProject(t)
+
+	// Generate a keypair + empty store so LoadIdentity / ReadStore succeed.
+	if err := vault.WithStoreLock(func() error {
+		ageKey, _ := vault.EnsureKeypair()
+		store, _ := vault.ReadStore(ageKey.Identity)
+		return vault.WriteStore(store, ageKey.Recipient)
+	}); err != nil {
+		t.Fatalf("seed empty: %v", err)
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runEnvList(nil)
+	})
+	if runErr != nil {
+		t.Fatalf("runEnvList: %v", runErr)
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want empty", out)
+	}
+}
+
+func TestRunEnvList_TooManyArgs(t *testing.T) {
+	setupVaultProject(t)
+	err := runEnvList([]string{"unexpected"})
+	if err == nil {
+		t.Fatal("expected error for extra arg")
+	}
+	if !strings.Contains(err.Error(), "too many arguments") {
+		t.Errorf("error %q should mention too many arguments", err.Error())
+	}
+}
+
 func TestRunEnvSet_LargeValueWarning(t *testing.T) {
 	setupVaultProject(t)
 

--- a/pkg/userFlags/env_test.go
+++ b/pkg/userFlags/env_test.go
@@ -1,6 +1,7 @@
 package userflags
 
 import (
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -138,6 +139,113 @@ func TestRunEnvSet_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			setupVaultProject(t)
 			err := runEnvSet(tc.args, tc.envName, tc.stdin)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.errContains) {
+				t.Errorf("error %q should contain %q", err.Error(), tc.errContains)
+			}
+		})
+	}
+}
+
+func TestRunEnvGet_PrintsString(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"FOO", "bar"}, "global", false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runEnvGet([]string{"FOO"}, "global")
+	})
+	if runErr != nil {
+		t.Fatalf("runEnvGet: %v", runErr)
+	}
+	if out != "bar\n" {
+		t.Errorf("stdout = %q, want %q (raw value + newline)", out, "bar\n")
+	}
+}
+
+func TestRunEnvGet_PrintsNonString(t *testing.T) {
+	setupVaultProject(t)
+
+	// Seed non-string types via the store directly (CLI `set` always stores strings).
+	if err := vault.WithStoreLock(func() error {
+		ageKey, _ := vault.EnsureKeypair()
+		store, _ := vault.ReadStore(ageKey.Identity)
+		store.SetKey("global", "PORT", json.Number("8000"))
+		store.SetKey("global", "ENABLED", true)
+		return vault.WriteStore(store, ageKey.Recipient)
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"PORT", "8000\n"},    // json.Number prints unquoted
+		{"ENABLED", "true\n"}, // bool prints unquoted
+	}
+	for _, tc := range tests {
+		t.Run(tc.key, func(t *testing.T) {
+			var runErr error
+			out := captureStdout(t, func() {
+				runErr = runEnvGet([]string{tc.key}, "global")
+			})
+			if runErr != nil {
+				t.Fatalf("runEnvGet: %v", runErr)
+			}
+			if out != tc.want {
+				t.Errorf("stdout = %q, want %q", out, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunEnvGet_FromCustomEnv(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"DB_URL", "postgres"}, "prod", false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runEnvGet([]string{"DB_URL"}, "prod")
+	})
+	if runErr != nil {
+		t.Fatalf("runEnvGet: %v", runErr)
+	}
+	if out != "postgres\n" {
+		t.Errorf("stdout = %q, want %q", out, "postgres\n")
+	}
+}
+
+func TestRunEnvGet_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		seedKey     string
+		seedEnv     string
+		args        []string
+		envName     string
+		errContains string
+	}{
+		{"missing key arg", "K", "global", []string{}, "global", "missing required argument"},
+		{"too many args", "K", "global", []string{"A", "B"}, "global", "too many arguments"},
+		{"invalid env name", "K", "global", []string{"K"}, "bad name", "invalid"},
+		{"missing key in env", "K", "global", []string{"NOPE"}, "global", `key "NOPE" not found in environment "global"`},
+		{"missing env", "K", "global", []string{"K"}, "doesnotexist", `environment "doesnotexist" not found`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setupVaultProject(t)
+			if err := runEnvSet([]string{tc.seedKey, "v"}, tc.seedEnv, false); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+
+			err := runEnvGet(tc.args, tc.envName)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}

--- a/pkg/userFlags/env_test.go
+++ b/pkg/userFlags/env_test.go
@@ -2,9 +2,11 @@ package userflags
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -556,6 +558,186 @@ func TestRunEnvKeys_Errors(t *testing.T) {
 				t.Errorf("error %q should contain %q", err.Error(), tc.errContains)
 			}
 		})
+	}
+}
+
+// fakeEditor writes a small shell script that, when executed against $1,
+// replaces its contents with body. Returns the script path (set as $EDITOR).
+// Skipped on Windows.
+func fakeEditor(t *testing.T, body string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fakeEditor uses /bin/sh; skip on windows")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake_editor.sh")
+	content := "#!/bin/sh\ncat > \"$1\" <<'__EOF__'\n" + body + "\n__EOF__\n"
+	if err := os.WriteFile(script, []byte(content), 0o700); err != nil { //nolint:gosec // G306 test script needs +x
+		t.Fatalf("write fake editor: %v", err)
+	}
+	return script
+}
+
+func TestRunEnvEdit_NoChange(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"FOO", "bar"}, "global", false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	t.Setenv("EDITOR", "cat") // reads file, exits 0, doesn't modify
+	if err := runEnvEdit(nil, "global"); err != nil {
+		t.Fatalf("runEnvEdit: %v", err)
+	}
+
+	// FOO still present and unchanged.
+	if got := readStoredValue(t, "global", "FOO"); got != "bar" {
+		t.Errorf("FOO = %v, want %q (no-change path should not rewrite)", got, "bar")
+	}
+}
+
+func TestRunEnvEdit_EditorFailsNoWrite(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"FOO", "bar"}, "global", false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	t.Setenv("EDITOR", "false") // exits 1 immediately
+	err := runEnvEdit(nil, "global")
+	if err == nil {
+		t.Fatal("expected editor failure to surface as error")
+	}
+	if !strings.Contains(err.Error(), "editor failed") {
+		t.Errorf("error %q should mention editor failure", err.Error())
+	}
+	// Store untouched.
+	if got := readStoredValue(t, "global", "FOO"); got != "bar" {
+		t.Errorf("FOO = %v, want %q (editor failure must not rewrite)", got, "bar")
+	}
+}
+
+func TestRunEnvEdit_SaveValidJSON(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"OLD", "v"}, "staging", false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	t.Setenv("EDITOR", fakeEditor(t, `{"NEW_KEY":"new_value"}`))
+	if err := runEnvEdit(nil, "staging"); err != nil {
+		t.Fatalf("runEnvEdit: %v", err)
+	}
+
+	// OLD is gone (edit replaces the env wholesale), NEW_KEY is present.
+	if got := readStoredValue(t, "staging", "NEW_KEY"); got != "new_value" {
+		t.Errorf("NEW_KEY = %v, want %q", got, "new_value")
+	}
+}
+
+func TestRunEnvEdit_InvalidJSONPreservesStore(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"FOO", "bar"}, "global", false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	t.Setenv("EDITOR", fakeEditor(t, "not json {"))
+	err := runEnvEdit(nil, "global")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "invalid JSON") {
+		t.Errorf("error %q should mention invalid JSON", err.Error())
+	}
+	// Store untouched.
+	if got := readStoredValue(t, "global", "FOO"); got != "bar" {
+		t.Errorf("FOO = %v, want %q (invalid edit must not rewrite)", got, "bar")
+	}
+}
+
+func TestRunEnvEdit_CreatesEnvOnFirstEdit(t *testing.T) {
+	setupVaultProject(t)
+
+	// staging doesn't exist yet — edit should treat it as {} and let the
+	// user populate it.
+	t.Setenv("EDITOR", fakeEditor(t, `{"FRESH":"value"}`))
+	if err := runEnvEdit(nil, "staging"); err != nil {
+		t.Fatalf("runEnvEdit: %v", err)
+	}
+
+	if got := readStoredValue(t, "staging", "FRESH"); got != "value" {
+		t.Errorf("FRESH = %v, want %q (edit should create absent env)", got, "value")
+	}
+}
+
+func TestRunEnvEdit_TempFileCleanedUp(t *testing.T) {
+	projectDir := setupVaultProject(t)
+
+	t.Setenv("EDITOR", "cat")
+	if err := runEnvEdit(nil, "global"); err != nil {
+		t.Fatalf("runEnvEdit: %v", err)
+	}
+
+	// .hulak/ should not contain a leftover edit-<env>.json after a clean run.
+	leftover := filepath.Join(projectDir, utils.HiddenProjectName, "edit-global.json")
+	if _, err := os.Stat(leftover); !os.IsNotExist(err) {
+		t.Errorf("temp file %q was not cleaned up", leftover)
+	}
+}
+
+func TestRunEnvEdit_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		envName     string
+		errContains string
+	}{
+		{"too many args", []string{"unexpected"}, "global", "too many arguments"},
+		{"invalid env name", nil, "bad name", "invalid"},
+		{"reserved env name", nil, "_internal", "reserved"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setupVaultProject(t)
+			err := runEnvEdit(tc.args, tc.envName)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.errContains) {
+				t.Errorf("error %q should contain %q", err.Error(), tc.errContains)
+			}
+		})
+	}
+}
+
+// TestRunEnvEdit_NoDefaultGlobal documents that edit refuses to silently
+// pick "global" — when --env is omitted (envName=="") the picker is invoked.
+// We stub envPicker to avoid opening a real TUI in test runs, which would
+// hang waiting for keypress.
+func TestRunEnvEdit_NoDefaultGlobal(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"FOO", "bar"}, "global", false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	prevPicker := envPicker
+	t.Cleanup(func() { envPicker = prevPicker })
+	pickerCalled := false
+	envPicker = func() (string, error) {
+		pickerCalled = true
+		return "", errors.New("picker disabled in tests")
+	}
+
+	t.Setenv("EDITOR", fakeEditor(t, `{"GOT_EDITED":"yes"}`))
+	err := runEnvEdit(nil, "") // empty envName → picker
+	if err == nil {
+		t.Fatal("expected stubbed picker error to propagate, got nil")
+	}
+	if !pickerCalled {
+		t.Error("envPicker was not invoked; edit may have silently defaulted to global")
+	}
+	// Critical: global must NOT have been edited. If we'd defaulted to
+	// "global" instead of prompting, FOO would be gone.
+	if got := readStoredValue(t, "global", "FOO"); got != "bar" {
+		t.Errorf("global was edited despite empty --env (got FOO=%v); edit must prompt, not default", got)
 	}
 }
 

--- a/pkg/userFlags/env_test.go
+++ b/pkg/userFlags/env_test.go
@@ -775,3 +775,136 @@ func TestRunEnvSet_LargeValueWarning(t *testing.T) {
 		t.Error("large value should still be written")
 	}
 }
+
+// TestEscapeControlChars verifies that control characters which would break
+// table alignment (\n shifts rows; \r blanks the line; \t expands to tab stops)
+// are rendered as visible escapes, while plain text passes through unchanged.
+func TestEscapeControlChars(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain text unchanged", "hello", "hello"},
+		{"empty unchanged", "", ""},
+		{"newline escaped", "a\nb", `a\nb`},
+		{"carriage return escaped", "a\rb", `a\rb`},
+		{"crlf escaped", "a\r\nb", `a\r\nb`},
+		{"tab escaped", "a\tb", `a\tb`},
+		{"bell escaped as hex", "a\x07b", `a\x07b`},
+		{"esc escaped as hex", "a\x1bb", `a\x1bb`},
+		{"del escaped as hex", "a\x7fb", `a\x7fb`},
+		{"mixed", "k\rev\ny", `k\rev\ny`},
+		{"high-bit unchanged", "café", "café"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := escapeControlChars(tc.in); got != tc.want {
+				t.Errorf("escapeControlChars(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFormatTableValue_EscapesControlChars asserts that the table formatter
+// uses escapeControlChars for string values. A regression here would let a
+// stored value containing \r or \n shift downstream rows or blank a line.
+func TestFormatTableValue_EscapesControlChars(t *testing.T) {
+	got := formatTableValue("k\rinjected\nrow")
+	want := `k\rinjected\nrow`
+	if got != want {
+		t.Errorf("formatTableValue = %q, want %q", got, want)
+	}
+}
+
+// TestRunEnvKeys_AlignsValuesContainingControlChars guards the end-to-end
+// behavior: a value with a CR must not blank or misalign the table line.
+// We render two rows; both must appear on their own line, in order.
+func TestRunEnvKeys_AlignsValuesContainingControlChars(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"FIRST", "value\rwith-cr"}, "global", false); err != nil {
+		t.Fatalf("seed FIRST: %v", err)
+	}
+	if err := runEnvSet([]string{"SECOND", "plain"}, "global", false); err != nil {
+		t.Fatalf("seed SECOND: %v", err)
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runEnvKeys(nil, "global", "", true)
+	})
+	if runErr != nil {
+		t.Fatalf("runEnvKeys: %v", runErr)
+	}
+	// Raw CR must not survive into the rendered output — it would erase
+	// the start of the line in many terminals.
+	if strings.ContainsRune(out, '\r') {
+		t.Errorf("output should not contain raw CR; got %q", out)
+	}
+	// Both rows present, in order.
+	first := strings.Index(out, "FIRST")
+	second := strings.Index(out, "SECOND")
+	if first == -1 || second == -1 || first >= second {
+		t.Errorf("rows missing or out of order: %q", out)
+	}
+}
+
+// TestRunEnvEdit_WholesaleReplacesEnv pins down the destructive semantic
+// documented in the help text: keys present before the edit but absent from
+// the saved JSON are removed. A future refactor that "merges" edits with
+// existing keys instead of replacing them would silently retain deleted
+// secrets — exactly the behavior we promise NOT to have.
+func TestRunEnvEdit_WholesaleReplacesEnv(t *testing.T) {
+	setupVaultProject(t)
+	for _, kv := range [][2]string{
+		{"KEEP", "1"}, {"REMOVE_ME", "2"}, {"ALSO_REMOVE", "3"},
+	} {
+		if err := runEnvSet([]string{kv[0], kv[1]}, "global", false); err != nil {
+			t.Fatalf("seed %s: %v", kv[0], err)
+		}
+	}
+
+	// Save only KEEP and a NEW key.
+	t.Setenv("EDITOR", fakeEditor(t, `{"KEEP":"1","NEW":"4"}`))
+	if err := runEnvEdit(nil, "global"); err != nil {
+		t.Fatalf("runEnvEdit: %v", err)
+	}
+
+	// KEEP and NEW present.
+	if got := readStoredValue(t, "global", "KEEP"); got != "1" {
+		t.Errorf("KEEP = %v, want %q", got, "1")
+	}
+	if got := readStoredValue(t, "global", "NEW"); got != "4" {
+		t.Errorf("NEW = %v, want %q", got, "4")
+	}
+	// REMOVE_ME / ALSO_REMOVE must be gone — get must error.
+	if err := runEnvGet([]string{"REMOVE_ME"}, "global"); err == nil {
+		t.Error("REMOVE_ME should be deleted by wholesale replacement")
+	}
+	if err := runEnvGet([]string{"ALSO_REMOVE"}, "global"); err == nil {
+		t.Error("ALSO_REMOVE should be deleted by wholesale replacement")
+	}
+}
+
+// TestRunEnvEdit_LeavesOtherEnvsUntouched is the second half of the wholesale
+// guarantee: replacing one env must not affect any other env in the store.
+func TestRunEnvEdit_LeavesOtherEnvsUntouched(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"P", "prod-value"}, "prod", false); err != nil {
+		t.Fatalf("seed prod: %v", err)
+	}
+	if err := runEnvSet([]string{"S", "staging-value"}, "staging", false); err != nil {
+		t.Fatalf("seed staging: %v", err)
+	}
+
+	// Wipe staging by saving an empty object.
+	t.Setenv("EDITOR", fakeEditor(t, `{}`))
+	if err := runEnvEdit(nil, "staging"); err != nil {
+		t.Fatalf("runEnvEdit: %v", err)
+	}
+
+	// prod is untouched.
+	if got := readStoredValue(t, "prod", "P"); got != "prod-value" {
+		t.Errorf("prod.P = %v, want %q (other envs must not be affected)", got, "prod-value")
+	}
+}

--- a/pkg/userFlags/env_test.go
+++ b/pkg/userFlags/env_test.go
@@ -256,6 +256,74 @@ func TestRunEnvGet_Errors(t *testing.T) {
 	}
 }
 
+func TestRunEnvDelete_RemovesKey(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"FOO", "bar"}, "global", false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := runEnvDelete([]string{"FOO"}, "global"); err != nil {
+		t.Fatalf("runEnvDelete: %v", err)
+	}
+
+	// Verify gone via get-style lookup.
+	if err := runEnvGet([]string{"FOO"}, "global"); err == nil {
+		t.Fatal("expected key to be gone after delete")
+	}
+}
+
+func TestRunEnvDelete_LeavesOtherKeysAlone(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"FOO", "1"}, "global", false); err != nil {
+		t.Fatalf("seed FOO: %v", err)
+	}
+	if err := runEnvSet([]string{"BAR", "2"}, "global", false); err != nil {
+		t.Fatalf("seed BAR: %v", err)
+	}
+
+	if err := runEnvDelete([]string{"FOO"}, "global"); err != nil {
+		t.Fatalf("runEnvDelete: %v", err)
+	}
+
+	if got := readStoredValue(t, "global", "BAR"); got != "2" {
+		t.Errorf("BAR = %v, want %q (deleting FOO must not affect BAR)", got, "2")
+	}
+}
+
+func TestRunEnvDelete_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		seedKey     string
+		seedEnv     string
+		args        []string
+		envName     string
+		errContains string
+	}{
+		{"missing key arg", "K", "global", []string{}, "global", "missing required argument"},
+		{"too many args", "K", "global", []string{"A", "B"}, "global", "too many arguments"},
+		{"invalid env name", "K", "global", []string{"K"}, "bad name", "invalid"},
+		{"missing key in env", "K", "global", []string{"NOPE"}, "global", `key "NOPE" not found in environment "global"`},
+		{"missing env", "K", "global", []string{"K"}, "doesnotexist", `environment "doesnotexist" not found`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setupVaultProject(t)
+			if err := runEnvSet([]string{tc.seedKey, "v"}, tc.seedEnv, false); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+
+			err := runEnvDelete(tc.args, tc.envName)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.errContains) {
+				t.Errorf("error %q should contain %q", err.Error(), tc.errContains)
+			}
+		})
+	}
+}
+
 func TestRunEnvSet_LargeValueWarning(t *testing.T) {
 	setupVaultProject(t)
 

--- a/pkg/userFlags/env_test.go
+++ b/pkg/userFlags/env_test.go
@@ -383,6 +383,182 @@ func TestRunEnvList_TooManyArgs(t *testing.T) {
 	}
 }
 
+func TestRunEnvKeys_MasksByDefault(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"API_KEY", "sk-123"}, "global", false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runEnvKeys(nil, "global", "", false)
+	})
+	if runErr != nil {
+		t.Fatalf("runEnvKeys: %v", runErr)
+	}
+	if !strings.Contains(out, "API_KEY") {
+		t.Errorf("output should contain key name; got %q", out)
+	}
+	if !strings.Contains(out, maskedValue) {
+		t.Errorf("output should contain mask %q; got %q", maskedValue, out)
+	}
+	if strings.Contains(out, "sk-123") {
+		t.Errorf("output should NOT contain real value; got %q", out)
+	}
+}
+
+func TestRunEnvKeys_ShowReveals(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"API_KEY", "sk-123"}, "global", false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runEnvKeys(nil, "global", "", true)
+	})
+	if runErr != nil {
+		t.Fatalf("runEnvKeys: %v", runErr)
+	}
+	if !strings.Contains(out, "sk-123") {
+		t.Errorf("--show output should reveal value; got %q", out)
+	}
+	if strings.Contains(out, maskedValue) {
+		t.Errorf("--show output should NOT contain mask; got %q", out)
+	}
+}
+
+func TestRunEnvKeys_SortsKeys(t *testing.T) {
+	setupVaultProject(t)
+	for _, k := range []string{"ZETA", "alpha", "MIDDLE"} {
+		if err := runEnvSet([]string{k, "v"}, "global", false); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runEnvKeys(nil, "global", "", false)
+	})
+	if runErr != nil {
+		t.Fatalf("runEnvKeys: %v", runErr)
+	}
+
+	// sort.Strings is byte-order: uppercase before lowercase, ZETA's Z(0x5A) < a(0x61).
+	want := []string{"MIDDLE", "ZETA", "alpha"}
+	prevIdx := -1
+	prevKey := ""
+	for _, k := range want {
+		idx := strings.Index(out, k)
+		if idx == -1 {
+			t.Fatalf("output missing %q", k)
+		}
+		if prevIdx > idx {
+			t.Errorf("expected %q to appear after %q in sorted output; got %q", k, prevKey, out)
+		}
+		prevIdx = idx
+		prevKey = k
+	}
+}
+
+func TestRunEnvKeys_SearchSubstring(t *testing.T) {
+	setupVaultProject(t)
+	for _, k := range []string{"API_KEY", "DB_URL", "api_token", "TIMEOUT"} {
+		if err := runEnvSet([]string{k, "v"}, "global", false); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		// "api" — substring, case-insensitive: should match API_KEY and api_token.
+		runErr = runEnvKeys(nil, "global", "api", false)
+	})
+	if runErr != nil {
+		t.Fatalf("runEnvKeys: %v", runErr)
+	}
+	if !strings.Contains(out, "API_KEY") || !strings.Contains(out, "api_token") {
+		t.Errorf("substring match should include both API_KEY and api_token; got %q", out)
+	}
+	if strings.Contains(out, "DB_URL") || strings.Contains(out, "TIMEOUT") {
+		t.Errorf("substring match should exclude DB_URL/TIMEOUT; got %q", out)
+	}
+}
+
+func TestRunEnvKeys_SearchGlob(t *testing.T) {
+	setupVaultProject(t)
+	for _, k := range []string{"API_KEY", "API_TOKEN", "DB_URL"} {
+		if err := runEnvSet([]string{k, "v"}, "global", false); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		// Glob, case-sensitive: matches "API_*".
+		runErr = runEnvKeys(nil, "global", "API_*", false)
+	})
+	if runErr != nil {
+		t.Fatalf("runEnvKeys: %v", runErr)
+	}
+	if !strings.Contains(out, "API_KEY") || !strings.Contains(out, "API_TOKEN") {
+		t.Errorf("glob match should include both API_KEY and API_TOKEN; got %q", out)
+	}
+	if strings.Contains(out, "DB_URL") {
+		t.Errorf("glob match should exclude DB_URL; got %q", out)
+	}
+}
+
+func TestRunEnvKeys_SearchNoMatches(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"API_KEY", "v"}, "global", false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runEnvKeys(nil, "global", "ZZZ", false)
+	})
+	if runErr != nil {
+		t.Fatalf("runEnvKeys: %v", runErr)
+	}
+	if out != "" {
+		t.Errorf("expected empty output for no matches; got %q", out)
+	}
+}
+
+func TestRunEnvKeys_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		envName     string
+		search      string
+		errContains string
+	}{
+		{"too many args", []string{"unexpected"}, "global", "", "too many arguments"},
+		{"invalid env", []string{}, "bad name", "", "invalid"},
+		{"missing env", []string{}, "doesnotexist", "", `environment "doesnotexist" not found`},
+		{"bad glob", []string{}, "global", "[unclosed", "invalid glob pattern"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setupVaultProject(t)
+			if err := runEnvSet([]string{"K", "v"}, "global", false); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+
+			err := runEnvKeys(tc.args, tc.envName, tc.search, false)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.errContains) {
+				t.Errorf("error %q should contain %q", err.Error(), tc.errContains)
+			}
+		})
+	}
+}
+
 func TestRunEnvSet_LargeValueWarning(t *testing.T) {
 	setupVaultProject(t)
 

--- a/pkg/userFlags/init.go
+++ b/pkg/userFlags/init.go
@@ -27,12 +27,22 @@ func InitDefaultProject() error {
 		utils.PrintWarning(fmt.Sprintf("could not update .gitignore: %v", err))
 	}
 
-	content, err := embeddedFiles.ReadFile(utils.APIOptions)
+	root, err := utils.CreatePath(utils.APIOptions)
 	if err != nil {
 		return err
 	}
 
-	root, err := utils.CreatePath(utils.APIOptions)
+	// Don't clobber a customized example file. `hulak init` is designed to be
+	// safe to re-run; overwriting user-edited content would defeat that.
+	if utils.FileExists(root) {
+		utils.PrintWarning(
+			fmt.Sprintf("Kept existing '%s' (delete it to regenerate)", utils.APIOptions),
+		)
+		utils.PrintGreen("Done " + utils.CheckMark)
+		return nil
+	}
+
+	content, err := embeddedFiles.ReadFile(utils.APIOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/userFlags/init_test.go
+++ b/pkg/userFlags/init_test.go
@@ -1,0 +1,43 @@
+package userflags
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/xaaha/hulak/pkg/utils"
+)
+
+// TestInitDefaultProject_PreservesUserCustomizedAPIOptions verifies that
+// re-running `hulak init` does NOT overwrite a user-edited apiOptions.hk.yaml.
+// Init is designed to be safe to re-run; clobbering customizations would
+// defeat that property.
+func TestInitDefaultProject_PreservesUserCustomizedAPIOptions(t *testing.T) {
+	dir := t.TempDir()
+	t.Cleanup(chdirTemp(t, dir))
+
+	// First init: creates the example file.
+	if err := InitDefaultProject(); err != nil {
+		t.Fatalf("first InitDefaultProject: %v", err)
+	}
+
+	apiPath := filepath.Join(dir, utils.APIOptions)
+	custom := []byte("# user has edited this file\nkind: API\nfoo: bar\n")
+	if err := os.WriteFile(apiPath, custom, utils.FilePer); err != nil {
+		t.Fatalf("simulate user edit: %v", err)
+	}
+
+	// Second init: must not clobber the custom content.
+	if err := InitDefaultProject(); err != nil {
+		t.Fatalf("second InitDefaultProject: %v", err)
+	}
+
+	got, err := os.ReadFile(apiPath)
+	if err != nil {
+		t.Fatalf("read after re-init: %v", err)
+	}
+	if !bytes.Equal(got, custom) {
+		t.Errorf("re-init overwrote customized %s", utils.APIOptions)
+	}
+}

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -350,7 +350,7 @@ func newEnvCmd() *command {
 
 	// delete — remove a key
 	deleteFs := flag.NewFlagSet("env delete", flag.ContinueOnError)
-	_ = registerEnvFlag(deleteFs, utils.DefaultEnvVal, "Environment to operate on")
+	deleteEnv := registerEnvFlag(deleteFs, utils.DefaultEnvVal, "Environment to operate on")
 
 	// edit — interactive editor
 	editFs := flag.NewFlagSet("env edit", flag.ContinueOnError)
@@ -480,7 +480,7 @@ func newEnvCmd() *command {
 					Description: "Delete from a specific environment (alias)",
 				},
 			},
-			Run: notImplemented("delete"),
+			Run: func(args []string) error { return runEnvDelete(args, *deleteEnv) },
 		},
 		{
 			Name:  "edit",

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -492,7 +492,7 @@ func newEnvCmd() *command {
 		{
 			Name:  "edit",
 			Short: "Edit secrets interactively",
-			Long:  "Open the decrypted environment in $EDITOR (falls back to vi).\n\nWhen --env is omitted you'll be prompted to pick an environment from a TUI list,\nthe same flow as `hulak run`. To create a brand-new environment, pass --env\nexplicitly with the new name.\n\nThe decrypted JSON is written to a temp file with 0600 permissions inside .hulak/.\nOn editor exit the JSON is validated, merged back into the store, and re-encrypted\natomically. If the editor exits non-zero or the file is unchanged, no write occurs.",
+			Long:  "Open the decrypted environment in $EDITOR (falls back to vi).\n\nWhen --env is omitted you'll be prompted to pick an environment from a TUI list,\nthe same flow as `hulak run`. To create a brand-new environment, pass --env\nexplicitly with the new name.\n\nThe decrypted JSON is written to a temp file with 0600 permissions inside .hulak/.\nWhat you save in the editor REPLACES the entire environment — keys you delete\nfrom the file are deleted from the store. Other environments in the store are\nuntouched. The store is re-encrypted atomically.\n\nIf the editor exits non-zero or the file is unchanged, no write occurs.",
 			Flags: editFs,
 			Examples: []*utils.CommandHelp{
 				{

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -349,8 +349,8 @@ func newEnvCmd() *command {
 
 	// set — store a key-value pair
 	setFs := flag.NewFlagSet("env set", flag.ContinueOnError)
-	_ = registerEnvFlag(setFs, utils.DefaultEnvVal, "Environment to operate on")
-	setFs.Bool("stdin", false, "Read value from stdin")
+	setEnv := registerEnvFlag(setFs, utils.DefaultEnvVal, "Environment to operate on")
+	setStdin := setFs.Bool("stdin", false, "Read value from stdin")
 
 	// get — retrieve a value by key
 	getFs := flag.NewFlagSet("env get", flag.ContinueOnError)
@@ -417,7 +417,7 @@ func newEnvCmd() *command {
 					Description: "Set a value in a specific environment",
 				},
 			},
-			Run: notImplemented("set"),
+			Run: func(args []string) error { return runEnvSet(args, *setEnv, *setStdin) },
 		},
 		{
 			Name:  "get",

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -71,7 +71,10 @@ func newVersionCmd() *command {
 	return &command{
 		Name:  "version",
 		Short: "Print hulak version",
-		Long:  "Print the current hulak version.",
+		Long:  "Print the current hulak version.\n\nUseful for bug reports and verifying installs.",
+		Examples: []*utils.CommandHelp{
+			{Command: "hulak version", Description: "Print the installed hulak version"},
+		},
 		Run: func(_ []string) error {
 			getVersion()
 			return nil
@@ -323,7 +326,7 @@ func newEnvCmd() *command {
 		Examples: []*utils.CommandHelp{
 			{
 				Command:     "hulak env list",
-				Description: "List all key-value pairs in the default environment",
+				Description: "List environment names defined in the vault",
 			},
 			{
 				Command:     "hulak env set API_KEY sk-123 --env prod",
@@ -335,7 +338,7 @@ func newEnvCmd() *command {
 			},
 			{
 				Command:     "hulak env keys --env prod",
-				Description: "List all keys in the prod environment",
+				Description: "List keys in the prod environment (values masked)",
 			},
 			{
 				Command:     "hulak env delete OLD_KEY",
@@ -353,14 +356,14 @@ func newEnvCmd() *command {
 	getFs := flag.NewFlagSet("env get", flag.ContinueOnError)
 	_ = registerEnvFlag(getFs, utils.DefaultEnvVal, "Environment to operate on")
 
-	// list — show all key-value pairs
+	// list — show environment names
 	listFs := flag.NewFlagSet("env list", flag.ContinueOnError)
-	_ = registerEnvFlag(listFs, utils.DefaultEnvVal, "Environment to operate on")
 
-	// keys — list keys only
+	// keys — list keys within an environment
 	keysFs := flag.NewFlagSet("env keys", flag.ContinueOnError)
 	_ = registerEnvFlag(keysFs, utils.DefaultEnvVal, "Environment to operate on")
-	keysFs.Bool("show", false, "Show actual values instead of masked output")
+	keysFs.Bool("show", false, "Reveal values instead of masking them")
+	keysFs.String("search", "", "Filter keys by case-insensitive substring or glob pattern")
 
 	// delete — remove a key
 	deleteFs := flag.NewFlagSet("env delete", flag.ContinueOnError)
@@ -390,94 +393,142 @@ func newEnvCmd() *command {
 			Name:    "set",
 			Aliases: []string{"add"},
 			Short:   "Set a key-value pair",
-			Long:    "Store a secret in the encrypted vault.\n\nUse --stdin to pipe the value from standard input.",
+			Long:    "Store a secret in the encrypted vault.\n\nIf VALUE is omitted, you'll be prompted to enter it (no echo, no shell history).\nUse --stdin to pipe the value from standard input (useful for scripts).",
 			Flags:   setFs,
 			Args: []argDef{
 				{Name: "key", Required: true, Desc: "Secret key name"},
-				{Name: "value", Desc: "Secret value (omit to use --stdin)"},
+				{Name: "value", Desc: "Secret value (omit to be prompted, or use --stdin)"},
+			},
+			Examples: []*utils.CommandHelp{
+				{Command: "hulak env set API_KEY sk-123", Description: "Set a value in the default (global) environment"},
+				{Command: "hulak env set DB_URL --env prod", Description: "Prompt for the value (no shell history)"},
+				{Command: "echo -n \"$TOKEN\" | hulak env set TOKEN --stdin", Description: "Read value from stdin (scripts/CI)"},
+				{Command: "hulak env set FEATURE_FLAG true --env staging", Description: "Set a value in a specific environment"},
 			},
 			Run: notImplemented("set"),
 		},
 		{
 			Name:  "get",
 			Short: "Get a value by key",
-			Long:  "Retrieve a secret from the encrypted vault and print it to stdout.",
+			Long:  "Retrieve a secret from the encrypted vault and print it to stdout.\n\nOutput is raw — no formatting — suitable for $(...) substitution in scripts.\nExits non-zero if the key is missing.",
 			Flags: getFs,
 			Args: []argDef{
 				{Name: "key", Required: true, Desc: "Secret key to retrieve"},
+			},
+			Examples: []*utils.CommandHelp{
+				{Command: "hulak env get API_KEY", Description: "Print API_KEY from the default environment"},
+				{Command: "hulak env get DB_URL --env prod", Description: "Print DB_URL from the prod environment"},
+				{Command: "API_KEY=$(hulak env get API_KEY --env staging)", Description: "Capture a value into a shell variable"},
 			},
 			Run: notImplemented("get"),
 		},
 		{
 			Name:    "list",
 			Aliases: []string{"ls"},
-			Short:   "List all key-value pairs",
-			Long:    "Show all secrets in an environment. Values are masked by default.",
+			Short:   "List environment names",
+			Long:    "Show all environment names defined in the encrypted vault.\n\nThis lists the environments themselves (e.g. global, staging, prod).\nUse `hulak env keys --env <name>` to list keys within an environment.",
 			Flags:   listFs,
-			Run:     notImplemented("list"),
+			Examples: []*utils.CommandHelp{
+				{Command: "hulak env list", Description: "List all environment names"},
+				{Command: "hulak env ls", Description: "Same as list (alias)"},
+			},
+			Run: notImplemented("list"),
 		},
 		{
 			Name:    "keys",
 			Aliases: []string{"key"},
-			Short:   "List keys only",
-			Long:    "Show all secret key names in an environment without values.\n\nUse --show to display actual values.",
+			Short:   "List keys in an environment",
+			Long:    "Show secret keys within an environment.\n\nValues are masked by default (••••) so the output is safe to share in screen recordings\nand meetings. Use --show to reveal them.\nUse --search to filter by case-insensitive substring or glob pattern (e.g. \"API*\", \"DB_?\").",
 			Flags:   keysFs,
-			Run:     notImplemented("keys"),
+			Examples: []*utils.CommandHelp{
+				{Command: "hulak env keys --env prod", Description: "List keys in prod with values masked"},
+				{Command: "hulak env keys --env prod --show", Description: "Reveal actual values"},
+				{Command: "hulak env keys --env prod --search \"API*\"", Description: "Filter keys by glob pattern"},
+				{Command: "hulak env keys --env staging --search api", Description: "Filter by case-insensitive substring"},
+			},
+			Run: notImplemented("keys"),
 		},
 		{
 			Name:    "delete",
 			Aliases: []string{"rm", "remove"},
 			Short:   "Delete a key",
-			Long:    "Remove a secret from the encrypted vault.",
+			Long:    "Remove a secret from the encrypted vault.\n\nExits non-zero if the key doesn't exist.",
 			Flags:   deleteFs,
 			Args: []argDef{
 				{Name: "key", Required: true, Desc: "Secret key to delete"},
+			},
+			Examples: []*utils.CommandHelp{
+				{Command: "hulak env delete OLD_KEY", Description: "Delete OLD_KEY from the default environment"},
+				{Command: "hulak env rm STALE_TOKEN --env staging", Description: "Delete from a specific environment (alias)"},
 			},
 			Run: notImplemented("delete"),
 		},
 		{
 			Name:  "edit",
 			Short: "Edit secrets interactively",
-			Long:  "Open an interactive editor for secrets in an environment.",
+			Long:  "Open the decrypted environment in $EDITOR (falls back to vi).\n\nThe decrypted JSON is written to a temp file with 0600 permissions. On editor exit\nthe JSON is validated, merged back into the store, and re-encrypted atomically.\nIf the editor exits non-zero or the file is unchanged, no write occurs.",
 			Flags: editFs,
-			Run:   notImplemented("edit"),
+			Examples: []*utils.CommandHelp{
+				{Command: "hulak env edit", Description: "Edit the default environment"},
+				{Command: "hulak env edit --env prod", Description: "Edit the prod environment"},
+				{Command: "EDITOR=nvim hulak env edit --env staging", Description: "Use a specific editor"},
+			},
+			Run: notImplemented("edit"),
 		},
 		{
 			Name:  "import-key",
 			Short: "Import an age identity file",
-			Long:  "Import an age private key from a file or stdin into the hulak config directory.",
+			Long:  "Import an age private key from a file or stdin into the hulak config directory.\n\nValidates the key format before storing. Writes to ~/.config/hulak/identity.txt\n(or the platform-specific config dir).",
 			Flags: importKeyFs,
 			Args: []argDef{
 				{Name: "path", Desc: "Path to the identity file (omit to read from stdin)"},
+			},
+			Examples: []*utils.CommandHelp{
+				{Command: "hulak env import-key /path/to/backup.txt", Description: "Import from a backup file"},
+				{Command: "echo \"AGE-SECRET-KEY-1QF...\" | hulak env import-key --stdin", Description: "Import from stdin (scripts)"},
 			},
 			Run: notImplemented("import-key"),
 		},
 		{
 			Name:  "export-key",
 			Short: "Export the age identity file",
-			Long:  "Print the age private key to stdout for backup or transfer to another machine.",
+			Long:  "Print the age private key to stdout for backup or transfer to another machine.\n\nUse --armor for ASCII-armored output suitable for copy-paste.",
 			Flags: exportKeyFs,
-			Run:   notImplemented("export-key"),
+			Examples: []*utils.CommandHelp{
+				{Command: "hulak env export-key", Description: "Print the private key (with security warning)"},
+				{Command: "hulak env export-key > ~/backup.txt", Description: "Save to a backup file"},
+				{Command: "hulak env export-key --armor", Description: "ASCII-armored output for copy-paste"},
+			},
+			Run: notImplemented("export-key"),
 		},
 		{
 			Name:  "add-recipient",
 			Short: "Add a recipient for shared vault access",
-			Long:  "Add an age public key as a recipient so another user can decrypt the vault.",
+			Long:  "Add an age public key as a recipient so another user can decrypt the vault.\n\nThe vault is re-encrypted to all current recipients plus the new one.",
 			Args:  []argDef{{Name: "public-key", Required: true, Desc: "Age public key to add"}},
-			Run:   notImplemented("add-recipient"),
+			Examples: []*utils.CommandHelp{
+				{Command: "hulak env add-recipient age1ql3z...", Description: "Add a teammate's public key"},
+			},
+			Run: notImplemented("add-recipient"),
 		},
 		{
 			Name:  "remove-recipient",
 			Short: "Remove a recipient",
-			Long:  "Remove an age public key from the recipient list.",
+			Long:  "Remove an age public key from the recipient list and re-encrypt the vault.\n\nNote: removed users can still decrypt copies of the vault from before this point.\nIf revocation matters, also rotate the underlying secrets.",
 			Args:  []argDef{{Name: "public-key", Required: true, Desc: "Age public key to remove"}},
-			Run:   notImplemented("remove-recipient"),
+			Examples: []*utils.CommandHelp{
+				{Command: "hulak env remove-recipient age1ql3z...", Description: "Remove a teammate's public key"},
+			},
+			Run: notImplemented("remove-recipient"),
 		},
 		{
 			Name:  "list-recipients",
 			Short: "List all recipients",
 			Long:  "Show all age public keys that can decrypt the vault.",
-			Run:   notImplemented("list-recipients"),
+			Examples: []*utils.CommandHelp{
+				{Command: "hulak env list-recipients", Description: "Show all recipients with names and key prefixes"},
+			},
+			Run: notImplemented("list-recipients"),
 		},
 	}
 
@@ -488,6 +539,12 @@ func newHelpCmd(root *command) *command {
 	return &command{
 		Name:  "help",
 		Short: "Show help for hulak",
+		Long:  "Print the top-level hulak help.\n\nFor help on a specific command, use `hulak <command> --help` instead.",
+		Examples: []*utils.CommandHelp{
+			{Command: "hulak help", Description: "Show top-level help"},
+			{Command: "hulak env --help", Description: "Show help for a specific command"},
+			{Command: "hulak env keys --help", Description: "Show help for a nested subcommand"},
+		},
 		Run: func(_ []string) error {
 			root.printHelp()
 			return nil

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -337,7 +337,7 @@ func newEnvCmd() *command {
 
 	// get — retrieve a value by key
 	getFs := flag.NewFlagSet("env get", flag.ContinueOnError)
-	_ = registerEnvFlag(getFs, utils.DefaultEnvVal, "Environment to operate on")
+	getEnv := registerEnvFlag(getFs, utils.DefaultEnvVal, "Environment to operate on")
 
 	// list — show environment names
 	listFs := flag.NewFlagSet("env list", flag.ContinueOnError)
@@ -424,7 +424,7 @@ func newEnvCmd() *command {
 					Description: "Capture a value into a shell variable",
 				},
 			},
-			Run: notImplemented("get"),
+			Run: func(args []string) error { return runEnvGet(args, *getEnv) },
 		},
 		{
 			Name:    "list",

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -346,15 +346,19 @@ func newEnvCmd() *command {
 	keysFs := flag.NewFlagSet("env keys", flag.ContinueOnError)
 	keysEnv := registerEnvFlag(keysFs, utils.DefaultEnvVal, "Environment to operate on")
 	keysShow := keysFs.Bool("show", false, "Reveal values instead of masking them")
-	keysSearch := keysFs.String("search", "", "Filter keys by case-insensitive substring or glob pattern")
+	keysSearch := keysFs.String(
+		"search",
+		"",
+		"Filter keys by case-insensitive substring or glob pattern",
+	)
 
 	// delete — remove a key
 	deleteFs := flag.NewFlagSet("env delete", flag.ContinueOnError)
 	deleteEnv := registerEnvFlag(deleteFs, utils.DefaultEnvVal, "Environment to operate on")
 
-	// edit — interactive editor
+	// edit — interactive editor; empty default → TUI picker, like `hulak run`
 	editFs := flag.NewFlagSet("env edit", flag.ContinueOnError)
-	_ = registerEnvFlag(editFs, utils.DefaultEnvVal, "Environment to operate on")
+	editEnv := registerEnvFlag(editFs, "", "Environment to edit (omit to pick interactively)")
 
 	// import-key — import an age identity
 	importKeyFs := flag.NewFlagSet("env import-key", flag.ContinueOnError)
@@ -487,17 +491,31 @@ func newEnvCmd() *command {
 		{
 			Name:  "edit",
 			Short: "Edit secrets interactively",
-			Long:  "Open the decrypted environment in $EDITOR (falls back to vi).\n\nThe decrypted JSON is written to a temp file with 0600 permissions. On editor exit\nthe JSON is validated, merged back into the store, and re-encrypted atomically.\nIf the editor exits non-zero or the file is unchanged, no write occurs.",
+			Long:  "Open the decrypted environment in $EDITOR (falls back to vi).\n\nWhen --env is omitted you'll be prompted to pick an environment from a TUI list,\nthe same flow as `hulak run`. To create a brand-new environment, pass --env\nexplicitly with the new name.\n\nThe decrypted JSON is written to a temp file with 0600 permissions inside .hulak/.\nOn editor exit the JSON is validated, merged back into the store, and re-encrypted\natomically. If the editor exits non-zero or the file is unchanged, no write occurs.",
 			Flags: editFs,
 			Examples: []*utils.CommandHelp{
-				{Command: "hulak env edit", Description: "Edit the default environment"},
-				{Command: "hulak env edit --env prod", Description: "Edit the prod environment"},
+				{
+					Command:     "hulak env edit",
+					Description: "Pick an environment from the TUI, then edit",
+				},
+				{
+					Command:     "hulak env edit --env prod",
+					Description: "Edit prod directly (skip the picker)",
+				},
+				{
+					Command:     "hulak env edit --env new_one",
+					Description: "Create a brand-new environment by name",
+				},
 				{
 					Command:     "EDITOR=nvim hulak env edit --env staging",
 					Description: "Use a specific editor",
 				},
+				{
+					Command:     "EDITOR=\"zed --wait\" hulak env edit --env staging",
+					Description: "GUI editors need a wait flag so hulak waits until you save (zed --wait, code -w)",
+				},
 			},
-			Run: notImplemented("edit"),
+			Run: func(args []string) error { return runEnvEdit(args, *editEnv) },
 		},
 		{
 			Name:  "import-key",

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -400,10 +400,22 @@ func newEnvCmd() *command {
 				{Name: "value", Desc: "Secret value (omit to be prompted, or use --stdin)"},
 			},
 			Examples: []*utils.CommandHelp{
-				{Command: "hulak env set API_KEY sk-123", Description: "Set a value in the default (global) environment"},
-				{Command: "hulak env set DB_URL --env prod", Description: "Prompt for the value (no shell history)"},
-				{Command: "echo -n \"$TOKEN\" | hulak env set TOKEN --stdin", Description: "Read value from stdin (scripts/CI)"},
-				{Command: "hulak env set FEATURE_FLAG true --env staging", Description: "Set a value in a specific environment"},
+				{
+					Command:     "hulak env set API_KEY sk-123",
+					Description: "Set a value in the default (global) environment",
+				},
+				{
+					Command:     "hulak env set DB_URL --env prod",
+					Description: "Prompt for the value (no shell history)",
+				},
+				{
+					Command:     "echo -n \"$TOKEN\" | hulak env set TOKEN --stdin",
+					Description: "Read value from stdin (scripts/CI)",
+				},
+				{
+					Command:     "hulak env set FEATURE_FLAG true --env staging",
+					Description: "Set a value in a specific environment",
+				},
 			},
 			Run: notImplemented("set"),
 		},
@@ -416,9 +428,18 @@ func newEnvCmd() *command {
 				{Name: "key", Required: true, Desc: "Secret key to retrieve"},
 			},
 			Examples: []*utils.CommandHelp{
-				{Command: "hulak env get API_KEY", Description: "Print API_KEY from the default environment"},
-				{Command: "hulak env get DB_URL --env prod", Description: "Print DB_URL from the prod environment"},
-				{Command: "API_KEY=$(hulak env get API_KEY --env staging)", Description: "Capture a value into a shell variable"},
+				{
+					Command:     "hulak env get API_KEY",
+					Description: "Print API_KEY from the default environment",
+				},
+				{
+					Command:     "hulak env get DB_URL --env prod",
+					Description: "Print DB_URL from the prod environment",
+				},
+				{
+					Command:     "API_KEY=$(hulak env get API_KEY --env staging)",
+					Description: "Capture a value into a shell variable",
+				},
 			},
 			Run: notImplemented("get"),
 		},
@@ -441,10 +462,19 @@ func newEnvCmd() *command {
 			Long:    "Show secret keys within an environment.\n\nValues are masked by default (••••) so the output is safe to share in screen recordings\nand meetings. Use --show to reveal them.\nUse --search to filter by case-insensitive substring or glob pattern (e.g. \"API*\", \"DB_?\").",
 			Flags:   keysFs,
 			Examples: []*utils.CommandHelp{
-				{Command: "hulak env keys --env prod", Description: "List keys in prod with values masked"},
+				{
+					Command:     "hulak env keys --env prod",
+					Description: "List keys in prod with values masked",
+				},
 				{Command: "hulak env keys --env prod --show", Description: "Reveal actual values"},
-				{Command: "hulak env keys --env prod --search \"API*\"", Description: "Filter keys by glob pattern"},
-				{Command: "hulak env keys --env staging --search api", Description: "Filter by case-insensitive substring"},
+				{
+					Command:     "hulak env keys --env prod --search \"API*\"",
+					Description: "Filter keys by glob pattern",
+				},
+				{
+					Command:     "hulak env keys --env staging --search api",
+					Description: "Filter by case-insensitive substring",
+				},
 			},
 			Run: notImplemented("keys"),
 		},
@@ -458,8 +488,14 @@ func newEnvCmd() *command {
 				{Name: "key", Required: true, Desc: "Secret key to delete"},
 			},
 			Examples: []*utils.CommandHelp{
-				{Command: "hulak env delete OLD_KEY", Description: "Delete OLD_KEY from the default environment"},
-				{Command: "hulak env rm STALE_TOKEN --env staging", Description: "Delete from a specific environment (alias)"},
+				{
+					Command:     "hulak env delete OLD_KEY",
+					Description: "Delete OLD_KEY from the default environment",
+				},
+				{
+					Command:     "hulak env rm STALE_TOKEN --env staging",
+					Description: "Delete from a specific environment (alias)",
+				},
 			},
 			Run: notImplemented("delete"),
 		},
@@ -471,7 +507,10 @@ func newEnvCmd() *command {
 			Examples: []*utils.CommandHelp{
 				{Command: "hulak env edit", Description: "Edit the default environment"},
 				{Command: "hulak env edit --env prod", Description: "Edit the prod environment"},
-				{Command: "EDITOR=nvim hulak env edit --env staging", Description: "Use a specific editor"},
+				{
+					Command:     "EDITOR=nvim hulak env edit --env staging",
+					Description: "Use a specific editor",
+				},
 			},
 			Run: notImplemented("edit"),
 		},
@@ -484,8 +523,14 @@ func newEnvCmd() *command {
 				{Name: "path", Desc: "Path to the identity file (omit to read from stdin)"},
 			},
 			Examples: []*utils.CommandHelp{
-				{Command: "hulak env import-key /path/to/backup.txt", Description: "Import from a backup file"},
-				{Command: "echo \"AGE-SECRET-KEY-1QF...\" | hulak env import-key --stdin", Description: "Import from stdin (scripts)"},
+				{
+					Command:     "hulak env import-key /path/to/backup.txt",
+					Description: "Import from a backup file",
+				},
+				{
+					Command:     "echo \"AGE-SECRET-KEY-1QF...\" | hulak env import-key --stdin",
+					Description: "Import from stdin (scripts)",
+				},
 			},
 			Run: notImplemented("import-key"),
 		},
@@ -495,9 +540,18 @@ func newEnvCmd() *command {
 			Long:  "Print the age private key to stdout for backup or transfer to another machine.\n\nUse --armor for ASCII-armored output suitable for copy-paste.",
 			Flags: exportKeyFs,
 			Examples: []*utils.CommandHelp{
-				{Command: "hulak env export-key", Description: "Print the private key (with security warning)"},
-				{Command: "hulak env export-key > ~/backup.txt", Description: "Save to a backup file"},
-				{Command: "hulak env export-key --armor", Description: "ASCII-armored output for copy-paste"},
+				{
+					Command:     "hulak env export-key",
+					Description: "Print the private key (with security warning)",
+				},
+				{
+					Command:     "hulak env export-key > ~/backup.txt",
+					Description: "Save to a backup file",
+				},
+				{
+					Command:     "hulak env export-key --armor",
+					Description: "ASCII-armored output for copy-paste",
+				},
 			},
 			Run: notImplemented("export-key"),
 		},
@@ -507,7 +561,10 @@ func newEnvCmd() *command {
 			Long:  "Add an age public key as a recipient so another user can decrypt the vault.\n\nThe vault is re-encrypted to all current recipients plus the new one.",
 			Args:  []argDef{{Name: "public-key", Required: true, Desc: "Age public key to add"}},
 			Examples: []*utils.CommandHelp{
-				{Command: "hulak env add-recipient age1ql3z...", Description: "Add a teammate's public key"},
+				{
+					Command:     "hulak env add-recipient age1ql3z...",
+					Description: "Add a teammate's public key",
+				},
 			},
 			Run: notImplemented("add-recipient"),
 		},
@@ -517,7 +574,10 @@ func newEnvCmd() *command {
 			Long:  "Remove an age public key from the recipient list and re-encrypt the vault.\n\nNote: removed users can still decrypt copies of the vault from before this point.\nIf revocation matters, also rotate the underlying secrets.",
 			Args:  []argDef{{Name: "public-key", Required: true, Desc: "Age public key to remove"}},
 			Examples: []*utils.CommandHelp{
-				{Command: "hulak env remove-recipient age1ql3z...", Description: "Remove a teammate's public key"},
+				{
+					Command:     "hulak env remove-recipient age1ql3z...",
+					Description: "Remove a teammate's public key",
+				},
 			},
 			Run: notImplemented("remove-recipient"),
 		},
@@ -526,7 +586,10 @@ func newEnvCmd() *command {
 			Short: "List all recipients",
 			Long:  "Show all age public keys that can decrypt the vault.",
 			Examples: []*utils.CommandHelp{
-				{Command: "hulak env list-recipients", Description: "Show all recipients with names and key prefixes"},
+				{
+					Command:     "hulak env list-recipients",
+					Description: "Show all recipients with names and key prefixes",
+				},
 			},
 			Run: notImplemented("list-recipients"),
 		},

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -407,10 +407,11 @@ func newEnvCmd() *command {
 			Run: func(args []string) error { return runEnvSet(args, *setEnv, *setStdin) },
 		},
 		{
-			Name:  "get",
-			Short: "Get a value by key",
-			Long:  "Retrieve a secret from the encrypted vault and print it to stdout.\n\nOutput is raw — no formatting — suitable for $(...) substitution in scripts.\nExits non-zero if the key is missing.",
-			Flags: getFs,
+			Name:    "get",
+			Aliases: []string{"g", "show", "view"},
+			Short:   "Get a value by key",
+			Long:    "Retrieve a secret from the encrypted vault and print it to stdout.\n\nOutput is raw — no formatting — suitable for $(...) substitution in scripts.\nExits non-zero if the key is missing.",
+			Flags:   getFs,
 			Args: []argDef{
 				{Name: "key", Required: true, Desc: "Secret key to retrieve"},
 			},
@@ -432,7 +433,7 @@ func newEnvCmd() *command {
 		},
 		{
 			Name:    "list",
-			Aliases: []string{"ls"},
+			Aliases: []string{"ls", "l"},
 			Short:   "List environment names",
 			Long:    "Show all environment names defined in the encrypted vault.\n\nThis lists the environments themselves (e.g. global, staging, prod).\nUse `hulak env keys --env <name>` to list keys within an environment.",
 			Flags:   listFs,
@@ -469,7 +470,7 @@ func newEnvCmd() *command {
 		},
 		{
 			Name:    "delete",
-			Aliases: []string{"rm", "remove"},
+			Aliases: []string{"rm", "remove", "del"},
 			Short:   "Delete a key",
 			Long:    "Remove a secret from the encrypted vault.\n\nExits non-zero if the key doesn't exist.",
 			Flags:   deleteFs,

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -344,9 +344,9 @@ func newEnvCmd() *command {
 
 	// keys — list keys within an environment
 	keysFs := flag.NewFlagSet("env keys", flag.ContinueOnError)
-	_ = registerEnvFlag(keysFs, utils.DefaultEnvVal, "Environment to operate on")
-	keysFs.Bool("show", false, "Reveal values instead of masking them")
-	keysFs.String("search", "", "Filter keys by case-insensitive substring or glob pattern")
+	keysEnv := registerEnvFlag(keysFs, utils.DefaultEnvVal, "Environment to operate on")
+	keysShow := keysFs.Bool("show", false, "Reveal values instead of masking them")
+	keysSearch := keysFs.String("search", "", "Filter keys by case-insensitive substring or glob pattern")
 
 	// delete — remove a key
 	deleteFs := flag.NewFlagSet("env delete", flag.ContinueOnError)
@@ -459,7 +459,9 @@ func newEnvCmd() *command {
 					Description: "Filter by case-insensitive substring",
 				},
 			},
-			Run: notImplemented("keys"),
+			Run: func(args []string) error {
+				return runEnvKeys(args, *keysEnv, *keysSearch, *keysShow)
+			},
 		},
 		{
 			Name:    "delete",

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -436,7 +436,7 @@ func newEnvCmd() *command {
 				{Command: "hulak env list", Description: "List all environment names"},
 				{Command: "hulak env ls", Description: "Same as list (alias)"},
 			},
-			Run: notImplemented("list"),
+			Run: runEnvList,
 		},
 		{
 			Name:    "keys",

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -255,7 +255,7 @@ func newRunCmd() *command {
 			return nil
 		}
 
-		f, err := parseRunArgs(fs, envFlagVal, &sequential, &debug, args)
+		f, err := parseRunArgs(*envFlagVal, sequential, debug, args)
 		if err != nil {
 			return err
 		}
@@ -267,44 +267,27 @@ func newRunCmd() *command {
 	return runCmd
 }
 
-// parseRunArgs resolves the positional path and trailing flags into runner.Flags.
-// Extracted so tests can verify flag parsing without triggering runner.Execute.
-func parseRunArgs(
-	fs *flag.FlagSet,
-	envFlagVal *string,
-	sequential *bool,
-	debug *bool,
-	args []string,
-) (*runner.Flags, error) {
+// parseRunArgs builds a runner.Flags from the path and parsed flag values.
+// The path routes to FilePath (file), Dir (concurrent), or Dirseq (sequential).
+func parseRunArgs(envFlagVal string, sequential, debug bool, args []string) (*runner.Flags, error) {
 	path := args[0]
-
-	// Go's flag package stops at the first non-flag argument, so
-	// "run file.yaml --debug" leaves --debug unparsed. Re-parse
-	// the remaining args to pick up trailing flags.
-	if len(args) > 1 {
-		if err := fs.Parse(args[1:]); err != nil {
-			return nil, fmt.Errorf("%w\nSee 'hulak run --help' for usage", err)
-		}
-	}
 
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, fmt.Errorf("cannot access %q: %w", path, err)
 	}
 
-	f := &runner.Flags{
-		Debug: *debug,
-	}
+	f := &runner.Flags{Debug: debug}
 
-	if *envFlagVal != "" {
-		f.Env = *envFlagVal
+	if envFlagVal != "" {
+		f.Env = envFlagVal
 		f.EnvSet = true
 	} else {
 		f.Env = utils.DefaultEnvVal
 	}
 
 	if info.IsDir() {
-		if *sequential {
+		if sequential {
 			f.Dirseq = path
 		} else {
 			f.Dir = path

--- a/pkg/utils/config_unix.go
+++ b/pkg/utils/config_unix.go
@@ -8,13 +8,15 @@ import (
 	"path/filepath"
 )
 
-// UserConfigDir returns global '.config/hulak' path for respective os
+// UserConfigDir returns the per-app config directory for hulak: either
+// $XDG_CONFIG_HOME/hulak or ~/.config/hulak. Always app-scoped — never
+// returns the bare config root.
 func UserConfigDir() (string, error) {
 	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
 		if !filepath.IsAbs(dir) {
 			return "", errors.New("path in $XDG_CONFIG_HOME is relative")
 		}
-		return dir, nil
+		return filepath.Join(dir, ProjectName), nil
 	}
 
 	home, err := os.UserHomeDir()

--- a/pkg/utils/config_unix_test.go
+++ b/pkg/utils/config_unix_test.go
@@ -1,0 +1,46 @@
+//go:build !windows
+
+package utils
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestUserConfigDir_AppendsProjectNameToXDG(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	got, err := UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir() error: %v", err)
+	}
+	want := filepath.Join(xdg, ProjectName)
+	if got != want {
+		t.Errorf("UserConfigDir() = %q, want %q (XDG branch must append %q)", got, want, ProjectName)
+	}
+}
+
+func TestUserConfigDir_FallsBackToHomeWhenXDGUnset(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", home)
+
+	got, err := UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir() error: %v", err)
+	}
+	want := filepath.Join(home, ".config", ProjectName)
+	if got != want {
+		t.Errorf("UserConfigDir() = %q, want %q", got, want)
+	}
+}
+
+func TestUserConfigDir_ErrorsOnRelativeXDG(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "relative/path")
+
+	_, err := UserConfigDir()
+	if err == nil {
+		t.Fatal("expected error for relative XDG_CONFIG_HOME, got nil")
+	}
+}

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -36,6 +36,12 @@ const (
 
 const StoreFile = "store.age"
 
+// Editor is the fallback editor used when $EDITOR is unset. POSIX guarantees
+// `vi`, so this works in bare/minimal environments (Alpine, distroless, etc.)
+// where vim/nano may not be installed. Users who prefer something else should
+// set $EDITOR in their shell.
+const Editor = "vi"
+
 // acceptable file patterns
 const (
 	YAML = ".yaml"

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -80,7 +80,7 @@ const (
 
 // tick mark and x for success and failure
 const (
-	CheckMark           = "\u2713"  // tick
+	CheckMark           = "\u2714"  // tick
 	CrossMark           = "\u2717"  // x
 	ChevronRight        = "\uf054 " // >
 	ChevronRightCircled = "\uf138"

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -73,9 +73,14 @@ const ResponseType = "code"
 
 // Permissions for creating directory and files
 const (
-	DirPer    fs.FileMode = 0o755
-	FilePer   fs.FileMode = 0o644
-	SecretPer fs.FileMode = 0o600
+	DirPer fs.FileMode = 0o755
+	// SecretDirPer is owner-only on the directory holding secret material
+	// (e.g. ~/.config/hulak that contains identity.txt). Group/other have
+	// no access — defense-in-depth so the directory listing alone can't leak
+	// the existence of an identity file to other users on a shared host.
+	SecretDirPer fs.FileMode = 0o700
+	FilePer      fs.FileMode = 0o644
+	SecretPer    fs.FileMode = 0o600
 )
 
 // tick mark and x for success and failure

--- a/pkg/utils/printing.go
+++ b/pkg/utils/printing.go
@@ -32,6 +32,13 @@ func PrintWarning(msg string) {
 	fmt.Printf("%s%s%s\n", Yellow, msg, ColorReset)
 }
 
+// PrintWarningStderr writes a "warning: <msg>" line in yellow to stderr.
+// Use this for soft warnings during commands whose stdout must stay clean
+// (e.g. `hulak env get` captured via $(...) ).
+func PrintWarningStderr(msg string) {
+	fmt.Fprintf(os.Stderr, "%swarning: %s%s\n", Yellow, msg, ColorReset)
+}
+
 // PrintRed is used mostly for errors
 func PrintRed(msg string) {
 	fmt.Printf("%s%s%s\n", Red, msg, ColorReset)

--- a/pkg/utils/table.go
+++ b/pkg/utils/table.go
@@ -1,0 +1,153 @@
+package utils
+
+import (
+	"io"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// Two spaces matches the mise / kubectl convention — tight enough to scan,
+// DefaultTablePadding is the gap (in spaces) between columns in PrintTable.
+// loose enough not to mush columns together.
+const DefaultTablePadding = 2
+
+// DefaultTableMaxCellWidth is the soft per-cell truncation threshold for
+// human-readable list views. Tight enough that long tokens, JWTs, and JSON
+// blobs don't wrap or wreck the terminal; loose enough that typical URLs
+// and IDs print in full.
+//
+// Users who need the full value should run `hulak env get KEY` — the table
+// view is for scanning, the get command is for reading.
+const DefaultTableMaxCellWidth = 60
+
+// tableHeaderStyle wraps header cells in bold + italic + bright yellow.
+// Bold ensures readability on terminals that don't render italic; yellow
+// matches the existing PrintWarning palette so section/table headings feel
+// like the same visual family.
+const tableHeaderStyle = "\033[1;3;93m"
+
+// ansiRe matches CSI SGR escape sequences (\x1b[...m). Used to strip styling
+// when measuring a cell's visible width so columns align by what users see,
+// not by raw byte count.
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// visibleWidth returns the rune count of s with ANSI escape codes stripped.
+// This is what we align on, since escape codes are zero-width visually.
+func visibleWidth(s string) int {
+	return len([]rune(ansiRe.ReplaceAllString(s, "")))
+}
+
+// Truncate shortens s to at most width runes. When truncation happens, the
+// last three characters become "..." so the total width stays at exactly
+// width. width <= 3 returns s unchanged (no useful truncation possible).
+//
+// Counts runes, not bytes — multi-byte characters (e.g. `••••`) are handled
+// correctly.
+func Truncate(s string, width int) string {
+	if width <= 3 {
+		return s
+	}
+	r := []rune(s)
+	if len(r) <= width {
+		return s
+	}
+	return string(r[:width-3]) + Ellipsis
+}
+
+// PrintTable writes rows as a borderless aligned table to out. Use it for any
+// "list of records" CLI output: env names, key/value pairs, recipients, etc.
+//
+//   - headers, if non-nil, is printed as the first row, styled bold+italic+yellow.
+//   - rows is a slice of cell slices.
+//   - maxCellWidth truncates over-long cells via Truncate. 0 disables
+//     truncation; DefaultTableMaxCellWidth is the standard limit.
+//   - out=nil falls back to os.Stdout.
+//
+// Alignment is ANSI-aware: cells containing escape codes (styled headers,
+// colored values) are padded based on their *visible* width, so columns line
+// up cleanly regardless of styling.
+func PrintTable(out io.Writer, headers []string, rows [][]string, maxCellWidth int) error {
+	if out == nil {
+		out = os.Stdout
+	}
+
+	truncate := func(c string) string {
+		if maxCellWidth > 0 {
+			return Truncate(c, maxCellWidth)
+		}
+		return c
+	}
+
+	// Truncate everything first so width measurements reflect what'll print.
+	hdr := make([]string, len(headers))
+	for i, h := range headers {
+		hdr[i] = truncate(h)
+	}
+	body := make([][]string, len(rows))
+	for i, r := range rows {
+		body[i] = make([]string, len(r))
+		for j, c := range r {
+			body[i][j] = truncate(c)
+		}
+	}
+
+	// Apply header style after truncation so escape codes don't get cut.
+	styledHeaders := make([]string, len(hdr))
+	for i, h := range hdr {
+		styledHeaders[i] = tableHeaderStyle + h + ColorReset
+	}
+
+	// Compute per-column widths from visible content.
+	var widths []int
+	measure := func(r []string) {
+		for i, c := range r {
+			for len(widths) <= i {
+				widths = append(widths, 0)
+			}
+			if w := visibleWidth(c); w > widths[i] {
+				widths[i] = w
+			}
+		}
+	}
+	if len(styledHeaders) > 0 {
+		measure(styledHeaders)
+	}
+	for _, r := range body {
+		measure(r)
+	}
+	if len(widths) == 0 {
+		return nil
+	}
+
+	gap := strings.Repeat(" ", DefaultTablePadding)
+	writeRow := func(cells []string) error {
+		var sb strings.Builder
+		for i, c := range cells {
+			sb.WriteString(c)
+			// Pad and gap only between cells — never after the last one,
+			// to keep lines free of trailing whitespace.
+			if i < len(cells)-1 {
+				if pad := widths[i] - visibleWidth(c); pad > 0 {
+					sb.WriteString(strings.Repeat(" ", pad))
+				}
+				sb.WriteString(gap)
+			}
+		}
+		sb.WriteByte('\n')
+		_, err := io.WriteString(out, sb.String())
+		return err
+	}
+
+	if len(styledHeaders) > 0 {
+		if err := writeRow(styledHeaders); err != nil {
+			return err
+		}
+	}
+	for _, r := range body {
+		if err := writeRow(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/utils/table_test.go
+++ b/pkg/utils/table_test.go
@@ -1,0 +1,185 @@
+package utils
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		width int
+		want  string
+	}{
+		{"short string unchanged", "hello", 10, "hello"},
+		{"exactly at width", "hello", 5, "hello"},
+		{"truncated", "hello world", 8, "hello..."},
+		{"truncated keeps width", "abcdefghij", 6, "abc..."},
+		{"width <= 3 unchanged", "hello", 3, "hello"},
+		{"width zero unchanged", "hello", 0, "hello"},
+		{"empty string", "", 5, ""},
+		{"multi-byte runes", "café résumé", 6, "caf..."}, // counts runes, not bytes
+		{"only multi-byte", "••••••", 5, "••..."},        // 6 bullet runes → truncate to 5
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Truncate(tc.in, tc.width)
+			if got != tc.want {
+				t.Errorf("Truncate(%q, %d) = %q, want %q", tc.in, tc.width, got, tc.want)
+			}
+		})
+	}
+}
+
+// stripAnsi removes ANSI escape codes so tests can compare on visible content.
+func stripAnsi(s string) string {
+	return ansiRe.ReplaceAllString(s, "")
+}
+
+func TestPrintTable_NoHeader(t *testing.T) {
+	var buf bytes.Buffer
+	rows := [][]string{
+		{"API_KEY", "sk-123"},
+		{"DB_URL", "postgres://x"},
+	}
+	if err := PrintTable(&buf, nil, rows, 0); err != nil {
+		t.Fatalf("PrintTable: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "API_KEY") || !strings.Contains(out, "DB_URL") {
+		t.Errorf("missing keys in output: %q", out)
+	}
+	// Second column must start at the same visible position on both rows.
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), out)
+	}
+	if strings.Index(lines[0], "sk-123") != strings.Index(lines[1], "postgres://x") {
+		t.Errorf("columns not aligned:\n  %q\n  %q", lines[0], lines[1])
+	}
+}
+
+func TestPrintTable_AlignsVaryingLengths(t *testing.T) {
+	var buf bytes.Buffer
+	rows := [][]string{
+		{"a", "1"},
+		{"medium_key", "2"},
+		{"a_much_longer_key_name", "3"},
+	}
+	if err := PrintTable(&buf, nil, rows, 0); err != nil {
+		t.Fatalf("PrintTable: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	pos := strings.Index(lines[0], "1")
+	for i, l := range lines[1:] {
+		got := strings.Index(l, []string{"2", "3"}[i])
+		if got != pos {
+			t.Errorf("row %d: value column at offset %d, want %d (line=%q)", i+1, got, pos, l)
+		}
+	}
+}
+
+func TestPrintTable_WithHeader(t *testing.T) {
+	var buf bytes.Buffer
+	headers := []string{"KEY", "VALUE"}
+	rows := [][]string{{"foo", "bar"}}
+	if err := PrintTable(&buf, headers, rows, 0); err != nil {
+		t.Fatalf("PrintTable: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected header + 1 row, got %d lines: %q", len(lines), buf.String())
+	}
+	// Header is styled; data row is not.
+	if !strings.Contains(lines[0], "\x1b[") {
+		t.Errorf("header line should contain ANSI escape codes; got %q", lines[0])
+	}
+	if strings.Contains(lines[1], "\x1b[") {
+		t.Errorf("data row should NOT contain ANSI codes; got %q", lines[1])
+	}
+	// Visible content of header line is "KEY  VALUE".
+	if visible := stripAnsi(lines[0]); !strings.HasPrefix(visible, "KEY") {
+		t.Errorf("visible header should start with KEY; got %q", visible)
+	}
+}
+
+func TestPrintTable_AlignsWithStyledHeader(t *testing.T) {
+	// ANSI codes in the header are zero-width; columns should still align.
+	var buf bytes.Buffer
+	headers := []string{"K", "V"}
+	rows := [][]string{
+		{"abcdef", "ghi"},
+		{"x", "yyyy"},
+	}
+	if err := PrintTable(&buf, headers, rows, 0); err != nil {
+		t.Fatalf("PrintTable: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	// Compute visible position of each row's second cell.
+	pos := func(line string) int { return strings.Index(stripAnsi(line), strings.Fields(stripAnsi(line))[1]) }
+	headerPos := pos(lines[0])
+	for i, l := range lines[1:] {
+		if got := pos(l); got != headerPos {
+			t.Errorf("row %d second column at visible offset %d, want %d", i+1, got, headerPos)
+		}
+	}
+}
+
+func TestPrintTable_TruncatesLongCells(t *testing.T) {
+	var buf bytes.Buffer
+	long := strings.Repeat("x", 100)
+	rows := [][]string{{"K", long}}
+	if err := PrintTable(&buf, nil, rows, 20); err != nil {
+		t.Fatalf("PrintTable: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "...") {
+		t.Errorf("expected ellipsis in truncated output, got %q", out)
+	}
+	if strings.Contains(out, long) {
+		t.Errorf("expected long value to be truncated, but saw it whole in %q", out)
+	}
+}
+
+func TestPrintTable_NoTruncationWhenZero(t *testing.T) {
+	var buf bytes.Buffer
+	long := strings.Repeat("x", 500)
+	rows := [][]string{{"K", long}}
+	if err := PrintTable(&buf, nil, rows, 0); err != nil {
+		t.Fatalf("PrintTable: %v", err)
+	}
+	if !strings.Contains(buf.String(), long) {
+		t.Error("expected full value when maxCellWidth=0")
+	}
+}
+
+func TestPrintTable_EmptyRows(t *testing.T) {
+	var buf bytes.Buffer
+	if err := PrintTable(&buf, nil, nil, 0); err != nil {
+		t.Fatalf("PrintTable: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output, got %q", buf.String())
+	}
+}
+
+func TestPrintTable_SingleColumn(t *testing.T) {
+	// Used by `env list`: one cell per row, no header.
+	var buf bytes.Buffer
+	rows := [][]string{{"global"}, {"prod"}, {"staging"}}
+	if err := PrintTable(&buf, nil, rows, 0); err != nil {
+		t.Fatalf("PrintTable: %v", err)
+	}
+	want := "global\nprod\nstaging\n"
+	if buf.String() != want {
+		t.Errorf("output = %q, want %q", buf.String(), want)
+	}
+}

--- a/pkg/utils/validate.go
+++ b/pkg/utils/validate.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// MaxEnvNameLen is the upper bound on environment-name length.
+// Chosen to fit comfortably in a single line of human output, leave headroom for
+// JSON keys, and stay well under filesystem path limits.
+const MaxEnvNameLen = 64
+
+// envNamePattern matches valid hulak environment names: ASCII letters, digits,
+// underscore, and hyphen. No spaces, no dots, no slashes, no shell metacharacters.
+var envNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// ValidateEnvName reports whether name is a syntactically valid environment
+// identifier. Used by every CLI site that accepts an --env value, by migration
+// when sanitizing legacy filenames, and by the vault store on read.
+func ValidateEnvName(name string) error {
+	if name == "" {
+		return fmt.Errorf("environment name cannot be empty")
+	}
+	if len(name) > MaxEnvNameLen {
+		return fmt.Errorf(
+			"environment name %q is too long (%d chars, max %d)",
+			name, len(name), MaxEnvNameLen,
+		)
+	}
+	if !envNamePattern.MatchString(name) {
+		return fmt.Errorf(
+			"environment name %q is invalid: only letters, digits, underscore, and hyphen are allowed",
+			name,
+		)
+	}
+	return nil
+}

--- a/pkg/utils/validate.go
+++ b/pkg/utils/validate.go
@@ -17,6 +17,9 @@ var envNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 // ValidateEnvName reports whether name is a syntactically valid environment
 // identifier. Used by every CLI site that accepts an --env value, by migration
 // when sanitizing legacy filenames, and by the vault store on read.
+//
+// Names starting with `_` are reserved for the store's internal metadata
+// (e.g. _version). User-defined env names must not start with an underscore.
 func ValidateEnvName(name string) error {
 	if name == "" {
 		return fmt.Errorf("environment name cannot be empty")
@@ -25,6 +28,12 @@ func ValidateEnvName(name string) error {
 		return fmt.Errorf(
 			"environment name %q is too long (%d chars, max %d)",
 			name, len(name), MaxEnvNameLen,
+		)
+	}
+	if name[0] == '_' {
+		return fmt.Errorf(
+			"environment name %q is invalid: names starting with '_' are reserved for internal use",
+			name,
 		)
 	}
 	if !envNamePattern.MatchString(name) {

--- a/pkg/utils/validate_test.go
+++ b/pkg/utils/validate_test.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateEnvName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// valid
+		{"simple lowercase", "global", false},
+		{"with digit", "prod1", false},
+		{"with underscore", "team_a", false},
+		{"with hyphen", "team-a", false},
+		{"mixed case", "StagingV2", false},
+		{"single char", "a", false},
+		{"max length (64)", strings.Repeat("a", MaxEnvNameLen), false},
+		{"all separators allowed", "team_a-1", false},
+
+		// invalid
+		{"empty string", "", true},
+		{"contains space", "my env", true},
+		{"contains dot", "my.env", true},
+		{"contains slash", "team/prod", true},
+		{"contains backslash", `team\prod`, true},
+		{"contains shell metachar", "prod;rm", true},
+		{"contains dollar", "$prod", true},
+		{"unicode letter", "préprod", true},
+		{"too long (65)", strings.Repeat("a", MaxEnvNameLen+1), true},
+		{"path traversal", "../etc", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateEnvName(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ValidateEnvName(%q) error = %v, wantErr %v", tc.input, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/utils/validate_test.go
+++ b/pkg/utils/validate_test.go
@@ -23,6 +23,8 @@ func TestValidateEnvName(t *testing.T) {
 
 		// invalid
 		{"empty string", "", true},
+		{"reserved underscore prefix", "_version", true},
+		{"underscore prefix", "_internal", true},
 		{"contains space", "my env", true},
 		{"contains dot", "my.env", true},
 		{"contains slash", "team/prod", true},

--- a/pkg/vault/keys.go
+++ b/pkg/vault/keys.go
@@ -64,10 +64,15 @@ func LoadIdentity() (*age.X25519Identity, error) {
 }
 
 // SetIdentity writes the private key to the global config identity file.
+// Creates the parent directory if it doesn't exist so first-use bootstrap
+// works without a separate "init the config dir" step.
 func SetIdentity(privateKey string) error {
 	identityFilePath, err := getIdentityFilePath()
 	if err != nil {
 		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(identityFilePath), utils.DirPer); err != nil {
+		return fmt.Errorf("failed to create config dir: %w", err)
 	}
 
 	return os.WriteFile(identityFilePath, []byte(privateKey+"\n"), utils.SecretPer)

--- a/pkg/vault/keys.go
+++ b/pkg/vault/keys.go
@@ -71,7 +71,7 @@ func SetIdentity(privateKey string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(identityFilePath), utils.DirPer); err != nil {
+	if err := os.MkdirAll(filepath.Dir(identityFilePath), utils.SecretDirPer); err != nil {
 		return fmt.Errorf("failed to create config dir: %w", err)
 	}
 

--- a/pkg/vault/keys_test.go
+++ b/pkg/vault/keys_test.go
@@ -84,23 +84,14 @@ func setupConfigDir(t *testing.T) string {
 		t.Fatalf("failed to resolve symlinks: %v", err)
 	}
 
-	// UserConfigDir on unix checks XDG_CONFIG_HOME first
-	oldXDG := os.Getenv("XDG_CONFIG_HOME")
+	// Point XDG_CONFIG_HOME at our temp dir so utils.UserConfigDir resolves
+	// to <tmpDir>/hulak — isolated from the user's real ~/.config/hulak.
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
-	t.Cleanup(func() {
-		os.Setenv("XDG_CONFIG_HOME", oldXDG)
-	})
 
-	// UserConfigDir appends "hulak" to XDG_CONFIG_HOME
-	// but our getIdentityFilePath calls UserConfigDir which returns tmpDir directly
-	// (since XDG_CONFIG_HOME is set, it returns it as-is without appending hulak)
-	// Let's check what UserConfigDir actually returns
 	configDir, err := utils.UserConfigDir()
 	if err != nil {
 		t.Fatalf("UserConfigDir() error: %v", err)
 	}
-
-	// Create the config dir if needed
 	if err := os.MkdirAll(configDir, utils.DirPer); err != nil {
 		t.Fatalf("failed to create config dir: %v", err)
 	}
@@ -272,6 +263,48 @@ func TestEnsureKeypairDetectsMismatch(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "mismatch") {
 		t.Errorf("error = %q, want it to contain 'mismatch'", err.Error())
+	}
+}
+
+// TestEnsureKeypairRecoversMissingPubKey verifies that if .hulak/key.pub
+// goes missing but the identity is intact, EnsureKeypair derives the
+// pubkey from the identity and writes it back — without generating a
+// new keypair (which would silently brick any existing store.age).
+func TestEnsureKeypairRecoversMissingPubKey(t *testing.T) {
+	projectDir := setupHulakProject(t)
+	setupConfigDir(t)
+
+	first, err := EnsureKeypair()
+	if err != nil {
+		t.Fatalf("EnsureKeypair() initial: %v", err)
+	}
+
+	// Simulate accidental deletion of key.pub.
+	pubKeyPath := filepath.Join(projectDir, utils.HiddenProjectName, publicKeyFile)
+	if err := os.Remove(pubKeyPath); err != nil {
+		t.Fatalf("failed to remove key.pub: %v", err)
+	}
+
+	second, err := EnsureKeypair()
+	if err != nil {
+		t.Fatalf("EnsureKeypair() after pub-key loss: %v", err)
+	}
+
+	// Identity must NOT have rotated.
+	if second.Identity.String() != first.Identity.String() {
+		t.Error("EnsureKeypair() rotated identity on missing pubkey — would brick existing store.age")
+	}
+	// Recipient must derive from the same identity.
+	if second.Recipient.String() != first.Recipient.String() {
+		t.Errorf("recipient mismatch: got %q, want %q", second.Recipient.String(), first.Recipient.String())
+	}
+	// key.pub must be on disk again.
+	got, err := os.ReadFile(pubKeyPath)
+	if err != nil {
+		t.Fatalf("key.pub not re-created: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != first.Recipient.String() {
+		t.Errorf("re-derived key.pub = %q, want %q", strings.TrimSpace(string(got)), first.Recipient.String())
 	}
 }
 

--- a/pkg/vault/keys_test.go
+++ b/pkg/vault/keys_test.go
@@ -308,6 +308,53 @@ func TestEnsureKeypairRecoversMissingPubKey(t *testing.T) {
 	}
 }
 
+// TestEnsureKeypairRefusesToOverwriteExistingStore verifies that if the
+// identity is missing but a store.age exists, EnsureKeypair refuses to
+// generate a fresh keypair. Generating one would make the existing
+// ciphertext permanently undecryptable — the new pubkey wouldn't match
+// the recipient store.age was originally encrypted to.
+//
+// Real-world trigger: $XDG_CONFIG_HOME resolves to a different path than
+// when the store was created (changed dotfiles, different shell, direnv,
+// SSH session with no XDG, etc.). The error guides the user to fix the
+// path rather than silently destroying their data.
+func TestEnsureKeypairRefusesToOverwriteExistingStore(t *testing.T) {
+	projectDir := setupHulakProject(t)
+	configDir := setupConfigDir(t)
+
+	// Create a real keypair and write a store encrypted to it.
+	ageKey, err := EnsureKeypair()
+	if err != nil {
+		t.Fatalf("initial EnsureKeypair: %v", err)
+	}
+	store := &Store{Envs: map[string]Env{"global": {"FOO": "bar"}}}
+	if err := WriteStore(store, ageKey.Recipient); err != nil {
+		t.Fatalf("WriteStore: %v", err)
+	}
+
+	// Simulate the "XDG changed; identity not at the resolved path" scenario:
+	// remove identity.txt while leaving store.age intact.
+	if err := os.Remove(filepath.Join(configDir, identityFile)); err != nil {
+		t.Fatalf("remove identity: %v", err)
+	}
+	// Also remove key.pub so we can't take the "derive from identity" path.
+	if err := os.Remove(filepath.Join(projectDir, utils.HiddenProjectName, publicKeyFile)); err != nil {
+		t.Fatalf("remove key.pub: %v", err)
+	}
+
+	_, err = EnsureKeypair()
+	if err == nil {
+		t.Fatal("expected EnsureKeypair to refuse generation when store.age exists, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "store") || !strings.Contains(msg, "Refusing") {
+		t.Errorf("error %q should mention the existing store and refusal", msg)
+	}
+	if !strings.Contains(msg, "XDG_CONFIG_HOME") {
+		t.Errorf("error %q should hint at XDG_CONFIG_HOME as a likely cause", msg)
+	}
+}
+
 func TestLoadIdentity(t *testing.T) {
 	t.Run("loads existing identity", func(t *testing.T) {
 		setupConfigDir(t)

--- a/pkg/vault/keys_unix_test.go
+++ b/pkg/vault/keys_unix_test.go
@@ -1,0 +1,55 @@
+//go:build !windows
+
+package vault
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"filippo.io/age"
+
+	"github.com/xaaha/hulak/pkg/utils"
+)
+
+// TestSetIdentityCreatesDirOwnerOnly verifies that when SetIdentity has to
+// MkdirAll the parent directory itself (first-use bootstrap), it creates the
+// dir owner-only (0700). Group/other access on a shared host would let other
+// users `ls` the dir and learn an identity file exists, even if they can't
+// read it — defense in depth around the most sensitive file in the system.
+//
+// We zero the umask so the assertion catches a regression where SetIdentity
+// passes a wider mode (e.g. 0755) and the user's umask is what actually
+// trims it down to 0700 in practice.
+func TestSetIdentityCreatesDirOwnerOnly(t *testing.T) {
+	xdg := t.TempDir()
+	xdg, err := filepath.EvalSymlinks(xdg)
+	if err != nil {
+		t.Fatalf("eval symlinks: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	oldMask := syscall.Umask(0)
+	t.Cleanup(func() { syscall.Umask(oldMask) })
+
+	id, _ := age.GenerateX25519Identity()
+	if err := SetIdentity(id.String()); err != nil {
+		t.Fatalf("SetIdentity: %v", err)
+	}
+
+	configDir, err := utils.UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir: %v", err)
+	}
+	info, err := os.Stat(configDir)
+	if err != nil {
+		t.Fatalf("stat config dir: %v", err)
+	}
+	if got := info.Mode().Perm(); got != utils.SecretDirPer {
+		t.Errorf(
+			"config dir permissions = %o, want %o (identity dir must be owner-only)",
+			got, utils.SecretDirPer,
+		)
+	}
+}

--- a/pkg/vault/lock.go
+++ b/pkg/vault/lock.go
@@ -30,6 +30,12 @@ func WithStoreLock(fn func() error) error {
 		return err
 	}
 
+	// Ensure .hulak/ exists so the lock file (and downstream store ops)
+	// can be created on first use, before init has formalized the project.
+	if err := os.MkdirAll(filepath.Dir(path), utils.DirPer); err != nil {
+		return fmt.Errorf("failed to create %s/: %w", utils.HiddenProjectName, err)
+	}
+
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, utils.SecretPer)
 	if err != nil {
 		return fmt.Errorf("failed to open lock file: %w", err)

--- a/pkg/vault/lock.go
+++ b/pkg/vault/lock.go
@@ -1,0 +1,58 @@
+package vault
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/xaaha/hulak/pkg/utils"
+)
+
+// LockFile is the basename of the cross-process write lock inside .hulak/.
+// Each project has exactly one. The file is created on demand and never
+// deleted — its presence is harmless, and removing it could race with another
+// process holding the lock.
+const LockFile = ".lock"
+
+// WithStoreLock acquires an exclusive OS-level file lock on .hulak/.lock,
+// invokes fn, and releases the lock when fn returns. Use this around any
+// read-modify-write of the encrypted store so concurrent `hulak env set`
+// calls cannot lose each other's edits.
+//
+// Reads do not need this lock: WriteStore renames atomically, so readers
+// always observe a single consistent snapshot.
+//
+// The lock is released automatically if the holding process crashes — the OS
+// drops it when the file descriptor closes.
+func WithStoreLock(fn func() error) error {
+	path, err := lockFilePath()
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, utils.SecretPer)
+	if err != nil {
+		return fmt.Errorf("failed to open lock file: %w", err)
+	}
+	defer f.Close()
+
+	if err := acquireFileLock(f); err != nil {
+		return fmt.Errorf("failed to acquire store lock: %w", err)
+	}
+	defer func() {
+		// Best-effort release. Closing f also releases the lock, so even
+		// if this errors the OS will clean up.
+		_ = releaseFileLock(f)
+	}()
+
+	return fn()
+}
+
+// lockFilePath returns the absolute path to .hulak/.lock in the project root.
+func lockFilePath() (string, error) {
+	markerPath, err := utils.GetProjectMarker()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(markerPath, LockFile), nil
+}

--- a/pkg/vault/lock_test.go
+++ b/pkg/vault/lock_test.go
@@ -1,0 +1,84 @@
+package vault
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/xaaha/hulak/pkg/utils"
+)
+
+// TestWithStoreLockCreatesFile verifies that WithStoreLock creates the
+// .hulak/.lock file on first call.
+func TestWithStoreLockCreatesFile(t *testing.T) {
+	projectDir := setupHulakProject(t)
+
+	if err := WithStoreLock(func() error { return nil }); err != nil {
+		t.Fatalf("WithStoreLock() error: %v", err)
+	}
+
+	lockPath := filepath.Join(projectDir, utils.HiddenProjectName, LockFile)
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Errorf("lock file not created: %v", err)
+	}
+}
+
+// TestWithStoreLockSerializes verifies that concurrent calls do not
+// overlap inside fn. We hold each call for a short duration and check
+// that no two calls were active at the same time.
+func TestWithStoreLockSerializes(t *testing.T) {
+	setupHulakProject(t)
+
+	const goroutines = 8
+	var (
+		wg          sync.WaitGroup
+		active      atomic.Int32
+		maxActive   atomic.Int32
+		invocations atomic.Int32
+	)
+
+	for range goroutines {
+		wg.Go(func() {
+			err := WithStoreLock(func() error {
+				cur := active.Add(1)
+				// Track high-water mark of concurrent fn invocations.
+				for {
+					prev := maxActive.Load()
+					if cur <= prev || maxActive.CompareAndSwap(prev, cur) {
+						break
+					}
+				}
+				time.Sleep(5 * time.Millisecond)
+				invocations.Add(1)
+				active.Add(-1)
+				return nil
+			})
+			if err != nil {
+				t.Errorf("WithStoreLock() error: %v", err)
+			}
+		})
+	}
+	wg.Wait()
+
+	if got := invocations.Load(); got != goroutines {
+		t.Errorf("invocations = %d, want %d", got, goroutines)
+	}
+	if got := maxActive.Load(); got != 1 {
+		t.Errorf("maxActive = %d, want 1 (lock allowed concurrent execution)", got)
+	}
+}
+
+// TestWithStoreLockPropagatesError verifies the user's error from fn is
+// returned unchanged.
+func TestWithStoreLockPropagatesError(t *testing.T) {
+	setupHulakProject(t)
+
+	want := os.ErrPermission
+	got := WithStoreLock(func() error { return want })
+	if got != want {
+		t.Errorf("WithStoreLock() error = %v, want %v", got, want)
+	}
+}

--- a/pkg/vault/lock_unix.go
+++ b/pkg/vault/lock_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package vault
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// acquireFileLock takes an exclusive blocking flock on f. Blocks until the
+// lock is available; cancellation is via process signal.
+func acquireFileLock(f *os.File) error {
+	// File descriptors are always small non-negative ints in practice; the
+	// uintptr->int conversion is safe.
+	return unix.Flock(int(f.Fd()), unix.LOCK_EX) //nolint:gosec // G115
+}
+
+// releaseFileLock releases the flock on f. Closing f also releases it,
+// so this is best-effort during normal shutdown.
+func releaseFileLock(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_UN) //nolint:gosec // G115
+}

--- a/pkg/vault/lock_windows.go
+++ b/pkg/vault/lock_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package vault
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// acquireFileLock takes an exclusive blocking lock on f via LockFileEx.
+// Locks the first byte of the file (which need not exist) — the byte range
+// is just a synchronization rendezvous, no data is read or written.
+func acquireFileLock(f *os.File) error {
+	var ol windows.Overlapped
+	return windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0, // reserved
+		1, // bytes to lock (low)
+		0, // bytes to lock (high)
+		&ol,
+	)
+}
+
+// releaseFileLock releases the LockFileEx lock on f.
+func releaseFileLock(f *os.File) error {
+	var ol windows.Overlapped
+	return windows.UnlockFileEx(
+		windows.Handle(f.Fd()),
+		0, // reserved
+		1, // bytes to unlock (low)
+		0, // bytes to unlock (high)
+		&ol,
+	)
+}

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 
 	"filippo.io/age"
 
@@ -23,6 +24,15 @@ const StoreVersion = 1
 // underscore reserves it from collision with user-defined env names
 // (which utils.ValidateEnvName rejects when starting with '_').
 const versionFieldName = "_version"
+
+// MaxStoreSizeWarnBytes is the soft threshold for the decrypted store size.
+// Above this, ReadStore prints a one-time stderr warning that performance
+// may degrade. Not a hard limit — large stores still work.
+const MaxStoreSizeWarnBytes = 1 << 20 // 1 MiB
+
+// storeSizeWarnOnce gates the size warning to once per process, so users
+// don't get spammed when a single command issues multiple reads.
+var storeSizeWarnOnce sync.Once
 
 // Env is the user's environment like 'staging', 'prod',
 type Env map[string]any
@@ -168,11 +178,30 @@ func ReadStore(identity age.Identity) (*Store, error) {
 		return nil, fmt.Errorf("failed to decrypt store: %w", err)
 	}
 
+	maybeWarnStoreSize(len(plainText))
+
 	store := &Store{}
 	if err := json.Unmarshal(plainText, store); err != nil {
 		return nil, err
 	}
 	return store, nil
+}
+
+// maybeWarnStoreSize prints a one-time stderr warning if the decrypted store
+// exceeds MaxStoreSizeWarnBytes. Stderr (not stdout) so callers like
+// `hulak env get` captured via $(...) stay clean.
+func maybeWarnStoreSize(size int) {
+	if size <= MaxStoreSizeWarnBytes {
+		return
+	}
+	storeSizeWarnOnce.Do(func() {
+		fmt.Fprintf(os.Stderr,
+			"%swarning: decrypted store is %.1f MB — large stores can slow `hulak env` operations; consider {{getFile \"path\"}} for big blobs%s\n",
+			utils.Yellow,
+			float64(size)/(1<<20),
+			utils.ColorReset,
+		)
+	})
 }
 
 // WriteStore marshals the store to JSON, encrypts it, and writes to store.age.

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -195,12 +195,10 @@ func maybeWarnStoreSize(size int) {
 		return
 	}
 	storeSizeWarnOnce.Do(func() {
-		fmt.Fprintf(os.Stderr,
-			"%swarning: decrypted store is %.1f MB — large stores can slow `hulak env` operations; consider {{getFile \"path\"}} for big blobs%s\n",
-			utils.Yellow,
+		utils.PrintWarningStderr(fmt.Sprintf(
+			"decrypted store is %.1f MB — large stores can slow `hulak env` operations; consider {{getFile \"path\"}} for big blobs",
 			float64(size)/(1<<20),
-			utils.ColorReset,
-		)
+		))
 	})
 }
 

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -15,6 +15,15 @@ import (
 
 // Contains encrypted store persistence and environment secret key management.
 
+// StoreVersion is the current schema version of the encrypted JSON store.
+// Bumped only on backwards-incompatible changes to the on-disk layout.
+const StoreVersion = 1
+
+// versionFieldName is the JSON key for the schema version. The leading
+// underscore reserves it from collision with user-defined env names
+// (which utils.ValidateEnvName rejects when starting with '_').
+const versionFieldName = "_version"
+
 // Env is the user's environment like 'staging', 'prod',
 type Env map[string]any
 
@@ -23,6 +32,71 @@ type Env map[string]any
 // and its value is a map of secret key-value pairs.
 type Store struct {
 	Envs map[string]Env
+}
+
+// MarshalJSON serializes the store as a flat object with `_version` alongside
+// the named environments: {"_version": 1, "global": {...}, "prod": {...}}.
+func (s *Store) MarshalJSON() ([]byte, error) {
+	out := make(map[string]any, len(s.Envs)+1)
+	out[versionFieldName] = StoreVersion
+	for name, env := range s.Envs {
+		out[name] = env
+	}
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON parses the flat object form, validates the version, and
+// populates Envs. A missing `_version` field is treated as version 1 (legacy
+// stores written before versioning was introduced).
+func (s *Store) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("failed to parse store: %w", err)
+	}
+
+	// Default to 1 (not StoreVersion) — a missing _version field means the
+	// store was written by pre-versioning hulak, which is by definition v1.
+	// This must stay 1 forever, even when StoreVersion increments.
+	version := 1
+	if vRaw, ok := raw[versionFieldName]; ok {
+		if err := json.Unmarshal(vRaw, &version); err != nil {
+			return fmt.Errorf("invalid %s field: %w", versionFieldName, err)
+		}
+	}
+	if version > StoreVersion {
+		return fmt.Errorf(
+			"store was written by a newer hulak (version %d, this version supports %d) — upgrade with `brew upgrade hulak`",
+			version,
+			StoreVersion,
+		)
+	}
+
+	// skip version, parse env
+	s.Envs = make(map[string]Env, len(raw))
+	for name, envRaw := range raw {
+		if name == versionFieldName {
+			continue
+		}
+		env, err := decodeEnv(envRaw)
+		if err != nil {
+			return fmt.Errorf("failed to parse env %q: %w", name, err)
+		}
+		s.Envs[name] = env
+	}
+	return nil
+}
+
+// decodeEnv parses a single environment's raw JSON bytes into an Env map.
+// Numbers are kept as json.Number to preserve int/float distinction and avoid
+// precision loss for large integers.
+func decodeEnv(raw json.RawMessage) (Env, error) {
+	var env Env
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	if err := dec.Decode(&env); err != nil {
+		return nil, err
+	}
+	return env, nil
 }
 
 // GetEnv returns the key-value map for a given environment name.
@@ -94,14 +168,11 @@ func ReadStore(identity age.Identity) (*Store, error) {
 		return nil, fmt.Errorf("failed to decrypt store: %w", err)
 	}
 
-	var envs map[string]Env
-	dec := json.NewDecoder(bytes.NewReader(plainText))
-	dec.UseNumber() // avoids float64, get exact original text
-	if err := dec.Decode(&envs); err != nil {
-		return nil, fmt.Errorf("failed to parse store: %w", err)
+	store := &Store{}
+	if err := json.Unmarshal(plainText, store); err != nil {
+		return nil, err
 	}
-
-	return &Store{Envs: envs}, nil
+	return store, nil
 }
 
 // WriteStore marshals the store to JSON, encrypts it, and writes to store.age.
@@ -112,7 +183,8 @@ func WriteStore(store *Store, recipients ...age.Recipient) error {
 		return err
 	}
 
-	plainText, err := json.MarshalIndent(store.Envs, "", "  ")
+	// for edit command, we need to display readable json
+	plainText, err := json.MarshalIndent(store, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal store: %w", err)
 	}

--- a/pkg/vault/store_test.go
+++ b/pkg/vault/store_test.go
@@ -2,9 +2,11 @@ package vault
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"filippo.io/age"
@@ -532,6 +534,83 @@ func TestReadStoreFutureVersionRejected(t *testing.T) {
 	msg := err.Error()
 	if !strings.Contains(msg, "newer hulak") || !strings.Contains(msg, "upgrade") {
 		t.Errorf("error message %q should mention 'newer hulak' and 'upgrade'", msg)
+	}
+}
+
+// captureStderr swaps os.Stderr for a pipe, runs fn, restores os.Stderr,
+// and returns whatever fn wrote to stderr.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = orig })
+
+	done := make(chan string, 1)
+	go func() {
+		var buf strings.Builder
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+	_ = w.Close()
+	return <-done
+}
+
+func TestReadStoreSizeWarning_LargeTriggersOnce(t *testing.T) {
+	setupHulakProject(t)
+	id, _ := age.GenerateX25519Identity()
+
+	// Build a store whose decrypted JSON exceeds 1 MB.
+	big := strings.Repeat("a", MaxStoreSizeWarnBytes+1024)
+	original := &Store{Envs: map[string]Env{"global": {"BLOB": big}}}
+	if err := WriteStore(original, id.Recipient()); err != nil {
+		t.Fatalf("WriteStore: %v", err)
+	}
+
+	// Reset the once-gate so this test sees the warning regardless of order.
+	storeSizeWarnOnce = sync.Once{}
+
+	out := captureStderr(t, func() {
+		if _, err := ReadStore(id); err != nil {
+			t.Fatalf("ReadStore #1: %v", err)
+		}
+		if _, err := ReadStore(id); err != nil {
+			t.Fatalf("ReadStore #2: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "warning") || !strings.Contains(out, "MB") {
+		t.Errorf("expected size warning in stderr, got %q", out)
+	}
+	if got := strings.Count(out, "warning"); got != 1 {
+		t.Errorf("warning fired %d times, want 1 (once per process)", got)
+	}
+}
+
+func TestReadStoreSizeWarning_SmallNoWarning(t *testing.T) {
+	setupHulakProject(t)
+	id, _ := age.GenerateX25519Identity()
+
+	original := &Store{Envs: map[string]Env{"global": {"KEY": "value"}}}
+	if err := WriteStore(original, id.Recipient()); err != nil {
+		t.Fatalf("WriteStore: %v", err)
+	}
+
+	storeSizeWarnOnce = sync.Once{}
+
+	out := captureStderr(t, func() {
+		if _, err := ReadStore(id); err != nil {
+			t.Fatalf("ReadStore: %v", err)
+		}
+	})
+
+	if out != "" {
+		t.Errorf("expected no stderr output for small store, got %q", out)
 	}
 }
 

--- a/pkg/vault/store_test.go
+++ b/pkg/vault/store_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"filippo.io/age"
@@ -434,6 +435,104 @@ func TestDetectStore(t *testing.T) {
 			t.Errorf("DetectStore() = %v, want StoreNone when .hulak has no store.age", got)
 		}
 	})
+}
+
+func TestWriteStoreEmbedsVersion(t *testing.T) {
+	setupHulakProject(t)
+	id, _ := age.GenerateX25519Identity()
+
+	s := &Store{Envs: map[string]Env{"global": {"KEY": "value"}}}
+	if err := WriteStore(s, id.Recipient()); err != nil {
+		t.Fatalf("WriteStore() error: %v", err)
+	}
+
+	// Decrypt and inspect the raw JSON to confirm _version is present.
+	cipher, err := os.ReadFile(filepath.Join(utils.HiddenProjectName, utils.StoreFile))
+	if err != nil {
+		t.Fatalf("read store: %v", err)
+	}
+	plain, err := DecryptText(cipher, id)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(plain, &raw); err != nil {
+		t.Fatalf("parse plain: %v", err)
+	}
+
+	vRaw, ok := raw["_version"]
+	if !ok {
+		t.Fatal("_version field missing from written store")
+	}
+	var got int
+	if err := json.Unmarshal(vRaw, &got); err != nil {
+		t.Fatalf("parse _version: %v", err)
+	}
+	if got != StoreVersion {
+		t.Errorf("_version = %d, want %d", got, StoreVersion)
+	}
+}
+
+func TestReadStoreLegacyWithoutVersion(t *testing.T) {
+	setupHulakProject(t)
+	id, _ := age.GenerateX25519Identity()
+
+	// Legacy store: pure env map, no _version key.
+	legacy, err := json.Marshal(map[string]Env{
+		"global": {"BASE_URL": "https://api.example.com"},
+	})
+	if err != nil {
+		t.Fatalf("marshal legacy: %v", err)
+	}
+	cipher, err := EncryptText(legacy, id.Recipient())
+	if err != nil {
+		t.Fatalf("encrypt legacy: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(utils.HiddenProjectName, utils.StoreFile), cipher, utils.SecretPer,
+	); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+
+	got, err := ReadStore(id)
+	if err != nil {
+		t.Fatalf("ReadStore() legacy error: %v", err)
+	}
+	if got.GetEnv("global")["BASE_URL"] != "https://api.example.com" {
+		t.Errorf("legacy global.BASE_URL = %v, want %q", got.GetEnv("global")["BASE_URL"], "https://api.example.com")
+	}
+}
+
+func TestReadStoreFutureVersionRejected(t *testing.T) {
+	setupHulakProject(t)
+	id, _ := age.GenerateX25519Identity()
+
+	future, err := json.Marshal(map[string]any{
+		"_version": StoreVersion + 1,
+		"global":   map[string]any{"KEY": "value"},
+	})
+	if err != nil {
+		t.Fatalf("marshal future: %v", err)
+	}
+	cipher, err := EncryptText(future, id.Recipient())
+	if err != nil {
+		t.Fatalf("encrypt future: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(utils.HiddenProjectName, utils.StoreFile), cipher, utils.SecretPer,
+	); err != nil {
+		t.Fatalf("write future: %v", err)
+	}
+
+	_, err = ReadStore(id)
+	if err == nil {
+		t.Fatal("ReadStore() with future version should error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "newer hulak") || !strings.Contains(msg, "upgrade") {
+		t.Errorf("error message %q should mention 'newer hulak' and 'upgrade'", msg)
+	}
 }
 
 func TestWriteStoreAtomicCleanup(t *testing.T) {

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -71,7 +71,11 @@ func SetPublicKey(publicEncKey string) error {
 //   - identity present, pubkey missing → derive pubkey from identity and write
 //     it back. Recovers from accidental key.pub deletion without generating
 //     a new identity (which would silently brick any existing store.age).
-//   - identity missing                  → generate a fresh keypair and write
+//   - identity missing, store.age exists → refuse. Generating a new identity
+//     would make the existing ciphertext permanently undecryptable. Likely
+//     cause: $XDG_CONFIG_HOME changed between runs, so the resolved path
+//     no longer points at the original identity file.
+//   - identity missing, no store.age   → generate a fresh keypair and write
 //     both files. Any orphan pubkey from a previous identity is overwritten.
 func EnsureKeypair() (AgeKey, error) {
 	identityPath, err := getIdentityFilePath()
@@ -117,7 +121,24 @@ func EnsureKeypair() (AgeKey, error) {
 		return AgeKey{Identity: identity, Recipient: recipient}, nil
 	}
 
-	// No identity on disk — generate a fresh keypair.
+	// Identity missing. Refuse to generate a new keypair if a store already
+	// exists — the new identity wouldn't match the recipient store.age was
+	// encrypted to, and the ciphertext would be unrecoverable.
+	if existingStore, err := storePath(); err == nil && utils.FileExists(existingStore) {
+		return AgeKey{}, utils.HelpfulError(
+			fmt.Sprintf(
+				"identity not found at %s but %s exists. Refusing to generate a new identity that would not match the existing store",
+				identityPath, existingStore,
+			),
+			"Likely fixes",
+			[]string{
+				"Restore the original identity at " + identityPath,
+				"Or set $XDG_CONFIG_HOME to point at the directory holding the original identity",
+			},
+		)
+	}
+
+	// No identity, no store — safe to generate a fresh keypair.
 	ageKey, err := GenerateKeyPair()
 	if err != nil {
 		return AgeKey{}, err

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -2,8 +2,10 @@ package vault
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"filippo.io/age"
 
@@ -62,10 +64,15 @@ func SetPublicKey(publicEncKey string) error {
 	return os.WriteFile(pubKeyPath, []byte(publicEncKey+"\n"), utils.FilePer)
 }
 
-// EnsureKeypair generates and stores an age keypair if one does not already exist.
-// It's idempotent. If both key.pub and identity.txt exist, reads them back,
-// verifies they are a matching pair, and returns the parsed AgeKey.
-// Both .hulak/ and the global config directory must already exist (created by hulak init).
+// EnsureKeypair returns the age keypair for this project, lazily creating one
+// on first use. Identity is the source of truth; key.pub is derived. So:
+//
+//   - identity + pubkey both present  → verify they match, return.
+//   - identity present, pubkey missing → derive pubkey from identity and write
+//     it back. Recovers from accidental key.pub deletion without generating
+//     a new identity (which would silently brick any existing store.age).
+//   - identity missing                  → generate a fresh keypair and write
+//     both files. Any orphan pubkey from a previous identity is overwritten.
 func EnsureKeypair() (AgeKey, error) {
 	identityPath, err := getIdentityFilePath()
 	if err != nil {
@@ -77,22 +84,40 @@ func EnsureKeypair() (AgeKey, error) {
 		return AgeKey{}, err
 	}
 
-	// If both files exist, read, verify pair, and return
-	if utils.FileExists(pubKeyPath) && utils.FileExists(identityPath) {
+	identityExists := utils.FileExists(identityPath)
+	pubKeyExists := utils.FileExists(pubKeyPath)
+
+	if identityExists && pubKeyExists {
 		privKeyStr, err := GetIdentity()
 		if err != nil {
 			return AgeKey{}, err
 		}
-
 		pubKeyBytes, err := os.ReadFile(pubKeyPath)
 		if err != nil {
 			return AgeKey{}, err
 		}
-
 		return VerifyKeypair(privKeyStr, string(pubKeyBytes))
 	}
 
-	// Generate new keypair
+	if identityExists {
+		// Pubkey is missing but identity is present — derive and re-write
+		// the pubkey instead of generating a new keypair.
+		privKeyStr, err := GetIdentity()
+		if err != nil {
+			return AgeKey{}, err
+		}
+		identity, err := age.ParseX25519Identity(strings.TrimSpace(privKeyStr))
+		if err != nil {
+			return AgeKey{}, fmt.Errorf("failed to parse identity: %w", err)
+		}
+		recipient := identity.Recipient()
+		if err := SetPublicKey(recipient.String()); err != nil {
+			return AgeKey{}, err
+		}
+		return AgeKey{Identity: identity, Recipient: recipient}, nil
+	}
+
+	// No identity on disk — generate a fresh keypair.
 	ageKey, err := GenerateKeyPair()
 	if err != nil {
 		return AgeKey{}, err


### PR DESCRIPTION
## Summary

Closes #142. Implements all six `hulak env` CRUD commands plus the cross-cutting prerequisites the rest of the encryption epic depends on. Also fixes two related data-loss footguns surfaced during testing.

## What's in

**Cross-cutting prerequisites**
- `utils.ValidateEnvName` — `^[a-zA-Z0-9_-]+$`, length ≤ 64, rejects `_` prefix (reserved for internal metadata)
- `vault.Store` schema versioning — `_version: 1` field via custom Marshal/Unmarshal; missing-field defaulted to v1 for legacy reads; future versions error with upgrade guidance
- `vault.WithStoreLock` — cross-process exclusive lock on `.hulak/.lock` (`flock` on Unix, `LockFileEx` on Windows). Read-modify-write writes can't lose each other's edits
- Decrypt-time size warning at 1 MiB (once per process, stderr)
- Set-time per-value warning at 64 KiB (stderr)

**CRUD commands** (`pkg/userFlags/env.go`)
- `set` — positional / `--stdin` / interactive no-echo prompt; rejects `>1` value positionals to avoid silent join surprises
- `get` — raw stdout, scriptable via `$()`, exit non-zero on missing key
- `list` — env names, no `--env`, styled header in TTY
- `keys` — masked by default (`••••`), `--show`, `--search` (substring or `filepath.Match` glob)
- `delete` — exit non-zero if key missing
- `edit` — opens `$EDITOR` (fallback `vi`) on `.hulak/edit-<env>.json`; TUI picker when `--env` omitted (no silent global default for destructive edits); refuses non-zero editor exits and unchanged saves; temp file 0600, atomic merge

**Table renderer** (`pkg/utils/table.go`)
- ANSI-aware aligner — column widths computed by visible runes, not bytes (so styled headers don't break alignment)
- Bold + italic + bright yellow header style; TTY-only via `stdoutHeaders` helper so scripts (`for env in $(hulak env list)`) stay clean
- 60-char per-cell soft truncation with rune-aware `Truncate`
- Replaces inline `text/tabwriter` calls in `keys`/`list`

**Framework fix** (`pkg/userFlags/command.go`)
- Iterative flag parsing — stdlib `flag.Parse` stops at first positional, leaving trailing flags unparsed. Now positionals and flags can interleave (`set FOO bar --env prod` works correctly). Cleans up the previous `parseRunArgs` workaround

**Bug fixes surfaced during testing**
- `utils.UserConfigDir` (Unix XDG branch) — was returning `$XDG_CONFIG_HOME` bare; now correctly appends `hulak`. Aligns with the Windows branch
- `vault.SetIdentity` — now `MkdirAll`s the parent dir so first-use bootstrap doesn't error
- `vault.EnsureKeypair` — three-branch logic:
  (1) both files match → use them
  (2) identity present, pubkey missing → derive pubkey from identity (no rotation)
  (3) identity missing AND `store.age` exists → refuse with `HelpfulError` pointing at the most likely cause (XDG drift)
  Previously a missing identity would silently rotate the keypair and brick existing ciphertext
- `init.go` — `InitDefaultProject` no longer overwrites a customized `apiOptions.hk.yaml` (refuses with "Kept existing" message)

**Docs** (`docs/store.md`, `docs/cli.md`)
- Removed status markers; description aligned with what's shipped vs aspirational
- `edit` row notes TUI picker default
- `keys` row lists `--search` flag
- Removed unimplemented `hulak env backup`/`restore` and `add-recipient --github` references (the latter filed as #172 once #144+#170 land)
- Dropped speculative passphrase-protected identity section

## Tests

- All cross-cutting helpers: `ValidateEnvName`, `Truncate`, `PrintTable` (with ANSI alignment), `WithStoreLock` (race-detector clean serialization test), versioned Marshal/Unmarshal, store-size and value-size warnings
- All six CRUD handlers, including stdin / prompt / glob-search / mask vs `--show` / picker stub / temp-file cleanup
- Bug-fix regressions:
  - `TestUserConfigDir_AppendsProjectNameToXDG`
  - `TestEnsureKeypairRecoversMissingPubKey`
  - `TestEnsureKeypairRefusesToOverwriteExistingStore`
  - `TestInitDefaultProject_PreservesUserCustomizedAPIOptions`

## Test plan

- [ ] `go test ./...` (passes locally with race detector)
- [ ] `golangci-lint run ./...` (0 issues)
- [ ] `GOOS=windows GOARCH=amd64 go build ./...` (cross-compile clean)
- [ ] Manual TTY pass — set/get/list/keys/delete/edit, picker, GUI editor with `--wait`, table alignment with styled header, scripting via piped output