### PR TITLE
feat: stdout/stderr discipline, exit codes, runner output polish

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,8 +115,8 @@ func ensureHulakProject() {
 		)
 	}
 
-	utils.PrintWarning("error: environment resolution requires a Hulak project")
-	fmt.Print("Initialize one here? [y/N] ")
+	utils.PrintErrorStderr("environment resolution requires a Hulak project")
+	fmt.Fprint(os.Stderr, "Initialize one here? [y/N] ")
 
 	scanner := bufio.NewScanner(os.Stdin)
 	if scanner.Scan() {

--- a/main.go
+++ b/main.go
@@ -20,6 +20,12 @@ func main() {
 	// inside ParseFlagsSubcmds. It only returns here for interactive mode.
 	flags, err := userflags.ParseFlagsSubcmds()
 	if err != nil {
+		// Runner failures already printed per-file detail via printOutcome
+		// and a summary line — exit silently with non-zero so we don't
+		// print the failure twice.
+		if runner.IsRunFailure(err) {
+			os.Exit(1)
+		}
 		utils.PanicRedAndExit("%v", err)
 	}
 
@@ -33,9 +39,21 @@ func main() {
 
 	var envMap map[string]any
 	if utils.FileHasTemplateVars(filePath) {
-		envMap = runner.InitializeProject(flags.Env, false)
+		var initErr error
+		envMap, initErr = runner.InitializeProject(flags.Env, false)
+		if initErr != nil {
+			utils.PanicRedAndExit("%v", initErr)
+		}
 	}
-	runner.ExecuteSingleFile(envMap, flags.Debug, filePath)
+
+	if err := runner.ExecuteSingleFile(envMap, flags.Debug, filePath); err != nil {
+		// Same suppression as above: runner.IsRunFailure means printOutcome
+		// already explained the failure on stderr; just flip the exit code.
+		if !runner.IsRunFailure(err) {
+			utils.PrintErrorStderr(err.Error())
+		}
+		os.Exit(1)
+	}
 }
 
 func runInteractiveFlow(env *string, envSet bool) string {

--- a/main.go
+++ b/main.go
@@ -49,6 +49,10 @@ func main() {
 	if err := runner.ExecuteSingleFile(envMap, flags.Debug, filePath); err != nil {
 		// Same suppression as above: runner.IsRunFailure means printOutcome
 		// already explained the failure on stderr; just flip the exit code.
+		// The non-IsRunFailure branch is defensive — handleAPIRequests is
+		// the only thing ExecuteSingleFile can fail on today, and it always
+		// returns *runFailureError. Kept so a future caller change doesn't
+		// silently swallow a different error type.
 		if !runner.IsRunFailure(err) {
 			utils.PrintErrorStderr(err.Error())
 		}

--- a/main.go
+++ b/main.go
@@ -122,15 +122,15 @@ func ensureHulakProject() {
 	if scanner.Scan() {
 		answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
 		if answer == "y" || answer == "yes" {
-			fmt.Println()
+			fmt.Fprintln(os.Stderr)
 			if err := envparser.CreateDefaultEnvs(nil); err != nil {
 				utils.PanicRedAndExit("%v", err)
 			}
-			fmt.Println()
+			fmt.Fprintln(os.Stderr)
 			return
 		}
 	}
 
-	fmt.Println("\nTo set up manually, run: hulak init")
+	fmt.Fprintln(os.Stderr, "\nTo set up manually, run: hulak init")
 	os.Exit(0)
 }

--- a/mise.toml
+++ b/mise.toml
@@ -32,9 +32,9 @@ vhs assets/gql.tape
 [tasks."test:api"]
 description = "Run E2E API calls"
 run = """
-go run . -fp e2etests/test_collection/form_data.hk.yaml &&
-go run . -fp e2etests/test_collection/url_encoded_form.hk.yaml &&
-go run . -fp e2etests/test_collection/graphql.hk.yml
+go run . -fp e2etests/test_collection/form_data.hk.yaml -env global &&
+go run . -fp e2etests/test_collection/url_encoded_form.hk.yaml -env global &&
+go run . -fp e2etests/test_collection/graphql.hk.yml -env global
 """
 
 [tasks."test:auth2"]

--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -142,19 +142,20 @@ func getFileMutex(filePath string) *sync.Mutex {
 	return mutex.(*sync.Mutex)
 }
 
-// processValueOf processes GetValueOf action
-// gets the value of key from a json file.
-// If a relative/absolute path is provided (e.g., "../../test.json"), it uses that exact path.
-// Otherwise, it searches for matching files and uses _response.json suffix for non-JSON files.
+// processValueOf processes GetValueOf action — returns the value at key from
+// the resolved JSON file, or "" if anything goes wrong. Errors are printed to
+// stderr; we can't return them because this is invoked as a template function
+// whose signature is fixed at func(...) any. Stdout stays clean so any
+// downstream `$(...)` capture still gets clean program output.
 func processValueOf(key, fileName string) any {
 	// Validate inputs
 	if key == "" || fileName == "" {
 		if key == "" {
-			utils.PrintRed(fmt.Sprintf("Provide key for %s action", utils.TemplateFuncGetValueOf))
+			utils.PrintErrorStderr(fmt.Sprintf("provide key for %s action", utils.TemplateFuncGetValueOf))
 		} else {
-			utils.PrintRed(
+			utils.PrintErrorStderr(
 				fmt.Sprintf(
-					"Provide fileName/path to key for %s action",
+					"provide fileName/path to key for %s action",
 					utils.TemplateFuncGetValueOf,
 				),
 			)
@@ -164,20 +165,20 @@ func processValueOf(key, fileName string) any {
 
 	jsonResFilePath, err := resolveJSONFilePath(fileName)
 	if err != nil {
-		utils.PrintRed(err.Error())
+		utils.PrintErrorStderr(err.Error())
 		return ""
 	}
 
 	content, err := readJSONFile(jsonResFilePath)
 	if err != nil {
-		utils.PrintRed(err.Error())
+		utils.PrintErrorStderr(err.Error())
 		return ""
 	}
 
 	result, err := extractValueByKey(key, content)
 	if err != nil {
-		utils.PrintRed(fmt.Sprintf(
-			"error while looking up the value: '%s'.\nMake sure '%s' exists and has key '%s'",
+		utils.PrintErrorStderr(fmt.Sprintf(
+			"looking up value '%s': make sure '%s' exists and has key '%s'",
 			key,
 			filepath.Join(
 				"...",
@@ -236,7 +237,7 @@ func resolveJSONFilePath(fileName string) (string, error) {
 
 	// Handle multiple matches warning
 	if len(yamlPathList) > 1 {
-		utils.PrintWarning(fmt.Sprintf("Multiple '%s'. Using %s", cleanFileName, yamlPathList[0]))
+		utils.PrintWarningStderr(fmt.Sprintf("multiple '%s' files; using %s", cleanFileName, yamlPathList[0]))
 	}
 
 	singlePath := yamlPathList[0]

--- a/pkg/apiCalls/apicalls.go
+++ b/pkg/apiCalls/apicalls.go
@@ -84,28 +84,37 @@ func StandardCallWithClient(
 }
 
 // SendAndSaveAPIRequest calls the PrepareStruct using the provided envMap
-// and makes the Api Call with StandardCall and prints the response in console
-func SendAndSaveAPIRequest(secretsMap map[string]any, path string, debug bool) error {
+// and makes the Api Call with StandardCall and prints the response in console.
+//
+// Returns the HTTP status string (e.g. "200 OK") so the runner can render
+// a per-file outcome line. On pre-flight failures (config parse, request
+// build) the status is empty. On transport failures (network down, DNS) the
+// status is also empty — the err carries the detail.
+func SendAndSaveAPIRequest(secretsMap map[string]any, path string, debug bool) (string, error) {
 	apiConfig, _, err := yamlparser.FinalStructForAPI(
 		path,
 		secretsMap,
 	)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	apiInfo, err := apiConfig.PrepareStruct()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	resp, err := StandardCall(apiInfo, debug)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	PrintAndSaveFinalResp(resp, path)
-	return nil
+	status := ""
+	if resp.Response != nil {
+		status = resp.Response.Status
+	}
+	return status, nil
 }
 
 // PrintAndSaveFinalResp prints and saves the CustomResponse

--- a/pkg/apiCalls/apicalls.go
+++ b/pkg/apiCalls/apicalls.go
@@ -117,15 +117,15 @@ func PrintAndSaveFinalResp(resp CustomResponse, path string) {
 		strBody = string(jsonData)
 		err = utils.PrintJSONColored(jsonData)
 		if err != nil {
-			utils.PrintRed(string(err.Error()))
+			utils.PrintErrorStderr(err.Error())
 		}
 	} else {
-		utils.PrintWarning("error serializing response: " + err.Error())
+		utils.PrintWarningStderr("serializing response: " + err.Error())
 		strBody = fmt.Sprintf("%+v", resp) // Fallback to raw struct
 		fmt.Println(strBody)
 	}
 
 	if err := evalAndWriteRes(strBody, path); err != nil {
-		utils.PrintRed("PrintAndSaveFinalResp " + err.Error())
+		utils.PrintErrorStderr("saving response: " + err.Error())
 	}
 }

--- a/pkg/apiCalls/prepare.go
+++ b/pkg/apiCalls/prepare.go
@@ -65,6 +65,7 @@ func processResponse(
 		return CustomResponse{
 			Response: &ResponseInfo{
 				StatusCode: resp.StatusCode,
+				Status:     resp.Status,
 				Body:       responseBody,
 			},
 			Duration: durationFormatted,

--- a/pkg/apiCalls/writeResponse.go
+++ b/pkg/apiCalls/writeResponse.go
@@ -33,7 +33,7 @@ func writeFile(path, suffixType, contentBody string) {
 	dir := filepath.Dir(path)
 	fullFilePath := filepath.Join(dir, fileName+suffixType)
 	if err := os.WriteFile(fullFilePath, []byte(contentBody), 0o600); err != nil {
-		utils.PrintRed("Error while saving file: %v\n" + err.Error())
+		utils.PrintErrorStderr("saving response file: " + err.Error())
 		return
 	}
 }

--- a/pkg/envparser/createFilesFolder.go
+++ b/pkg/envparser/createFilesFolder.go
@@ -2,6 +2,7 @@
 package envparser
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,8 +18,7 @@ func CreateEnvDirAndFiles(fileName string) (string, error) {
 
 	envDirpath, err := utils.CreatePath(defEnvDir)
 	if err != nil {
-		utils.PrintRed("Error creating filePath")
-		return "", err
+		return "", fmt.Errorf("creating env path: %w", err)
 	}
 
 	envFilePath := filepath.Join(envDirpath, fileName+defEnvSfx)

--- a/pkg/envparser/envparser.go
+++ b/pkg/envparser/envparser.go
@@ -46,9 +46,9 @@ func setEnvironment(envFromFlag string, isCli bool) (bool, error) {
 
 	// compare both values
 	if !slices.Contains(envFromFiles, envFromFlag) {
-		fmt.Printf("'%v.env' not found in the env directory\n", envFromFlag)
-		// ask to create the file, if the file does not exist
-		fmt.Printf("Create '%v.env'? (y/n)", envFromFlag)
+		// Prompts go to stderr so they never leak into $() capture.
+		fmt.Fprintf(os.Stderr, "'%v.env' not found in the env directory\n", envFromFlag)
+		fmt.Fprintf(os.Stderr, "Create '%v.env'? (y/n) ", envFromFlag)
 		reader := bufio.NewReader(os.Stdin)
 		responses, err := reader.ReadString('\n')
 		if err != nil {

--- a/pkg/envparser/envparser.go
+++ b/pkg/envparser/envparser.go
@@ -65,13 +65,13 @@ func setEnvironment(envFromFlag string, isCli bool) (bool, error) {
 		} else {
 			fileCreationSkipped = true
 			envFromFlag = utils.DefaultEnvVal
-			utils.PrintGreen("Skipping file Creation")
+			utils.PrintInfoStderr("Skipping file creation")
 		}
 	}
 
 	err = os.Setenv(utils.EnvKey, envFromFlag)
 	if isCli {
-		utils.PrintGreen("Environment: " + os.Getenv(utils.EnvKey))
+		utils.PrintInfoStderr("Environment: " + os.Getenv(utils.EnvKey))
 	}
 	if err != nil {
 		return fileCreationSkipped, err
@@ -209,7 +209,7 @@ Replaces global key with custom when keys repeat
 func GenerateSecretsMap(envFromFlag string, isCli bool) (map[string]any, error) {
 	if vault.DetectStore() == vault.StoreAge {
 		if isCli {
-			utils.PrintGreen("Environment: " + envFromFlag)
+			utils.PrintInfoStderr("Environment: " + envFromFlag)
 		}
 		return loadSecretsFromVault(envFromFlag)
 	}

--- a/pkg/migration/common.go
+++ b/pkg/migration/common.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/xaaha/hulak/pkg/utils"
 )
 
 // readJSON reads a JSON file and checks whether file exists, is empty,
@@ -76,7 +78,7 @@ func createMap(str string) map[string]any {
 	result := make(map[string]any)
 	// Unmarshal the cleaned JSON string into the result map
 	if err := json.Unmarshal([]byte(str), &result); err != nil {
-		fmt.Println("Error unmarshaling JSON:", err)
+		utils.PrintErrorStderr("unmarshaling JSON: " + err.Error())
 		return nil
 	}
 

--- a/pkg/migration/environment.go
+++ b/pkg/migration/environment.go
@@ -131,6 +131,6 @@ func migrateEnv(env Environment, comment ...string) error {
 		return utils.ColorError("error writing to file: %w", err)
 	}
 
-	utils.PrintGreen("\nEnvironment migration successful! " + utils.CheckMark)
+	utils.PrintSuccessStderr("Environment migration successful")
 	return nil
 }

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -27,18 +27,17 @@ func CompleteMigration(filePaths []string) error {
 
 			err = migrateEnv(env)
 			if err != nil {
-				return utils.ColorError("error migrating environment: %w", err)
+				return fmt.Errorf("error migrating environment: %w", err)
 			}
-			utils.PrintGreen(fmt.Sprintf("migrated '%s': ", path))
+			utils.PrintSuccessStderr(fmt.Sprintf("migrated '%s'", path))
 		case isCollection(jsonStr):
 			err := migrateCollection(jsonStr)
-			utils.PrintGreen(fmt.Sprintf("migrated '%s': ", path))
 			if err != nil {
-				utils.PrintWarning("Collection migration did not work for: " + path)
-				return err
+				return fmt.Errorf("collection migration failed for %s: %w", path, err)
 			}
+			utils.PrintSuccessStderr(fmt.Sprintf("migrated '%s'", path))
 		default:
-			utils.PrintWarning("Unknown Postman file format: " + path)
+			utils.PrintWarningStderr("Unknown Postman file format: " + path)
 		}
 	}
 

--- a/pkg/migration/pmCollection.go
+++ b/pkg/migration/pmCollection.go
@@ -352,8 +352,7 @@ func forEachRequest(collection *PmCollection, parentDirPath string) error {
 	// first, move collection variables to global.env
 	collectionVars := prepareVarStr(collection)
 	if err := migrateEnv(collectionVars, collection.Info.Name); err != nil {
-		utils.PrintRed("Error occurred while migrating Collection Variables")
-		return err
+		return fmt.Errorf("migrating collection variables: %w", err)
 	}
 
 	return processItems(collection.Item, parentDirPath)
@@ -512,6 +511,6 @@ func migrateCollection(jsonStr map[string]any) error {
 		return err
 	}
 
-	utils.PrintGreen("Collection Migration Successful! " + utils.CheckMark)
+	utils.PrintSuccessStderr("Collection migration successful")
 	return nil
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -112,14 +112,14 @@ func discoverFilePaths(
 			if !hasDirFlags {
 				utils.PanicRedAndExit("%v", err)
 			}
-			utils.PrintWarning(fmt.Sprintf("Warning with file flags: %v", err))
+			utils.PrintWarningStderr(fmt.Sprintf("file flags: %v", err))
 		}
 	}
 
 	if hasDirFlags {
 		dirPaths, err := apicalls.ListDirPaths(dir, dirseq)
 		if err != nil {
-			utils.PrintRed(fmt.Sprintf("Error processing directories: %v", err))
+			utils.PrintErrorStderr(fmt.Sprintf("processing directories: %v", err))
 		} else {
 			concurrentDir = dirPaths.Concurrent
 			sequentialDir = dirPaths.Sequential
@@ -139,20 +139,20 @@ func handleAPIRequests(
 ) {
 	if len(concurrentFiles) > 0 {
 		if len(concurrentFiles) > 1 || len(sequentialFiles) > 0 {
-			utils.PrintInfo(
+			utils.PrintInfoStderr(
 				fmt.Sprintf("Processing %d files concurrently...", len(concurrentFiles)),
 			)
 		}
 		runTasks(concurrentFiles, secrets, debug, fp)
 	}
 	if len(sequentialFiles) > 0 {
-		utils.PrintInfo(fmt.Sprintf("Processing %d files sequentially...", len(sequentialFiles)))
+		utils.PrintInfoStderr(fmt.Sprintf("Processing %d files sequentially...", len(sequentialFiles)))
 		processFilesSequentially(sequentialFiles, secrets, debug)
 	}
 
 	totalFiles := len(concurrentFiles) + len(sequentialFiles)
 	if totalFiles == 0 {
-		utils.PrintWarning(
+		utils.PrintWarningStderr(
 			"No files were processed. Please check your path or directory arguments.",
 		)
 	}
@@ -188,7 +188,7 @@ func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp s
 				for attempt := 0; attempt < maxRetries && !success; attempt++ {
 					if attempt > 0 {
 						backoffDuration := time.Duration(1<<(attempt-1)) * time.Second
-						utils.PrintWarning(fmt.Sprintf("Retrying %s (attempt %d/%d) after %v",
+						utils.PrintWarningStderr(fmt.Sprintf("Retrying %s (attempt %d/%d) after %v",
 							path, attempt+1, maxRetries, backoffDuration))
 						time.Sleep(backoffDuration)
 					}
@@ -210,20 +210,20 @@ func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp s
 					select {
 					case <-doneChan:
 						success = true
-						utils.PrintInfo(fmt.Sprintf("Processed '%s'", filepath.Base(path)))
+						utils.PrintInfoStderr(fmt.Sprintf("Processed '%s'", filepath.Base(path)))
 					case err := <-errChan:
 						lastErr = err
-						utils.PrintInfo(fmt.Sprintf("(attempt %d/%d)", attempt+1, maxRetries))
+						utils.PrintInfoStderr(fmt.Sprintf("(attempt %d/%d)", attempt+1, maxRetries))
 					case <-ctx.Done():
 						lastErr = fmt.Errorf("timeout after %v", timeout)
-						utils.PrintRed(fmt.Sprintf("Timeout processing %s after %v (attempt %d/%d)",
+						utils.PrintErrorStderr(fmt.Sprintf("timeout processing %s after %v (attempt %d/%d)",
 							path, timeout, attempt+1, maxRetries))
 					}
 					cancel()
 				}
 
 				if !success {
-					utils.PrintRed(fmt.Sprintf("Failed to process %s after %d attempts: %v",
+					utils.PrintErrorStderr(fmt.Sprintf("failed to process %s after %d attempts: %v",
 						path, maxRetries, lastErr))
 				}
 			}
@@ -256,9 +256,9 @@ func processFilesSequentially(filePaths []string, secretsMap map[string]any, deb
 		fileEnv := utils.CopyEnvMap(secretsMap)
 
 		err := processTask(path, fileEnv, debug)
-		utils.PrintInfo(fmt.Sprintf("Processed: '%s'", filepath.Base(path)))
+		utils.PrintInfoStderr(fmt.Sprintf("Processed: '%s'", filepath.Base(path)))
 		if err != nil {
-			utils.PrintRed(fmt.Sprintf("Error processing %s: %v", path, err))
+			utils.PrintErrorStderr(fmt.Sprintf("processing %s: %v", path, err))
 		}
 	}
 }
@@ -279,7 +279,7 @@ func generateFilePathList(fileName string, fp string) ([]string, error) {
 
 	if fileName != "" {
 		if matchingPaths, err := utils.ListMatchingFiles(fileName); err != nil {
-			utils.PrintRed(utils.ErrFilePathCollection + ": " + err.Error())
+			utils.PrintErrorStderr(utils.ErrFilePathCollection + ": " + err.Error())
 		} else {
 			filePathList = append(filePathList, matchingPaths...)
 		}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -222,6 +222,11 @@ type runFailureError struct {
 }
 
 func (e *runFailureError) Error() string {
+	// "request failed" is intentionally generic — current call sites all
+	// gate printing on IsRunFailure() and skip the message entirely (the
+	// per-file outcome line already explained what went wrong). It only
+	// surfaces if a future caller forgets the IsRunFailure check; in that
+	// case, generic-but-correct beats a stale chained message.
 	if e.total == 1 {
 		return "request failed"
 	}
@@ -306,8 +311,9 @@ func printOutcome(o outcome) {
 
 // splitErrorForOutcome flattens an error chain into one short headline plus
 // an optional hint extracted from the deepest error message. The headline is
-// wrapper-context (file path, key path) joined with " → " for readability;
-// the hint is the trailing actionable sentence (e.g. "Add ... to env/X.env").
+// the full wrapped chain with whitespace and ANSI codes normalized; the hint
+// is the trailing actionable sentence (e.g. "Add ... to env/X.env") pulled
+// onto its own line so the user's eye lands on it.
 //
 // Why bother: errors here are wrapped 3-4 deep ("substituting ...:
 // substituting ...: key X not found in environment Y. Add ..."). Printing
@@ -319,21 +325,24 @@ func splitErrorForOutcome(err error) (headline, hint string) {
 	}
 	msg := err.Error()
 	// Collapse any embedded newlines a wrapper may have injected (legacy
-	// ColorError used to do this). Spaces preserve the message; tabs become
-	// single spaces too. strings.Join keeps it compact.
+	// ColorError used to do this). Tabs collapse the same way so a stray
+	// indented line doesn't widen the rendered outcome.
 	msg = strings.ReplaceAll(msg, "\n", " ")
 	msg = strings.ReplaceAll(msg, "\t", " ")
 	// Trim any leftover ANSI escape codes from older wrappers.
 	msg = ansiInOutcome.ReplaceAllString(msg, "")
 	msg = strings.TrimSpace(msg)
 
-	// Heuristic split: the deepest error often ends with a sentence starting
-	// with "Add ...", "Run ...", or "Use ..." — a hint. Pull it onto its own
-	// line so the user's eye lands on it.
-	for _, marker := range []string{`. Add "`, ". Run ", ". Use ", ". Try "} {
-		if i := strings.LastIndex(msg, marker); i >= 0 {
-			return strings.TrimSpace(msg[:i+1]), strings.TrimSpace(msg[i+2:])
-		}
+	// Heuristic split: pull a trailing actionable sentence onto its own line.
+	// Marker is intentionally narrow — `. Add "` (period + space + Add + space
+	// + open quote) only matches the env-key-missing error format from
+	// envparser.formatMissingKeyError, where the quote anchors it to a real
+	// hint rather than free-form prose like "you must Add this header...".
+	// New hint-bearing errors should either use this exact format or, better,
+	// surface a typed hintError that this function can read explicitly.
+	const marker = `. Add "`
+	if i := strings.LastIndex(msg, marker); i >= 0 {
+		return strings.TrimSpace(msg[:i+1]), strings.TrimSpace(msg[i+2:])
 	}
 	return msg, ""
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -39,7 +39,10 @@ type Flags struct {
 }
 
 // Execute runs the full pipeline: discover files, resolve env, execute requests.
-func Execute(f *Flags) {
+// Returns an error if any request file failed — callers should propagate it
+// so the top-level exit code is non-zero on partial success. A nil error means
+// every dispatched request succeeded.
+func Execute(f *Flags) error {
 	fileList, concurrentDir, sequentialDir := discoverFilePaths(
 		f.File,
 		f.FilePath,
@@ -53,22 +56,26 @@ func Execute(f *Flags) {
 	var envMap map[string]any
 	if containsTemplateVars(allPaths) {
 		if !utils.IsHulakProject() {
-			utils.PanicRedAndExit("fatal: not a hulak project \n\nRun 'hulak init' to set up")
+			return fmt.Errorf("not a hulak project — run 'hulak init' to set up")
 		}
 		if !f.EnvSet {
 			selectedEnv, err := envSelector()
 			if err != nil {
-				utils.PanicRedAndExit("Environment selector error: %v", err)
+				return fmt.Errorf("environment selector: %w", err)
 			}
 			if selectedEnv == "" {
-				os.Exit(0)
+				return nil // user cancelled the picker; not an error
 			}
 			f.Env = selectedEnv
 		}
-		envMap = InitializeProject(f.Env, true)
+		var err error
+		envMap, err = InitializeProject(f.Env, true)
+		if err != nil {
+			return err
+		}
 	}
 
-	handleAPIRequests(
+	return handleAPIRequests(
 		envMap,
 		f.Debug,
 		append(fileList, concurrentDir...),
@@ -79,8 +86,8 @@ func Execute(f *Flags) {
 
 // ExecuteSingleFile runs a single file through the pipeline.
 // Used by interactive mode where the file is already known.
-func ExecuteSingleFile(envMap map[string]any, debug bool, filePath string) {
-	handleAPIRequests(envMap, debug, []string{filePath}, nil, filePath)
+func ExecuteSingleFile(envMap map[string]any, debug bool, filePath string) error {
+	return handleAPIRequests(envMap, debug, []string{filePath}, nil, filePath)
 }
 
 // containsTemplateVars returns true if any file in the list uses template vars.
@@ -90,17 +97,17 @@ func containsTemplateVars(paths []string) bool {
 
 // InitializeProject creates the env setup and returns the secrets map.
 // In vault mode (.hulak/store.age), skips creating the legacy env/ folder.
-func InitializeProject(env string, isCli bool) map[string]any {
+func InitializeProject(env string, isCli bool) (map[string]any, error) {
 	if vault.DetectStore() != vault.StoreAge {
 		if err := envparser.CreateDefaultEnvs(nil); err != nil {
-			utils.PanicRedAndExit("%v", err)
+			return nil, err
 		}
 	}
 	envMap, err := envparser.GenerateSecretsMap(env, isCli)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return envMap
+	return envMap, nil
 }
 
 // discoverFilePaths collects all file paths from -f, -fp, -dir, and -dirseq flags.
@@ -143,13 +150,15 @@ type outcome struct {
 }
 
 // handleAPIRequests processes API requests from pre-discovered file lists.
+// Returns nil if every dispatched request succeeded; otherwise an error
+// summarizing the failures so the call site can propagate a non-zero exit.
 func handleAPIRequests(
 	secrets map[string]any,
 	debug bool,
 	concurrentFiles []string,
 	sequentialFiles []string,
 	fp string,
-) {
+) error {
 	totalFiles := len(concurrentFiles) + len(sequentialFiles)
 	// Per-file outcome lines only help when multiple files are running — they
 	// let the user track which file finished. With a single file there's
@@ -180,12 +189,51 @@ func handleAPIRequests(
 		utils.PrintWarningStderr(
 			"No files were processed. Please check your path or directory arguments.",
 		)
-		return
+		return nil
 	}
 
 	if multiFile {
 		printRunSummary(outcomes, time.Since(overallStart))
 	}
+
+	// Aggregate failures into a single error so the exit code reflects them.
+	// Per-file detail has already been printed by printOutcome; the error
+	// returned here is just a short headline a top-level handler can surface
+	// without duplicating what's already on screen.
+	failed := 0
+	for _, o := range outcomes {
+		if !o.ok {
+			failed++
+		}
+	}
+	if failed > 0 {
+		return &runFailureError{failed: failed, total: totalFiles}
+	}
+	return nil
+}
+
+// runFailureError signals "n of m files failed" so the exit code flips
+// non-zero. The top-level error handler can recognize this type and skip
+// printing — the per-file outcome lines and the summary have already
+// communicated the failures to the user.
+type runFailureError struct {
+	failed int
+	total  int
+}
+
+func (e *runFailureError) Error() string {
+	if e.total == 1 {
+		return "request failed"
+	}
+	return fmt.Sprintf("%d of %d files failed", e.failed, e.total)
+}
+
+// IsRunFailure reports whether err originated from a runner pipeline failure
+// (one or more request files failed). Callers use this to suppress redundant
+// "error: ..." printing — printOutcome already showed the detail.
+func IsRunFailure(err error) bool {
+	var rf *runFailureError
+	return errors.As(err, &rf)
 }
 
 // printRunSummary prints "✓ N succeeded, ✗ M failed in T" plus a list of

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -129,6 +129,16 @@ func discoverFilePaths(
 	return fileList, concurrentDir, sequentialDir
 }
 
+// outcome captures the result of executing one request file. Used to render
+// the per-file outcome line and the end-of-run summary.
+type outcome struct {
+	path     string        // request file path
+	ok       bool          // true if request returned without error (any status code)
+	status   string        // HTTP status string, e.g. "200 OK"; empty for non-API kinds and pre-flight errors
+	duration time.Duration // wall-clock time for the request itself
+	err      error         // non-nil on failure
+}
+
 // handleAPIRequests processes API requests from pre-discovered file lists.
 func handleAPIRequests(
 	secrets map[string]any,
@@ -138,10 +148,13 @@ func handleAPIRequests(
 	fp string,
 ) {
 	totalFiles := len(concurrentFiles) + len(sequentialFiles)
-	// Per-file "Processed 'X'" lines only help when multiple files are running
-	// — they let the user track which file finished. With a single file there
-	// is exactly one outcome and the line is just noise; suppress it.
+	// Per-file outcome lines only help when multiple files are running — they
+	// let the user track which file finished. With a single file there's
+	// exactly one outcome and the line is just noise; suppress it.
 	multiFile := totalFiles > 1
+
+	overallStart := time.Now()
+	var outcomes []outcome
 
 	if len(concurrentFiles) > 0 {
 		if len(concurrentFiles) > 1 || len(sequentialFiles) > 0 {
@@ -149,24 +162,88 @@ func handleAPIRequests(
 				fmt.Sprintf("Processing %d files concurrently...", len(concurrentFiles)),
 			)
 		}
-		runTasks(concurrentFiles, secrets, debug, fp, multiFile)
+		outcomes = append(outcomes, runTasks(concurrentFiles, secrets, debug, fp, multiFile)...)
 	}
 	if len(sequentialFiles) > 0 {
 		utils.PrintInfoStderr(fmt.Sprintf("Processing %d files sequentially...", len(sequentialFiles)))
-		processFilesSequentially(sequentialFiles, secrets, debug, multiFile)
+		outcomes = append(outcomes, processFilesSequentially(sequentialFiles, secrets, debug, multiFile)...)
 	}
 
 	if totalFiles == 0 {
 		utils.PrintWarningStderr(
 			"No files were processed. Please check your path or directory arguments.",
 		)
+		return
+	}
+
+	if multiFile {
+		printRunSummary(outcomes, time.Since(overallStart))
 	}
 }
 
-// runTasks manages the go tasks with a limited worker pool.
-// multiFile gates the per-file "Processed 'X'" line — useful when several
-// files are interleaving, useless and noisy for a single file.
-func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp string, multiFile bool) {
+// printRunSummary prints "✓ N succeeded, ✗ M failed in T" plus a list of
+// failed file paths. Only invoked for multi-file runs — single-file outcome
+// is already obvious from the per-file outcome line.
+func printRunSummary(outcomes []outcome, total time.Duration) {
+	succeeded := 0
+	var failed []outcome
+	for _, o := range outcomes {
+		if o.ok {
+			succeeded++
+		} else {
+			failed = append(failed, o)
+		}
+	}
+
+	utils.PrintInfoStderr(fmt.Sprintf(
+		"%d succeeded, %d failed in %s", succeeded, len(failed), formatDuration(total),
+	))
+	for _, f := range failed {
+		utils.PrintInfoStderr("  ✗ " + filepath.Base(f.path))
+	}
+}
+
+// formatDuration renders a duration tightly: 142ms, 1.2s, 1m23s.
+// time.Duration's String() can yield clutter like 1.234567s; this trims it.
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Second:
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	case d < time.Minute:
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	default:
+		m := int(d / time.Minute)
+		s := int((d % time.Minute) / time.Second)
+		return fmt.Sprintf("%dm%ds", m, s)
+	}
+}
+
+// printOutcome renders one ✓/✗ line per file. status is empty for non-API
+// kinds (Auth2, future kinds) — the line just shows the timing.
+func printOutcome(o outcome) {
+	name := filepath.Base(o.path)
+	dur := formatDuration(o.duration)
+	if o.ok {
+		bracket := dur
+		if o.status != "" {
+			bracket = o.status + ", " + dur
+		}
+		utils.PrintSuccessStderr(fmt.Sprintf("%s [%s]", name, bracket))
+		return
+	}
+	// Failure path: status may still be set if the HTTP call succeeded but
+	// downstream processing failed. Surface whatever we have.
+	bracket := dur
+	if o.status != "" {
+		bracket = o.status + ", " + dur
+	}
+	utils.PrintErrorStderr(fmt.Sprintf("%s [%s]: %v", name, bracket, o.err))
+}
+
+// runTasks manages the go tasks with a limited worker pool. Returns one
+// outcome per file in the order they finished. multiFile gates whether the
+// per-file outcome line is printed (skipped for single-file runs).
+func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp string, multiFile bool) []outcome {
 	maxWorkers := utils.GetWorkers(nil)
 	maxRetries := 3
 	timeout := 60 * time.Second
@@ -177,6 +254,7 @@ func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp s
 
 	var wg sync.WaitGroup
 	taskChan := make(chan string, len(filePathList))
+	resultChan := make(chan outcome, len(filePathList))
 
 	for _, path := range filePathList {
 		taskChan <- path
@@ -189,10 +267,9 @@ func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp s
 			defer wg.Done()
 
 			for path := range taskChan {
-				success := false
-				var lastErr error
+				var final outcome
 
-				for attempt := 0; attempt < maxRetries && !success; attempt++ {
+				for attempt := 0; attempt < maxRetries; attempt++ {
 					if attempt > 0 {
 						backoffDuration := time.Duration(1<<(attempt-1)) * time.Second
 						utils.PrintWarningStderr(fmt.Sprintf("Retrying %s (attempt %d/%d) after %v",
@@ -202,78 +279,85 @@ func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp s
 
 					ctx, cancel := context.WithTimeout(context.Background(), timeout)
 
-					doneChan := make(chan struct{})
-					errChan := make(chan error, 1)
-
+					resCh := make(chan outcome, 1)
 					go func() {
-						err := processTask(path, utils.CopyEnvMap(secretsMap), debug)
-						if err != nil {
-							errChan <- err
-						} else {
-							close(doneChan)
-						}
+						resCh <- processTask(path, utils.CopyEnvMap(secretsMap), debug)
 					}()
 
 					select {
-					case <-doneChan:
-						success = true
-						if multiFile {
-							utils.PrintInfoStderr(fmt.Sprintf("Processed '%s'", filepath.Base(path)))
-						}
-					case err := <-errChan:
-						lastErr = err
-						utils.PrintInfoStderr(fmt.Sprintf("(attempt %d/%d)", attempt+1, maxRetries))
+					case res := <-resCh:
+						final = res
 					case <-ctx.Done():
-						lastErr = fmt.Errorf("timeout after %v", timeout)
-						utils.PrintErrorStderr(fmt.Sprintf("timeout processing %s after %v (attempt %d/%d)",
-							path, timeout, attempt+1, maxRetries))
+						final = outcome{
+							path: path,
+							ok:   false,
+							err:  fmt.Errorf("timeout after %v", timeout),
+						}
 					}
 					cancel()
+
+					if final.ok {
+						break
+					}
 				}
 
-				if !success {
-					utils.PrintErrorStderr(fmt.Sprintf("failed to process %s after %d attempts: %v",
-						path, maxRetries, lastErr))
+				// Single-file mode: response body prints to stdout already, so
+				// suppress the success outcome line on success. Failures still
+				// surface — a silent error must not look like success.
+				if multiFile || !final.ok {
+					printOutcome(final)
 				}
+				resultChan <- final
 			}
 		}(i)
 	}
 	wg.Wait()
+	close(resultChan)
+
+	outcomes := make([]outcome, 0, len(filePathList))
+	for o := range resultChan {
+		outcomes = append(outcomes, o)
+	}
+	return outcomes
 }
 
-// processTask handles a single task
-func processTask(path string, secretsMap map[string]any, debug bool) error {
+// processTask handles a single task and returns a structured outcome.
+// Wall-clock duration is measured around the dispatched call so it reflects
+// the actual API latency (plus YAML parse time, which is small).
+func processTask(path string, secretsMap map[string]any, debug bool) outcome {
+	start := time.Now()
 	config, err := yamlparser.ParseConfig(path, secretsMap)
 	if err != nil {
-		errMsg := fmt.Sprintf("failed to parse config %v", err)
-		return utils.ColorError(errMsg)
+		return outcome{path: path, ok: false, duration: time.Since(start), err: fmt.Errorf("failed to parse config: %w", err)}
 	}
 
 	switch {
 	case config.IsAuth():
-		return features.SendAPIRequestForAuth2(secretsMap, path, debug)
+		err := features.SendAPIRequestForAuth2(secretsMap, path, debug)
+		return outcome{path: path, ok: err == nil, duration: time.Since(start), err: err}
 	case (config.IsAPI() || config.IsGraphql()):
-		return apicalls.SendAndSaveAPIRequest(secretsMap, path, debug)
+		status, err := apicalls.SendAndSaveAPIRequest(secretsMap, path, debug)
+		return outcome{path: path, ok: err == nil, status: status, duration: time.Since(start), err: err}
 	default:
-		return fmt.Errorf("unsupported kind in file: %s", path)
+		return outcome{path: path, ok: false, duration: time.Since(start), err: fmt.Errorf("unsupported kind in file: %s", path)}
 	}
 }
 
-// processFilesSequentially handles files one by one.
-// multiFile gates the per-file success line — useless noise for a single file.
-func processFilesSequentially(filePaths []string, secretsMap map[string]any, debug bool, multiFile bool) {
+// processFilesSequentially handles files one by one. Returns outcomes in
+// execution order. multiFile gates the per-file outcome line — single-file
+// mode keeps stderr quiet on success since the response body already prints
+// to stdout; failures always surface so a silent error isn't mistaken for OK.
+func processFilesSequentially(filePaths []string, secretsMap map[string]any, debug bool, multiFile bool) []outcome {
+	outcomes := make([]outcome, 0, len(filePaths))
 	for _, path := range filePaths {
 		fileEnv := utils.CopyEnvMap(secretsMap)
-
-		err := processTask(path, fileEnv, debug)
-		if err != nil {
-			utils.PrintErrorStderr(fmt.Sprintf("processing %s: %v", path, err))
-			continue
+		o := processTask(path, fileEnv, debug)
+		if multiFile || !o.ok {
+			printOutcome(o)
 		}
-		if multiFile {
-			utils.PrintInfoStderr(fmt.Sprintf("Processed '%s'", filepath.Base(path)))
-		}
+		outcomes = append(outcomes, o)
 	}
+	return outcomes
 }
 
 // generateFilePathList returns a slice of file paths based on the flags -f and -fp.

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -4,10 +4,13 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -165,8 +168,12 @@ func handleAPIRequests(
 		outcomes = append(outcomes, runTasks(concurrentFiles, secrets, debug, fp, multiFile)...)
 	}
 	if len(sequentialFiles) > 0 {
-		utils.PrintInfoStderr(fmt.Sprintf("Processing %d files sequentially...", len(sequentialFiles)))
-		outcomes = append(outcomes, processFilesSequentially(sequentialFiles, secrets, debug, multiFile)...)
+		utils.PrintInfoStderr(
+			fmt.Sprintf("Processing %d files sequentially...", len(sequentialFiles)),
+		)
+		outcomes = append(
+			outcomes,
+			processFilesSequentially(sequentialFiles, secrets, debug, multiFile)...)
 	}
 
 	if totalFiles == 0 {
@@ -219,7 +226,10 @@ func formatDuration(d time.Duration) string {
 }
 
 // printOutcome renders one ✓/✗ line per file. status is empty for non-API
-// kinds (Auth2, future kinds) — the line just shows the timing.
+// kinds (Auth2, future kinds) — the line just shows the timing. Errors are
+// flattened to a single line so the outcome list stays scannable; if the
+// underlying error has actionable detail (e.g. a hint), it gets printed on
+// a follow-up indented line so the cause is still discoverable.
 func printOutcome(o outcome) {
 	name := filepath.Base(o.path)
 	dur := formatDuration(o.duration)
@@ -237,13 +247,64 @@ func printOutcome(o outcome) {
 	if o.status != "" {
 		bracket = o.status + ", " + dur
 	}
-	utils.PrintErrorStderr(fmt.Sprintf("%s [%s]: %v", name, bracket, o.err))
+	headline, hint := splitErrorForOutcome(o.err)
+	utils.PrintErrorStderr(fmt.Sprintf("%s [%s]: %s", name, bracket, headline))
+	if hint != "" {
+		// Two-space indent groups the hint visually under the failure line —
+		// matches the summary's `  ✗ X` indent so the eye reads them as one block.
+		fmt.Fprintf(os.Stderr, "  %s\n", hint)
+	}
 }
+
+// splitErrorForOutcome flattens an error chain into one short headline plus
+// an optional hint extracted from the deepest error message. The headline is
+// wrapper-context (file path, key path) joined with " → " for readability;
+// the hint is the trailing actionable sentence (e.g. "Add ... to env/X.env").
+//
+// Why bother: errors here are wrapped 3-4 deep ("substituting ...:
+// substituting ...: key X not found in environment Y. Add ..."). Printing
+// the whole chain in one line is unreadable; printing only the leaf loses
+// the file/key context. We keep both, just present them tidily.
+func splitErrorForOutcome(err error) (headline, hint string) {
+	if err == nil {
+		return "", ""
+	}
+	msg := err.Error()
+	// Collapse any embedded newlines a wrapper may have injected (legacy
+	// ColorError used to do this). Spaces preserve the message; tabs become
+	// single spaces too. strings.Join keeps it compact.
+	msg = strings.ReplaceAll(msg, "\n", " ")
+	msg = strings.ReplaceAll(msg, "\t", " ")
+	// Trim any leftover ANSI escape codes from older wrappers.
+	msg = ansiInOutcome.ReplaceAllString(msg, "")
+	msg = strings.TrimSpace(msg)
+
+	// Heuristic split: the deepest error often ends with a sentence starting
+	// with "Add ...", "Run ...", or "Use ..." — a hint. Pull it onto its own
+	// line so the user's eye lands on it.
+	for _, marker := range []string{`. Add "`, ". Run ", ". Use ", ". Try "} {
+		if i := strings.LastIndex(msg, marker); i >= 0 {
+			return strings.TrimSpace(msg[:i+1]), strings.TrimSpace(msg[i+2:])
+		}
+	}
+	return msg, ""
+}
+
+// ansiInOutcome strips ANSI SGR escape sequences from error strings.
+// Older wrappers (ColorError) baked colors into errors; we don't want those
+// surviving into the outcome line.
+var ansiInOutcome = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 // runTasks manages the go tasks with a limited worker pool. Returns one
 // outcome per file in the order they finished. multiFile gates whether the
 // per-file outcome line is printed (skipped for single-file runs).
-func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp string, multiFile bool) []outcome {
+func runTasks(
+	filePathList []string,
+	secretsMap map[string]any,
+	debug bool,
+	fp string,
+	multiFile bool,
+) []outcome {
 	maxWorkers := utils.GetWorkers(nil)
 	maxRetries := 3
 	timeout := 60 * time.Second
@@ -273,7 +334,7 @@ func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp s
 					if attempt > 0 {
 						backoffDuration := time.Duration(1<<(attempt-1)) * time.Second
 						utils.PrintWarningStderr(fmt.Sprintf("Retrying %s (attempt %d/%d) after %v",
-							path, attempt+1, maxRetries, backoffDuration))
+							filepath.Base(path), attempt+1, maxRetries, backoffDuration))
 						time.Sleep(backoffDuration)
 					}
 
@@ -296,7 +357,7 @@ func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp s
 					}
 					cancel()
 
-					if final.ok {
+					if final.ok || !isRetryable(final.err) {
 						break
 					}
 				}
@@ -321,6 +382,26 @@ func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp s
 	return outcomes
 }
 
+// configError marks an error that came from parsing/validating the YAML
+// config (not from the network). The retry loop checks for this type and
+// fails fast — retrying a malformed file or missing env var won't help and
+// just delays the user seeing the real problem.
+type configError struct{ err error }
+
+func (e *configError) Error() string { return e.err.Error() }
+func (e *configError) Unwrap() error { return e.err }
+
+// isRetryable reports whether the runner should retry after this error.
+// Network/transport errors and timeouts are retryable; config errors and
+// unsupported-kind errors are not.
+func isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var cfgErr *configError
+	return !errors.As(err, &cfgErr)
+}
+
 // processTask handles a single task and returns a structured outcome.
 // Wall-clock duration is measured around the dispatched call so it reflects
 // the actual API latency (plus YAML parse time, which is small).
@@ -328,7 +409,7 @@ func processTask(path string, secretsMap map[string]any, debug bool) outcome {
 	start := time.Now()
 	config, err := yamlparser.ParseConfig(path, secretsMap)
 	if err != nil {
-		return outcome{path: path, ok: false, duration: time.Since(start), err: fmt.Errorf("failed to parse config: %w", err)}
+		return outcome{path: path, ok: false, duration: time.Since(start), err: &configError{err}}
 	}
 
 	switch {
@@ -337,9 +418,20 @@ func processTask(path string, secretsMap map[string]any, debug bool) outcome {
 		return outcome{path: path, ok: err == nil, duration: time.Since(start), err: err}
 	case (config.IsAPI() || config.IsGraphql()):
 		status, err := apicalls.SendAndSaveAPIRequest(secretsMap, path, debug)
-		return outcome{path: path, ok: err == nil, status: status, duration: time.Since(start), err: err}
+		return outcome{
+			path:     path,
+			ok:       err == nil,
+			status:   status,
+			duration: time.Since(start),
+			err:      err,
+		}
 	default:
-		return outcome{path: path, ok: false, duration: time.Since(start), err: fmt.Errorf("unsupported kind in file: %s", path)}
+		return outcome{
+			path:     path,
+			ok:       false,
+			duration: time.Since(start),
+			err:      &configError{fmt.Errorf("unsupported kind in file: %s", path)},
+		}
 	}
 }
 
@@ -347,7 +439,12 @@ func processTask(path string, secretsMap map[string]any, debug bool) outcome {
 // execution order. multiFile gates the per-file outcome line — single-file
 // mode keeps stderr quiet on success since the response body already prints
 // to stdout; failures always surface so a silent error isn't mistaken for OK.
-func processFilesSequentially(filePaths []string, secretsMap map[string]any, debug bool, multiFile bool) []outcome {
+func processFilesSequentially(
+	filePaths []string,
+	secretsMap map[string]any,
+	debug bool,
+	multiFile bool,
+) []outcome {
 	outcomes := make([]outcome, 0, len(filePaths))
 	for _, path := range filePaths {
 		fileEnv := utils.CopyEnvMap(secretsMap)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -137,20 +137,25 @@ func handleAPIRequests(
 	sequentialFiles []string,
 	fp string,
 ) {
+	totalFiles := len(concurrentFiles) + len(sequentialFiles)
+	// Per-file "Processed 'X'" lines only help when multiple files are running
+	// — they let the user track which file finished. With a single file there
+	// is exactly one outcome and the line is just noise; suppress it.
+	multiFile := totalFiles > 1
+
 	if len(concurrentFiles) > 0 {
 		if len(concurrentFiles) > 1 || len(sequentialFiles) > 0 {
 			utils.PrintInfoStderr(
 				fmt.Sprintf("Processing %d files concurrently...", len(concurrentFiles)),
 			)
 		}
-		runTasks(concurrentFiles, secrets, debug, fp)
+		runTasks(concurrentFiles, secrets, debug, fp, multiFile)
 	}
 	if len(sequentialFiles) > 0 {
 		utils.PrintInfoStderr(fmt.Sprintf("Processing %d files sequentially...", len(sequentialFiles)))
-		processFilesSequentially(sequentialFiles, secrets, debug)
+		processFilesSequentially(sequentialFiles, secrets, debug, multiFile)
 	}
 
-	totalFiles := len(concurrentFiles) + len(sequentialFiles)
 	if totalFiles == 0 {
 		utils.PrintWarningStderr(
 			"No files were processed. Please check your path or directory arguments.",
@@ -158,8 +163,10 @@ func handleAPIRequests(
 	}
 }
 
-// runTasks manages the go tasks with a limited worker pool
-func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp string) {
+// runTasks manages the go tasks with a limited worker pool.
+// multiFile gates the per-file "Processed 'X'" line — useful when several
+// files are interleaving, useless and noisy for a single file.
+func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp string, multiFile bool) {
 	maxWorkers := utils.GetWorkers(nil)
 	maxRetries := 3
 	timeout := 60 * time.Second
@@ -210,7 +217,9 @@ func runTasks(filePathList []string, secretsMap map[string]any, debug bool, fp s
 					select {
 					case <-doneChan:
 						success = true
-						utils.PrintInfoStderr(fmt.Sprintf("Processed '%s'", filepath.Base(path)))
+						if multiFile {
+							utils.PrintInfoStderr(fmt.Sprintf("Processed '%s'", filepath.Base(path)))
+						}
 					case err := <-errChan:
 						lastErr = err
 						utils.PrintInfoStderr(fmt.Sprintf("(attempt %d/%d)", attempt+1, maxRetries))
@@ -250,15 +259,19 @@ func processTask(path string, secretsMap map[string]any, debug bool) error {
 	}
 }
 
-// processFilesSequentially handles files one by one
-func processFilesSequentially(filePaths []string, secretsMap map[string]any, debug bool) {
+// processFilesSequentially handles files one by one.
+// multiFile gates the per-file success line — useless noise for a single file.
+func processFilesSequentially(filePaths []string, secretsMap map[string]any, debug bool, multiFile bool) {
 	for _, path := range filePaths {
 		fileEnv := utils.CopyEnvMap(secretsMap)
 
 		err := processTask(path, fileEnv, debug)
-		utils.PrintInfoStderr(fmt.Sprintf("Processed: '%s'", filepath.Base(path)))
 		if err != nil {
 			utils.PrintErrorStderr(fmt.Sprintf("processing %s: %v", path, err))
+			continue
+		}
+		if multiFile {
+			utils.PrintInfoStderr(fmt.Sprintf("Processed '%s'", filepath.Base(path)))
 		}
 	}
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -1,9 +1,12 @@
 package runner
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestGenerateFilePathList_FpOnly(t *testing.T) {
@@ -274,5 +277,158 @@ func TestDiscoverFilePaths_FpAndDirTogether(t *testing.T) {
 	}
 	if len(sequential) != 0 {
 		t.Errorf("sequential should be empty, got %v", sequential)
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{"zero", 0, "0ms"},
+		{"sub-millisecond rounds down", 500 * time.Microsecond, "0ms"},
+		{"under one second", 142 * time.Millisecond, "142ms"},
+		{"just under one second", 999 * time.Millisecond, "999ms"},
+		{"one second exactly switches to seconds", time.Second, "1.0s"},
+		{"under one minute", 1234 * time.Millisecond, "1.2s"},
+		{"one minute exactly", time.Minute, "1m0s"},
+		{"minutes and seconds", 83 * time.Second, "1m23s"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatDuration(tc.d); got != tc.want {
+				t.Errorf("formatDuration(%v) = %q, want %q", tc.d, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSplitErrorForOutcome(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		wantHeadline string
+		wantHint     string
+	}{
+		{
+			name:         "nil error returns empty",
+			err:          nil,
+			wantHeadline: "",
+			wantHint:     "",
+		},
+		{
+			name:         "plain error has no hint",
+			err:          errors.New("something broke"),
+			wantHeadline: "something broke",
+			wantHint:     "",
+		},
+		{
+			name: "env-key-missing hint is split off",
+			err: errors.New(
+				`substituting "client_id": key "client_id" not found in environment "global". Add "client_id=<value>" to env/global.env`,
+			),
+			wantHeadline: `substituting "client_id": key "client_id" not found in environment "global".`,
+			wantHint:     `Add "client_id=<value>" to env/global.env`,
+		},
+		{
+			name:         "marker requires opening quote — false-positive prose stays unsplit",
+			err:          errors.New("you must Add this header before retrying"),
+			wantHeadline: "you must Add this header before retrying",
+			wantHint:     "",
+		},
+		{
+			name:         "embedded newlines collapse to spaces",
+			err:          errors.New("line one\nline two\nline three"),
+			wantHeadline: "line one line two line three",
+			wantHint:     "",
+		},
+		{
+			name:         "ANSI escape codes are stripped",
+			err:          errors.New("\x1b[31mred error\x1b[0m happened"),
+			wantHeadline: "red error happened",
+			wantHint:     "",
+		},
+		{
+			name: "ANSI + newline + hint together",
+			err: errors.New(
+				"\x1b[31mwrapped\x1b[0m:\nkey \"X\" not found in environment \"prod\". Add \"X=<value>\" to env/prod.env",
+			),
+			wantHeadline: `wrapped: key "X" not found in environment "prod".`,
+			wantHint:     `Add "X=<value>" to env/prod.env`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotHL, gotHint := splitErrorForOutcome(tc.err)
+			if gotHL != tc.wantHeadline {
+				t.Errorf("headline = %q, want %q", gotHL, tc.wantHeadline)
+			}
+			if gotHint != tc.wantHint {
+				t.Errorf("hint = %q, want %q", gotHint, tc.wantHint)
+			}
+		})
+	}
+}
+
+func TestRunFailureError_String(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *runFailureError
+		want string
+	}{
+		{"single file", &runFailureError{failed: 1, total: 1}, "request failed"},
+		{"multiple files", &runFailureError{failed: 2, total: 5}, "2 of 5 files failed"},
+		{"all failed", &runFailureError{failed: 4, total: 4}, "4 of 4 files failed"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsRunFailure(t *testing.T) {
+	rf := &runFailureError{failed: 1, total: 3}
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is not a run failure", nil, false},
+		{"plain error is not", errors.New("boom"), false},
+		{"runFailureError is", rf, true},
+		{"wrapped runFailureError is detectable via errors.As", fmt.Errorf("wrap: %w", rf), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsRunFailure(tc.err); got != tc.want {
+				t.Errorf("IsRunFailure(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	cfgErr := &configError{errors.New("missing key")}
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil never retries", nil, false},
+		{"configError fails fast", cfgErr, false},
+		{"wrapped configError fails fast (errors.As)", fmt.Errorf("wrap: %w", cfgErr), false},
+		{"plain error retries (assumed transport)", errors.New("dial tcp: timeout"), true},
+		{"context.DeadlineExceeded-style retries", errors.New("timeout after 60s"), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRetryable(tc.err); got != tc.want {
+				t.Errorf("isRetryable(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
 	}
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -177,13 +177,9 @@ func TestExecute_EnvNotSet_CallsSelector(t *testing.T) {
 		FilePath: tmpFile,
 	}
 
-	// Execute will call IsHulakProject which will be false in test context,
-	// so it would PanicRedAndExit. We only need to verify the selector is
-	// called BEFORE that point. Use recover to catch the exit.
-	func() {
-		defer func() { _ = recover() }()
-		Execute(f)
-	}()
+	// Execute will return an error in test context (no hulak project), but we
+	// only care that envSelector ran first. Discard the error.
+	_ = Execute(f)
 
 	if !called {
 		t.Error("envSelector should be called when EnvSet is false and files have template vars")
@@ -215,10 +211,7 @@ func TestExecute_EnvSet_SkipsSelector(t *testing.T) {
 		FilePath: tmpFile,
 	}
 
-	func() {
-		defer func() { _ = recover() }()
-		Execute(f)
-	}()
+	_ = Execute(f)
 
 	if called {
 		t.Error("envSelector should NOT be called when EnvSet is true")
@@ -250,10 +243,7 @@ func TestExecute_NoTemplateVars_SkipsSelector(t *testing.T) {
 		FilePath: tmpFile,
 	}
 
-	func() {
-		defer func() { _ = recover() }()
-		Execute(f)
-	}()
+	_ = Execute(f)
 
 	if called {
 		t.Error("envSelector should NOT be called when files have no template vars")

--- a/pkg/tui/envselect/envselect.go
+++ b/pkg/tui/envselect/envselect.go
@@ -51,12 +51,12 @@ func envItems() []string {
 	if vault.DetectStore() == vault.StoreAge {
 		identity, err := vault.LoadIdentity()
 		if err != nil {
-			utils.PrintRed(fmt.Sprintf("vault: %v", err))
+			utils.PrintErrorStderr(fmt.Sprintf("vault: %v", err))
 			return nil
 		}
 		store, err := vault.ReadStore(identity)
 		if err != nil {
-			utils.PrintRed(fmt.Sprintf("vault: failed to read store: %v", err))
+			utils.PrintErrorStderr(fmt.Sprintf("vault: failed to read store: %v", err))
 			return nil
 		}
 		return store.ListEnvs()

--- a/pkg/userFlags/command.go
+++ b/pkg/userFlags/command.go
@@ -70,12 +70,13 @@ func (cmd *command) Execute(args []string) error {
 		return sub.Execute(args[1:])
 	}
 
-	// Unknown subcommand — show error + help if this command only has subcommands
+	// Unknown subcommand — show help, then return an error so the top-level
+	// caller (main) can decide on the exit code. Help goes to stderr because
+	// it's diagnostic output, not the user's intended program output.
 	if len(cmd.SubCommands) > 0 && len(args[0]) > 0 && args[0][0] != '-' {
-		utils.PrintRed(fmt.Sprintf("unknown command %q for %s", args[0], cmd.Name))
-		fmt.Println()
+		fmt.Fprintln(os.Stderr)
 		cmd.printHelp()
-		os.Exit(1)
+		return fmt.Errorf("unknown command %q for %s", args[0], cmd.Name)
 	}
 
 	// No subcommand matched — parse flags and run

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -98,7 +98,7 @@ func runEnvSet(args []string, envName string, useStdin bool) error {
 			return err
 		}
 
-		utils.PrintGreen(fmt.Sprintf("%s Set %s in %s", utils.CheckMark, key, envName))
+		utils.PrintSuccessStderr(fmt.Sprintf("Set %s in %s", key, envName))
 		return nil
 	})
 }
@@ -262,7 +262,7 @@ func runEnvDelete(args []string, envName string) error {
 			return err
 		}
 
-		utils.PrintGreen(fmt.Sprintf("%s Deleted %s from %s", utils.CheckMark, key, envName))
+		utils.PrintSuccessStderr(fmt.Sprintf("Deleted %s from %s", key, envName))
 		return nil
 	})
 }
@@ -548,7 +548,7 @@ func runEnvEdit(args []string, envName string) error {
 		}
 
 		if bytes.Equal(original, edited) {
-			utils.PrintGreen(fmt.Sprintf("%s No changes to %s", utils.CheckMark, envName))
+			utils.PrintSuccessStderr(fmt.Sprintf("No changes to %s", envName))
 			return nil
 		}
 
@@ -565,7 +565,7 @@ func runEnvEdit(args []string, envName string) error {
 			return err
 		}
 
-		utils.PrintGreen(fmt.Sprintf("%s Updated %s", utils.CheckMark, envName))
+		utils.PrintSuccessStderr(fmt.Sprintf("Updated %s", envName))
 		return nil
 	})
 }

--- a/pkg/userFlags/init.go
+++ b/pkg/userFlags/init.go
@@ -24,7 +24,7 @@ func InitDefaultProject() error {
 	}
 
 	if err := ensureGitignoreEntry(); err != nil {
-		utils.PrintWarning(fmt.Sprintf("could not update .gitignore: %v", err))
+		utils.PrintWarningStderr(fmt.Sprintf("could not update .gitignore: %v", err))
 	}
 
 	root, err := utils.CreatePath(utils.APIOptions)
@@ -35,10 +35,10 @@ func InitDefaultProject() error {
 	// Don't clobber a customized example file. `hulak init` is designed to be
 	// safe to re-run; overwriting user-edited content would defeat that.
 	if utils.FileExists(root) {
-		utils.PrintWarning(
+		utils.PrintWarningStderr(
 			fmt.Sprintf("Kept existing '%s' (delete it to regenerate)", utils.APIOptions),
 		)
-		utils.PrintGreen("Done " + utils.CheckMark)
+		utils.PrintSuccessStderr("Done")
 		return nil
 	}
 
@@ -51,8 +51,8 @@ func InitDefaultProject() error {
 		return fmt.Errorf("error on writing '%s' file: %s", utils.APIOptions, err)
 	}
 
-	utils.PrintGreen(fmt.Sprintf("Created '%s': %s", utils.APIOptions, utils.CheckMark))
-	utils.PrintGreen("Done " + utils.CheckMark)
+	utils.PrintSuccessStderr(fmt.Sprintf("Created '%s'", utils.APIOptions))
+	utils.PrintSuccessStderr("Done")
 	return nil
 }
 

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -266,8 +266,10 @@ func newRunCmd() *command {
 			return err
 		}
 
-		runner.Execute(f)
-		return nil
+		// Propagate runner errors so the top-level exit code reflects failures.
+		// Per-file detail has already been printed; an empty error message is
+		// the runner's signal of "exit non-zero, no extra output needed".
+		return runner.Execute(f)
 	}
 
 	return runCmd

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -113,15 +113,21 @@ func newInitCmd() *command {
 		Run: func(args []string) error {
 			if *createEnvFlag {
 				if len(args) == 0 {
-					utils.PrintWarning("No environment names provided after -env flag")
+					utils.PrintWarningStderr("No environment names provided after -env flag")
 					return nil
 				}
+				// Collect failures so the user sees every one, but bail at the
+				// end so the exit code reflects that something went wrong.
+				var firstErr error
 				for _, env := range args {
 					if err := envparser.CreateDefaultEnvs(&env); err != nil {
-						utils.PrintRed(err.Error())
+						utils.PrintErrorStderr(err.Error())
+						if firstErr == nil {
+							firstErr = err
+						}
 					}
 				}
-				return nil
+				return firstErr
 			}
 			return InitDefaultProject()
 		},

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -376,7 +376,9 @@ func newEnvCmd() *command {
 
 	notImplemented := func(name string) func([]string) error {
 		return func(_ []string) error {
-			fmt.Printf("hulak env %s is not yet implemented\n", name)
+			// Stderr — this is a status notice, not the data the user asked for.
+			// If the user pipes the output, $() must not capture this line.
+			fmt.Fprintf(os.Stderr, "hulak env %s is not yet implemented\n", name)
 			return nil
 		}
 	}

--- a/pkg/userFlags/userflags.go
+++ b/pkg/userFlags/userflags.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/xaaha/hulak/pkg/runner"
-	"github.com/xaaha/hulak/pkg/utils"
 )
 
 // AllFlags  All user flags and subcommands
@@ -45,8 +44,7 @@ func ParseFlagsSubcmds() (*AllFlags, error) {
 			os.Exit(0)
 		case strings.HasPrefix(first, "-"):
 			if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
-				utils.PrintRed(fmt.Sprintf("%s\nSee 'hulak help' for available flags", err))
-				os.Exit(1)
+				return nil, fmt.Errorf("%s\nSee 'hulak help' for available flags", err)
 			}
 			switch {
 			case flagVersion:
@@ -77,8 +75,7 @@ func ParseFlagsSubcmds() (*AllFlags, error) {
 				os.Exit(0)
 			}
 		default:
-			utils.PrintRed(fmt.Sprintf("unknown command %q. See 'hulak help'", first))
-			os.Exit(1)
+			return nil, fmt.Errorf("unknown command %q. See 'hulak help'", first)
 		}
 	}
 

--- a/pkg/userFlags/userflags.go
+++ b/pkg/userFlags/userflags.go
@@ -63,7 +63,7 @@ func ParseFlagsSubcmds() (*AllFlags, error) {
 						envSet = true
 					}
 				})
-				runner.Execute(&runner.Flags{
+				err := runner.Execute(&runner.Flags{
 					Env:      flagEnv,
 					EnvSet:   envSet,
 					FilePath: flagFP,
@@ -72,6 +72,9 @@ func ParseFlagsSubcmds() (*AllFlags, error) {
 					Dir:      flagDir,
 					Dirseq:   flagDirseq,
 				})
+				if err != nil {
+					return nil, err
+				}
 				os.Exit(0)
 			}
 		default:

--- a/pkg/utils/printing.go
+++ b/pkg/utils/printing.go
@@ -32,11 +32,39 @@ func PrintWarning(msg string) {
 	fmt.Printf("%s%s%s\n", Yellow, msg, ColorReset)
 }
 
-// PrintWarningStderr writes a "warning: <msg>" line in yellow to stderr.
-// Use this for soft warnings during commands whose stdout must stay clean
-// (e.g. `hulak env get` captured via $(...) ).
+// Stderr-routed printers: use these for diagnostics, status, warnings, and
+// errors during commands whose stdout must stay clean. Stdout is reserved
+// for actual program output (e.g. `hulak env get` captured via $(...) must
+// return only the value). Each function colors ONLY the leading prefix —
+// the message body stays plain text so it remains readable when redirected
+// to a non-color terminal or a log file.
+
+// PrintWarningStderr writes a "warning: <msg>" line to stderr.
+// Prefix in yellow, message plain.
 func PrintWarningStderr(msg string) {
-	fmt.Fprintf(os.Stderr, "%swarning: %s%s\n", Yellow, msg, ColorReset)
+	fmt.Fprintf(os.Stderr, "%swarning:%s %s\n", Yellow, ColorReset, msg)
+}
+
+// PrintErrorStderr writes an "error: <msg>" line to stderr.
+// Prefix in red, message plain. Use for user-facing errors that have
+// already been handled (don't print one of these AND return an error —
+// pick one).
+func PrintErrorStderr(msg string) {
+	fmt.Fprintf(os.Stderr, "%serror:%s %s\n", Red, ColorReset, msg)
+}
+
+// PrintSuccessStderr writes a "✓ <msg>" line to stderr. Use for status
+// confirmations on commands whose stdout must stay clean (env set, env
+// delete, env edit). Checkmark in green, message plain.
+func PrintSuccessStderr(msg string) {
+	fmt.Fprintf(os.Stderr, "%s%s%s %s\n", Green, CheckMark, ColorReset, msg)
+}
+
+// PrintInfoStderr writes a plain informational line to stderr — no color,
+// no prefix. Use for progress hints and "FYI" output that shouldn't
+// pollute stdout but doesn't warrant warning/error decoration either.
+func PrintInfoStderr(msg string) {
+	fmt.Fprintln(os.Stderr, msg)
 }
 
 // PrintRed is used mostly for errors
@@ -49,9 +77,12 @@ func PrintInfo(msg string) {
 	fmt.Printf("%s%s%s\n", Blue, msg, ColorReset)
 }
 
-// PanicRedAndExit Print message in Red and os.Exit(1)
+// PanicRedAndExit prints a fatal error to STDERR (red prefix, plain message)
+// and exits with code 1. Use sparingly — only for errors that must terminate
+// the process and cannot reasonably be returned. Library code should return
+// errors instead and let main() decide whether to call this.
 func PanicRedAndExit(msg string, args ...any) {
-	fmt.Printf("\n%s%s%s\n", Red, fmt.Sprintf(msg, args...), ColorReset)
+	fmt.Fprintf(os.Stderr, "\n%serror:%s %s\n", Red, ColorReset, fmt.Sprintf(msg, args...))
 	os.Exit(1)
 }
 

--- a/pkg/yamlparser/apiTypes.go
+++ b/pkg/yamlparser/apiTypes.go
@@ -94,8 +94,8 @@ func (user *APICallFile) IsValid(filePath string) (bool, error) {
 	}
 
 	if !user.Body.IsValid() {
-		utils.PanicRedAndExit(
-			"Invalid Body in '%s'. Make sure body contains only one valid argument.\n %v",
+		return false, fmt.Errorf(
+			"invalid Body in '%s': make sure body contains only one valid argument.\n %v",
 			filePath,
 			user.Body,
 		)

--- a/pkg/yamlparser/apiTypes.go
+++ b/pkg/yamlparser/apiTypes.go
@@ -107,6 +107,7 @@ func (user *APICallFile) IsValid(filePath string) (bool, error) {
 func (user *APICallFile) PrepareStruct() (APIInfo, error) {
 	body, contentType, err := user.Body.EncodeBody()
 	if err != nil {
+		// TODO(#180): see issue — migrate ColorError to fmt.Errorf.
 		return APIInfo{}, utils.ColorError(utils.ErrBodyEncoding, err)
 	}
 

--- a/pkg/yamlparser/kind.go
+++ b/pkg/yamlparser/kind.go
@@ -2,10 +2,10 @@
 package yamlparser
 
 import (
+	"fmt"
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
-	"github.com/xaaha/hulak/pkg/utils"
 )
 
 // Kind represents the type of YAML flow hulak should follow.
@@ -82,15 +82,17 @@ func (c *ConfigType) IsGraphql() bool {
 
 // ParseConfig parses a YAML file into ConfigType.
 func ParseConfig(filePath string, secretsMap map[string]any) (*ConfigType, error) {
+	// checkYamlFile errors already carry the file path; don't wrap with a
+	// generic "error reading YAML file" prefix that just adds noise.
 	buf, err := checkYamlFile(filePath, secretsMap)
 	if err != nil {
-		return nil, utils.ColorError("error reading YAML file", err)
+		return nil, err
 	}
 
 	var cfg ConfigType
 	dec := yaml.NewDecoder(buf)
 	if err := dec.Decode(&cfg); err != nil {
-		return nil, utils.ColorError("error decoding YAML", err)
+		return nil, fmt.Errorf("decoding %s: %w", filePath, err)
 	}
 
 	cfg.Kind = cfg.Kind.normalize()

--- a/pkg/yamlparser/reader_test.go
+++ b/pkg/yamlparser/reader_test.go
@@ -2,7 +2,6 @@ package yamlparser
 
 import (
 	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/goccy/go-yaml"
@@ -62,33 +61,18 @@ KeyTwo: value2
 				filepath = "/non/existent/file.yaml"
 			}
 
+			buf, err := checkYamlFile(filepath, secretsMap)
 			if tc.expectErr {
-				// Simulate child process to test os.Exit behavior
-				if os.Getenv("EXPECT_EXIT") == "1" {
-					_, _ = checkYamlFile(
-						filepath,
-						secretsMap,
-					) // Call function that triggers os.Exit
-					return
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
 				}
-				// handle the current subprocess
-				cmd := exec.Command(os.Args[0], "-test.run="+t.Name()) //nolint:gosec // Standard Go subprocess test pattern
-				cmd.Env = append(os.Environ(), "EXPECT_EXIT=1")
-				err := cmd.Run()
-
-				// Verify exit code from the subprocess
-				if e, ok := err.(*exec.ExitError); ok && e.ExitCode() == 1 {
-					return // Test passes
-				}
-				t.Fatalf("Expected process to exit with code 1, but got %v", err)
-			} else {
-				buf, err := checkYamlFile(filepath, secretsMap)
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				if buf.Len() == 0 {
-					t.Errorf("Expected non-empty buffer, got empty buffer for test %s", tc.name)
-				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if buf.Len() == 0 {
+				t.Errorf("Expected non-empty buffer, got empty buffer for test %s", tc.name)
 			}
 		})
 	}
@@ -397,20 +381,13 @@ body:
 			}
 
 			if tc.expectErr {
-				if os.Getenv("EXPECT_EXIT") == "1" {
-					_, _ = checkYamlFile(filepath, tc.secretMap)
-					return
+				_, err := checkYamlFile(filepath, tc.secretMap)
+				if err == nil {
+					t.Fatalf("expected an error for test %s, got nil", tc.name)
 				}
-
-				cmd := exec.Command(os.Args[0], "-test.run="+t.Name()) //nolint:gosec // Standard Go subprocess test pattern
-				cmd.Env = append(os.Environ(), "EXPECT_EXIT=1")
-				err := cmd.Run()
-
-				if e, ok := err.(*exec.ExitError); ok && e.ExitCode() == 1 {
-					return // Expected exit, test passes
-				}
-				t.Fatalf("Expected process to exit with code 1, but got %v", err)
-			} else {
+				return
+			}
+			{
 				// For cases where we don't expect an error/panic
 				buf, err := checkYamlFile(filepath, tc.secretMap)
 				if err != nil {

--- a/pkg/yamlparser/yamlparser.go
+++ b/pkg/yamlparser/yamlparser.go
@@ -82,24 +82,24 @@ func replaceVarsWithValues(
 // Reads YAML, validates if the file exists, is not empty, and changes keys to lowercase
 func checkYamlFile(filepath string, secretsMap map[string]any) (*bytes.Buffer, error) {
 	if _, err := os.Stat(filepath); os.IsNotExist(err) {
-		utils.PanicRedAndExit("File does not exist, %s", filepath)
+		return nil, fmt.Errorf("file does not exist: %s", filepath)
 	}
 
 	file, err := os.Open(filepath)
 	if err != nil {
-		utils.PanicRedAndExit("Error opening file: %v", err)
+		return nil, fmt.Errorf("opening file %s: %w", filepath, err)
 	}
 	defer file.Close()
 
 	fileInfo, _ := file.Stat()
 	if fileInfo.Size() == 0 {
-		utils.PanicRedAndExit("Empty yaml file")
+		return nil, fmt.Errorf("empty yaml file: %s", filepath)
 	}
 
 	var data map[string]any
 	dec := yaml.NewDecoder(file)
 	if err = dec.Decode(&data); err != nil {
-		utils.PanicRedAndExit("1. error decoding data: %v", err)
+		return nil, fmt.Errorf("decoding %s: %w", filepath, err)
 	}
 
 	// make yaml keys  case insensitive. method or Method or METHOD should all be the same
@@ -120,7 +120,7 @@ func checkYamlFile(filepath string, secretsMap map[string]any) (*bytes.Buffer, e
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
 	if err := enc.Encode(parsedMap); err != nil {
-		utils.PanicRedAndExit("error encoding data: %v", err)
+		return nil, fmt.Errorf("encoding %s: %w", filepath, err)
 	}
 	enc.Close()
 

--- a/pkg/yamlparser/yamlparser.go
+++ b/pkg/yamlparser/yamlparser.go
@@ -16,22 +16,38 @@ import (
 // From the yaml file, create a json file. But the json could have {{}} on it
 // So, we need to, read the file, make sure those values are handled, then return the proper map
 
-// Parses the user's input yaml file to a json interface.
-// Then, this function recursively replaces all variables {{.value}} specified in user's yaml values, with values from environment map
-// This is necessary, as the some variables, like URL needs correct string
+// replaceVarsWithValues walks the YAML tree and substitutes {{...}} template
+// references with values from secretsMap. Errors carry a dotted path of the
+// failing key (e.g. "body.urlencodedformdata.client_secret") so the user can
+// jump straight to the offending YAML node — no need for a nested wrapper
+// chain at each recursion level.
 func replaceVarsWithValues(
 	dict map[string]any,
 	secretsMap map[string]any,
 ) (map[string]any, error) {
+	return replaceVarsWithPrefix(dict, secretsMap, "")
+}
+
+// replaceVarsWithPrefix is the recursive helper. prefix is the dotted path
+// of the parent map; the empty string at the root suppresses a leading dot.
+func replaceVarsWithPrefix(
+	dict map[string]any,
+	secretsMap map[string]any,
+	prefix string,
+) (map[string]any, error) {
 	changedMap := make(map[string]any)
 
 	for key, val := range dict {
+		fullKey := key
+		if prefix != "" {
+			fullKey = prefix + "." + key
+		}
+
 		switch valTyped := val.(type) {
 		case map[string]any:
-			// Recursively process nested maps
-			nestedMap, err := replaceVarsWithValues(valTyped, secretsMap)
+			nestedMap, err := replaceVarsWithPrefix(valTyped, secretsMap, fullKey)
 			if err != nil {
-				return nil, fmt.Errorf("error in %s: %w", key, err)
+				return nil, err
 			}
 			changedMap[key] = nestedMap
 
@@ -41,33 +57,23 @@ func replaceVarsWithValues(
 				changedMap[key] = valTyped
 				continue
 			}
-
-			// Process template variables
 			finalChangedValue, err := envparser.SubstituteVariables(valTyped, secretsMap)
 			if err != nil {
-				errMsg := fmt.Sprintf("error substituting variable in '%s': %v", key, err)
-				return nil, utils.ColorError(errMsg)
+				return nil, fmt.Errorf("substituting %q: %w", fullKey, err)
 			}
-
-			// Only store the processed template value
 			changedMap[key] = finalChangedValue
 
 		case map[string]string:
 			innerMap := make(map[string]any)
 			for k, v := range valTyped {
-				// OPTIMIZATION: Skip template parsing if no template syntax present
 				if !strings.Contains(v, "{{") {
 					innerMap[k] = v
 					continue
 				}
-
-				// Process template variables
 				finalChangedValue, err := envparser.SubstituteVariables(v, secretsMap)
 				if err != nil {
-					return nil, fmt.Errorf("error substituting variable in '%s.%s': %w", key, k, err)
+					return nil, fmt.Errorf("substituting %q: %w", fullKey+"."+k, err)
 				}
-
-				// Only store the processed template value
 				innerMap[k] = finalChangedValue
 			}
 			changedMap[key] = innerMap

--- a/pkg/yamlparser/yamlparser.go
+++ b/pkg/yamlparser/yamlparser.go
@@ -120,6 +120,8 @@ func checkYamlFile(filepath string, secretsMap map[string]any) (*bytes.Buffer, e
 	// translate the types, if acceptable
 	parsedMap, err = translateType(data, parsedMap, secretsMap, actions.GetValueOf)
 	if err != nil {
+		// TODO(#180): replace with fmt.Errorf — ColorError injects \n + ANSI
+		// codes that the runner has to strip before rendering.
 		return nil, utils.ColorError(utils.ErrYAMLPostProcessing, err)
 	}
 


### PR DESCRIPTION
## What this PR does

- **stdout/stderr discipline.**
  Stdout is now reserved for the answer the user asked for (response bodies, `env get` values, `env list`/`keys` tables, version, doctor report, help text).
  Everything else (status, prompts, warnings, errors, retry messages, success confirmations) routes to stderr.
  Audited every `fmt.Print*` and `utils.Print*` call site against the rule.

- **New stderr printers** in `pkg/utils/printing.go`
  - `PrintErrorStderr`
  - `PrintSuccessStderr`
  - `PrintInfoStderr`
  Existing `PrintWarningStderr` rewritten so only the `warning:` prefix is colored; message body stays plain text.
  Same convention for the new variants.

- **Exit codes.**
  `runner.Execute`, `ExecuteSingleFile`, `InitializeProject` now return `error` instead of `PanicRedAndExit`.
  `handleAPIRequests` aggregates failed outcomes into a typed `*runFailureError`.
  A new `runner.IsRunFailure()` lets `main` flip the exit code without reprinting (`printOutcome` already showed the detail).
  `hulak run -dir/` with any failed file now exits 1 — CI can rely on it.

- **Per-file outcome line.**
  Replaces `Processed 'X.yml'` with:
    - Success: `✔ X.yml [200 OK, 142ms]`
    - Failure: `error: X.yml [code, latency]: ...`
  Suppressed for single-file runs (the response body is already on stdout).
  Always shown for failures so silent errors can't be mistaken for success.

- **End-of-run summary.**
  Multi-file runs end with:
    `N succeeded, M failed in T`
  plus the names of failures.
  Skipped for single file.

- **Smarter retry policy.**
  New `configError` type + `isRetryable()` check.
  Config-parse / missing-env-var / unsupported-kind = fail fast.
  Retries reserved for transport errors.
  Cuts a 3.0s wasted-retry run to 236ms.

- **Cleaner error rendering.**
  Dropped legacy `ColorError` wrappers in yamlparser that injected `\n` and ANSI mid-message.
  Replaced 3 nested wrappers with a path-threading recursion:
    Instead of:
      `error in body: error in urlencodedformdata: substituting client_secret: ...`
    You get:
      `substituting "body.urlencodedformdata.client_secret": ...`
  New `splitErrorForOutcome` extracts the trailing actionable hint (`Add ...`, `Run ...`) onto its own indented line.

- **yamlparser fail-soft.**
  `PanicRedAndExit` calls in yamlparser become `fmt.Errorf` returns.
  One bad YAML file in a directory run no longer kills the whole batch.

- **Bug fixes**
  - `pkg/apiCalls/prepare.go`
    Non-debug response branch was dropping `Status`.
    Restored so the outcome line shows `200 OK`, not just the code.
  - `pkg/envparser/envparser.go`
    Interactive `Create '<env>.env'? (y/n)` prompt was on stdout.
    Moved to stderr.
  - `pkg/userFlags/subcommands.go`
    `notImplemented` notice was on stdout.
    Moved to stderr.
  - `main.go`
    Three `fmt.Println` calls in interactive bootstrap routed to stderr.

- **Docs.**
  The *Error Handling* block was rewritten to reflect:
    - library code returns errors
    - top level prints
    - don't `PrintRed` and `return err` together


## Tickets filed during this work

- #156 expanded with `--quiet` / `--verbose` verbosity flags + TTY-gate ANSI codes
  (closed #175 and #176 as duplicates of #156's broadened scope)
- #174 — Spinner for single-file run while waiting on the API
- #177 — `--format=json` for structured CI output
- #178 — `env edit` SIGINT cleanup of plaintext temp file (filed under `epic: encryption`)


## Out of scope (deferred)

- `runner.PanicRedAndExit` calls in:
  - `runner.go` (envSelector errors, IsHulakProject)
  - `gqlhelper.go`
  - `features/graphql/graphql.go`
  still exit directly.
  Bigger blast radius than belongs in this PR — separate cleanup.

- Older error patterns in `pkg/apiCalls` / `pkg/migration` largely untouched.
  Status/warnings are routed to stderr but the print-and-return-error idiom remains in places.
  Future PR.


## Test plan

- [x] `go test -race ./...` — all 14 packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOOS=windows go build ./...` — clean cross-compile

- [x] Acid tests verified end-to-end:
  - `V=$(hulak version)` → clean version string
  - `hulak run foo.yaml 2>/dev/null | jq` → valid JSON, no stderr noise
  - `hulak run -dir/ 2>/dev/null | wc -l` → only response data
  - Single failure / multi-file mixed → exit 1
  - All success → exit 0