### PR TITLE
init: vault by default, classic as opt-in subcommand (#130)

### DIFF
--- a/pkg/features/graphql/graphql.go
+++ b/pkg/features/graphql/graphql.go
@@ -8,7 +8,6 @@ import (
 	apicalls "github.com/xaaha/hulak/pkg/apiCalls"
 	"github.com/xaaha/hulak/pkg/envparser"
 	"github.com/xaaha/hulak/pkg/tui/envselect"
-	"github.com/xaaha/hulak/pkg/utils"
 	"github.com/xaaha/hulak/pkg/yamlparser"
 )
 
@@ -104,61 +103,61 @@ func detectContentType(body string) string {
 	}
 }
 
-// GetSecretsForEnv loads secrets based on whether templates exist in the files.
-// If env is provided, uses that environment directly.
-// If env is empty and templates are needed, shows the interactive selector.
-// Returns empty map if no templates needed, nil if user cancelled.
-func GetSecretsForEnv(urlToFileMap map[string]string, needsEnv bool, env string) map[string]any {
-	secretsMap, _, cancelled := ResolveSecretsForEnv(urlToFileMap, needsEnv, env)
-	if cancelled {
-		return nil
-	}
-	return secretsMap
-}
-
 // ResolveSecretsForEnv loads secrets and returns the resolved environment name.
-// If no environment is needed, the returned env name is empty.
-func ResolveSecretsForEnv(urlToFileMap map[string]string, needsEnv bool, env string) (map[string]any, string, bool) {
+// If no environment is needed, the returned env name is empty. The bool is
+// true when the user cancelled the interactive picker (not an error). Other
+// failures (selector failure, missing env file) come back as a non-nil error.
+func ResolveSecretsForEnv(
+	urlToFileMap map[string]string,
+	needsEnv bool,
+	env string,
+) (map[string]any, string, bool, error) {
 	// If env is explicitly provided, always load it (user knows what they want)
 	if env != "" {
-		secretsMap, selectedEnv := loadSecretsForEnv(env)
-		return secretsMap, selectedEnv, false
+		secretsMap, selectedEnv, err := loadSecretsForEnv(env)
+		if err != nil {
+			return nil, "", false, err
+		}
+		return secretsMap, selectedEnv, false, nil
 	}
 
 	if NeedsEnvResolution(urlToFileMap) || needsEnv {
-		secretsMap, selectedEnv := loadSecretsForEnv("")
-		if secretsMap == nil {
-			return nil, "", true
+		secretsMap, selectedEnv, err := loadSecretsForEnv("")
+		if err != nil {
+			return nil, "", false, err
 		}
-		return secretsMap, selectedEnv, false
+		if secretsMap == nil {
+			return nil, "", true, nil
+		}
+		return secretsMap, selectedEnv, false, nil
 	}
 
-	return map[string]any{}, "", false
+	return map[string]any{}, "", false, nil
 }
 
 // loadSecretsForEnv loads secrets from the specified environment.
-// If env is empty, shows the interactive env selector TUI.
-// Returns nil if user cancelled the selector.
-func loadSecretsForEnv(env string) (map[string]any, string) {
+// If env is empty, shows the interactive env selector TUI; a returned
+// secretsMap of nil with no error means the user cancelled the picker.
+func loadSecretsForEnv(env string) (map[string]any, string, error) {
 	selectedEnv := env
 
 	// If no env provided, show the interactive selector
 	if selectedEnv == "" {
-		var err error
-		selectedEnv, err = envselect.RunEnvSelector()
+		picked, err := envselect.RunEnvSelector()
 		if err != nil {
-			utils.PanicRedAndExit("Environment selector error: %v", err)
+			return nil, "", fmt.Errorf("environment selector: %w", err)
 		}
-		if selectedEnv == "" {
-			return nil, ""
+		if picked == "" {
+			return nil, "", nil
 		}
+		selectedEnv = picked
 	}
 
 	// Load secrets from the environment
 	secretsMap, err := envparser.LoadSecretsMap(selectedEnv)
 	if err != nil {
-		utils.PanicRedAndExit("Failed to load environment '%s': %v", selectedEnv, err)
+		return nil, "", fmt.Errorf("loading environment %q: %w", selectedEnv, err)
 	}
 
-	return secretsMap, selectedEnv
+	return secretsMap, selectedEnv, nil
 }

--- a/pkg/features/graphql/loader.go
+++ b/pkg/features/graphql/loader.go
@@ -207,7 +207,10 @@ func (l schemaLoader) fetchSchemas(results []ProcessResult) (LoadResult, error) 
 		if len(warnings) == 0 {
 			return LoadResult{}, nil
 		}
-		return LoadResult{}, fmt.Errorf("all schema fetches failed:\n  %s", strings.Join(warnings, "\n  "))
+		return LoadResult{}, fmt.Errorf(
+			"all schema fetches failed:\n  %s",
+			strings.Join(warnings, "\n  "),
+		)
 	}
 
 	endpointResults := make([]ProcessResult, 0, len(uniqueFetchResults))
@@ -266,7 +269,10 @@ func (l schemaLoader) fetchSchemas(results []ProcessResult) (LoadResult, error) 
 	sort.Strings(warnings)
 
 	if len(loaded) == 0 && len(warnings) > 0 {
-		return LoadResult{}, fmt.Errorf("all schema fetches failed:\n  %s", strings.Join(warnings, "\n  "))
+		return LoadResult{}, fmt.Errorf(
+			"all schema fetches failed:\n  %s",
+			strings.Join(warnings, "\n  "),
+		)
 	}
 
 	return LoadResult{

--- a/pkg/features/graphql/loader.go
+++ b/pkg/features/graphql/loader.go
@@ -39,7 +39,7 @@ type schemaLoader struct {
 	getwd                  func() (string, error)
 	findGraphQLFiles       func(string) (map[string]string, bool, error)
 	validateGraphQLFile    func(string) (string, bool, error)
-	resolveSecretsForEnv   func(map[string]string, bool, string) (map[string]any, string, bool)
+	resolveSecretsForEnv   func(map[string]string, bool, string) (map[string]any, string, bool, error)
 	processFilesConcurrent func([]string, map[string]any) []ProcessResult
 	fetchAndParseSchema    func(yamlparser.APIInfo) (Schema, error)
 	getWorkers             func(*int) int
@@ -146,7 +146,10 @@ func (l schemaLoader) loadFromDirectory(dir, env string) ([]ProcessResult, strin
 	}
 	sort.Strings(filePaths)
 
-	secretsMap, selectedEnv, cancelled := l.resolveSecretsForEnv(urlToFileMap, needsEnv, env)
+	secretsMap, selectedEnv, cancelled, err := l.resolveSecretsForEnv(urlToFileMap, needsEnv, env)
+	if err != nil {
+		return nil, "", false, err
+	}
 	if cancelled {
 		return nil, "", true, nil
 	}
@@ -161,7 +164,10 @@ func (l schemaLoader) loadFromFile(filePath, env string) ([]ProcessResult, strin
 	}
 
 	urlToFileMap := map[string]string{rawURL: filePath}
-	secretsMap, selectedEnv, cancelled := l.resolveSecretsForEnv(urlToFileMap, needsEnv, env)
+	secretsMap, selectedEnv, cancelled, err := l.resolveSecretsForEnv(urlToFileMap, needsEnv, env)
+	if err != nil {
+		return nil, "", false, err
+	}
 	if cancelled {
 		return nil, "", true, nil
 	}

--- a/pkg/features/graphql/loader_test.go
+++ b/pkg/features/graphql/loader_test.go
@@ -46,7 +46,7 @@ func TestLoadSchemasFromDirectory(t *testing.T) {
 			t.Fatal("validateGraphQLFile should not be called for directories")
 			return "", false, nil
 		},
-		resolveSecretsForEnv: func(urlToFileMap map[string]string, needsEnv bool, env string) (map[string]any, string, bool) {
+		resolveSecretsForEnv: func(urlToFileMap map[string]string, needsEnv bool, env string) (map[string]any, string, bool, error) {
 			if !needsEnv {
 				t.Fatal("expected needsEnv=true")
 			}
@@ -56,7 +56,7 @@ func TestLoadSchemasFromDirectory(t *testing.T) {
 			if len(urlToFileMap) != 2 {
 				t.Fatalf("expected 2 urls, got %d", len(urlToFileMap))
 			}
-			return map[string]any{"token": "x"}, "dev", false
+			return map[string]any{"token": "x"}, "dev", false, nil
 		},
 		processFilesConcurrent: func(filePaths []string, _ map[string]any) []ProcessResult {
 			want := []string{"/tmp/apis/a.yaml", "/tmp/apis/b.yaml"}
@@ -118,14 +118,14 @@ func TestLoadSchemasFromFile(t *testing.T) {
 			}
 			return "https://api.test/graphql", false, nil
 		},
-		resolveSecretsForEnv: func(_ map[string]string, needsEnv bool, env string) (map[string]any, string, bool) {
+		resolveSecretsForEnv: func(_ map[string]string, needsEnv bool, env string) (map[string]any, string, bool, error) {
 			if needsEnv {
 				t.Fatal("expected needsEnv=false")
 			}
 			if env != "prod" {
 				t.Fatalf("unexpected env: %s", env)
 			}
-			return map[string]any{}, "prod", false
+			return map[string]any{}, "prod", false, nil
 		},
 		processFilesConcurrent: func(filePaths []string, _ map[string]any) []ProcessResult {
 			if !reflect.DeepEqual(filePaths, []string{"/tmp/query.yaml"}) {
@@ -168,8 +168,8 @@ func TestLoadSchemasReturnsWarningsForPartialFailures(t *testing.T) {
 			return map[string]string{"https://good.test/graphql": "/tmp/good.yaml"}, false, nil
 		},
 		validateGraphQLFile: func(string) (string, bool, error) { return "", false, nil },
-		resolveSecretsForEnv: func(map[string]string, bool, string) (map[string]any, string, bool) {
-			return map[string]any{}, "", false
+		resolveSecretsForEnv: func(map[string]string, bool, string) (map[string]any, string, bool, error) {
+			return map[string]any{}, "", false, nil
 		},
 		processFilesConcurrent: func([]string, map[string]any) []ProcessResult {
 			return []ProcessResult{
@@ -223,8 +223,8 @@ func TestLoadSchemasUsesFilePathWhenProcessWarningHasNoURL(t *testing.T) {
 		validateGraphQLFile: func(string) (string, bool, error) {
 			return "https://api.test/graphql", false, nil
 		},
-		resolveSecretsForEnv: func(map[string]string, bool, string) (map[string]any, string, bool) {
-			return map[string]any{}, "", false
+		resolveSecretsForEnv: func(map[string]string, bool, string) (map[string]any, string, bool, error) {
+			return map[string]any{}, "", false, nil
 		},
 		processFilesConcurrent: func([]string, map[string]any) []ProcessResult {
 			return []ProcessResult{
@@ -264,8 +264,8 @@ func TestLoadSchemasDoesNotCollapseWarningsBeforeConcurrentFetch(t *testing.T) {
 			return map[string]string{"https://same.test/graphql": "/tmp/apis/a.yaml"}, false, nil
 		},
 		validateGraphQLFile: func(string) (string, bool, error) { return "", false, nil },
-		resolveSecretsForEnv: func(map[string]string, bool, string) (map[string]any, string, bool) {
-			return map[string]any{}, "", false
+		resolveSecretsForEnv: func(map[string]string, bool, string) (map[string]any, string, bool, error) {
+			return map[string]any{}, "", false, nil
 		},
 		processFilesConcurrent: func([]string, map[string]any) []ProcessResult {
 			return []ProcessResult{
@@ -330,8 +330,8 @@ func TestLoadSchemasReturnsErrorWhenAllEndpointsFail(t *testing.T) {
 		validateGraphQLFile: func(string) (string, bool, error) {
 			return "https://api.test/graphql", false, nil
 		},
-		resolveSecretsForEnv: func(map[string]string, bool, string) (map[string]any, string, bool) {
-			return map[string]any{}, "", false
+		resolveSecretsForEnv: func(map[string]string, bool, string) (map[string]any, string, bool, error) {
+			return map[string]any{}, "", false, nil
 		},
 		processFilesConcurrent: func([]string, map[string]any) []ProcessResult {
 			return []ProcessResult{
@@ -369,8 +369,8 @@ func TestLoadSchemasReturnsCancelledWhenEnvSelectionCancelled(t *testing.T) {
 			return map[string]string{"https://api.test/graphql": "/tmp/query.yaml"}, true, nil
 		},
 		validateGraphQLFile: func(string) (string, bool, error) { return "", false, nil },
-		resolveSecretsForEnv: func(map[string]string, bool, string) (map[string]any, string, bool) {
-			return nil, "", true
+		resolveSecretsForEnv: func(map[string]string, bool, string) (map[string]any, string, bool, error) {
+			return nil, "", true, nil
 		},
 		processFilesConcurrent: func([]string, map[string]any) []ProcessResult {
 			t.Fatal("processFilesConcurrent should not be called when env selection is cancelled")

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -43,13 +43,16 @@ type Flags struct {
 // so the top-level exit code is non-zero on partial success. A nil error means
 // every dispatched request succeeded.
 func Execute(f *Flags) error {
-	fileList, concurrentDir, sequentialDir := discoverFilePaths(
+	fileList, concurrentDir, sequentialDir, err := discoverFilePaths(
 		f.File,
 		f.FilePath,
 		f.Dir,
 		f.Dirseq,
 		f.Dir != "" || f.Dirseq != "",
 	)
+	if err != nil {
+		return err
+	}
 
 	allPaths := slices.Concat(fileList, concurrentDir, sequentialDir)
 
@@ -111,18 +114,29 @@ func InitializeProject(env string, isCli bool) (map[string]any, error) {
 }
 
 // discoverFilePaths collects all file paths from -f, -fp, -dir, and -dirseq flags.
+//
+// When the user provides only single-file flags (no -dir/-dirseq) and the
+// lookup fails, the error is fatal — there's nothing else to run, so it
+// returns up to the caller. When dir flags are also present the file-flag
+// failure becomes a warning so the directory work can still proceed.
+// Directory-listing failures are always reported as warnings; an empty
+// directory list isn't fatal on its own (callers may still have file-flag
+// matches to execute).
 func discoverFilePaths(
 	fileName, fp, dir, dirseq string,
 	hasDirFlags bool,
-) (fileList, concurrentDir, sequentialDir []string) {
+) ([]string, []string, []string, error) {
+	var fileList, concurrentDir, sequentialDir []string
+
 	if fp != "" || fileName != "" {
-		var err error
-		fileList, err = generateFilePathList(fileName, fp)
+		list, err := generateFilePathList(fileName, fp)
 		if err != nil {
 			if !hasDirFlags {
-				utils.PanicRedAndExit("%v", err)
+				return nil, nil, nil, err
 			}
 			utils.PrintWarningStderr(fmt.Sprintf("file flags: %v", err))
+		} else {
+			fileList = list
 		}
 	}
 
@@ -136,7 +150,7 @@ func discoverFilePaths(
 		}
 	}
 
-	return fileList, concurrentDir, sequentialDir
+	return fileList, concurrentDir, sequentialDir, nil
 }
 
 // outcome captures the result of executing one request file. Used to render

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -37,7 +37,7 @@ func TestDiscoverFilePaths_FpReturnsFileList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fileList, concurrent, sequential := discoverFilePaths(
+	fileList, concurrent, sequential, err := discoverFilePaths(
 		"",      // fileName
 		tmpFile, // fp
 		"",      // dir
@@ -45,6 +45,9 @@ func TestDiscoverFilePaths_FpReturnsFileList(t *testing.T) {
 		false,   // hasDirFlags
 	)
 
+	if err != nil {
+		t.Fatalf("discoverFilePaths: %v", err)
+	}
 	if len(fileList) != 1 || fileList[0] != tmpFile {
 		t.Errorf("fileList = %v, want [%s]", fileList, tmpFile)
 	}
@@ -65,7 +68,7 @@ func TestDiscoverFilePaths_DirReturnsConcurrent(t *testing.T) {
 		}
 	}
 
-	fileList, concurrent, sequential := discoverFilePaths(
+	fileList, concurrent, sequential, err := discoverFilePaths(
 		"",     // fileName
 		"",     // fp
 		tmpDir, // dir
@@ -73,6 +76,9 @@ func TestDiscoverFilePaths_DirReturnsConcurrent(t *testing.T) {
 		true,   // hasDirFlags
 	)
 
+	if err != nil {
+		t.Fatalf("discoverFilePaths: %v", err)
+	}
 	if len(fileList) != 0 {
 		t.Errorf("fileList should be empty, got %v", fileList)
 	}
@@ -93,13 +99,16 @@ func TestDiscoverFilePaths_DirseqReturnsSequential(t *testing.T) {
 		}
 	}
 
-	fileList, concurrent, sequential := discoverFilePaths(
+	fileList, concurrent, sequential, err := discoverFilePaths(
 		"",     // fileName
 		"",     // fp
 		"",     // dir
 		tmpDir, // dirseq
 		true,   // hasDirFlags
 	)
+	if err != nil {
+		t.Fatalf("discoverFilePaths: %v", err)
+	}
 
 	if len(fileList) != 0 {
 		t.Errorf("fileList should be empty, got %v", fileList)
@@ -141,9 +150,12 @@ func TestContainsTemplateVars_EmptyList(t *testing.T) {
 }
 
 func TestDiscoverFilePaths_EmptyInputs(t *testing.T) {
-	fileList, concurrent, sequential := discoverFilePaths(
+	fileList, concurrent, sequential, err := discoverFilePaths(
 		"", "", "", "", false,
 	)
+	if err != nil {
+		t.Fatalf("discoverFilePaths: %v", err)
+	}
 
 	if len(fileList) != 0 {
 		t.Errorf("fileList should be empty, got %v", fileList)
@@ -261,13 +273,16 @@ func TestDiscoverFilePaths_FpAndDirTogether(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fileList, concurrent, sequential := discoverFilePaths(
+	fileList, concurrent, sequential, err := discoverFilePaths(
 		"",      // fileName
 		tmpFile, // fp
 		tmpDir,  // dir
 		"",      // dirseq
 		true,    // hasDirFlags
 	)
+	if err != nil {
+		t.Fatalf("discoverFilePaths: %v", err)
+	}
 
 	if len(fileList) != 1 {
 		t.Errorf("fileList should have 1 entry, got %v", fileList)

--- a/pkg/userFlags/gqlhelper.go
+++ b/pkg/userFlags/gqlhelper.go
@@ -1,26 +1,30 @@
 package userflags
 
 import (
+	"fmt"
+
 	"github.com/xaaha/hulak/pkg/features/graphql"
 	"github.com/xaaha/hulak/pkg/tui"
 	"github.com/xaaha/hulak/pkg/tui/gqlexplorer"
-	"github.com/xaaha/hulak/pkg/utils"
 	"github.com/xaaha/hulak/pkg/yamlparser"
 )
 
 // loadGraphQLOperations handles single file mode and directory mode along
-// with unifying the operations into ExplorerData for the TUI.
+// with unifying the operations into ExplorerData for the TUI. Returns a
+// zero-valued ExplorerData with a nil refresh function when the user
+// cancelled either the env picker or the spinner — that's not an error.
 func loadGraphQLOperations(arg string, env string) (
 	gqlexplorer.ExplorerData,
 	gqlexplorer.RefreshFunc,
 	[]string,
+	error,
 ) {
 	prepared, err := graphql.PrepareSchemaLoad(arg, env)
 	if err != nil {
-		utils.PanicRedAndExit("Schema preparation error: %v", err)
+		return gqlexplorer.ExplorerData{}, nil, nil, fmt.Errorf("schema preparation: %w", err)
 	}
 	if prepared.Cancelled {
-		return gqlexplorer.ExplorerData{}, nil, nil
+		return gqlexplorer.ExplorerData{}, nil, nil, nil
 	}
 
 	// load spinner while waiting
@@ -28,15 +32,17 @@ func loadGraphQLOperations(arg string, env string) (
 		return graphql.FetchPreparedSchemas(prepared)
 	})
 	if err != nil {
-		utils.PanicRedAndExit("Schema fetch error: %v", err)
+		return gqlexplorer.ExplorerData{}, nil, nil, fmt.Errorf("schema fetch: %w", err)
 	}
 	loadResult, ok := raw.(graphql.LoadResult)
 	if !ok && raw != nil {
-		utils.PanicRedAndExit("unexpected result type from schema fetch")
+		return gqlexplorer.ExplorerData{}, nil, nil, fmt.Errorf(
+			"internal error: unexpected result type %T from schema fetch", raw,
+		)
 	}
 
 	if loadResult.Cancelled {
-		return gqlexplorer.ExplorerData{}, nil, nil
+		return gqlexplorer.ExplorerData{}, nil, nil, nil
 	}
 	refreshFn := func() (gqlexplorer.RefreshPayload, error) {
 		freshPrepared, err := graphql.PrepareSchemaLoad(arg, prepared.Env)
@@ -56,7 +62,7 @@ func loadGraphQLOperations(arg string, env string) (
 		}, nil
 	}
 
-	return explorerDataFromLoadResult(loadResult, prepared.Results), refreshFn, loadResult.Warnings
+	return explorerDataFromLoadResult(loadResult, prepared.Results), refreshFn, loadResult.Warnings, nil
 }
 
 // explorerDataFromLoadResult converts schema fetch results and process

--- a/pkg/userFlags/gqlhelper.go
+++ b/pkg/userFlags/gqlhelper.go
@@ -62,12 +62,18 @@ func loadGraphQLOperations(arg string, env string) (
 		}, nil
 	}
 
-	return explorerDataFromLoadResult(loadResult, prepared.Results), refreshFn, loadResult.Warnings, nil
+	return explorerDataFromLoadResult(
+		loadResult,
+		prepared.Results,
+	), refreshFn, loadResult.Warnings, nil
 }
 
 // explorerDataFromLoadResult converts schema fetch results and process
 // results into the unified ExplorerData consumed by the TUI explorer.
-func explorerDataFromLoadResult(loadResult graphql.LoadResult, processResults []graphql.ProcessResult) gqlexplorer.ExplorerData {
+func explorerDataFromLoadResult(
+	loadResult graphql.LoadResult,
+	processResults []graphql.ProcessResult,
+) gqlexplorer.ExplorerData {
 	data := gqlexplorer.ExplorerData{
 		InputTypes:      make(map[string]graphql.InputType),
 		EnumTypes:       make(map[string]graphql.EnumType),
@@ -87,7 +93,9 @@ func explorerDataFromLoadResult(loadResult graphql.LoadResult, processResults []
 
 	for i := range loadResult.Endpoints {
 		endpoint := &loadResult.Endpoints[i]
-		data.Operations = append(data.Operations, gqlexplorer.CollectOperations(&endpoint.Schema, endpoint.URL)...)
+		data.Operations = append(
+			data.Operations,
+			gqlexplorer.CollectOperations(&endpoint.Schema, endpoint.URL)...)
 		for k, v := range endpoint.Schema.InputTypes {
 			data.InputTypes[gqlexplorer.ScopedTypeKey(endpoint.URL, k)] = v
 		}

--- a/pkg/userFlags/init.go
+++ b/pkg/userFlags/init.go
@@ -20,22 +20,23 @@ var embeddedFiles embed.FS
 // InitClassicProject sets up the plaintext env/ layout: env/ directory,
 // global.env, the apiOptions.hk.yaml example, and an env/ entry in .gitignore.
 //
-// Refuses to run if .hulak/ already exists in the current directory — that
-// signals the user has already initialized the encrypted vault, and bolting
-// a parallel plaintext layout next to it would create two sources of truth
-// for environment values. The user has to remove .hulak/ explicitly to opt
-// out of the vault.
+// Refuses to run if .hulak/store.age is present — that's an initialized
+// encrypted vault and bolting a parallel plaintext layout next to it would
+// create two sources of truth. The store file (not just the .hulak/ dir) is
+// the right signal: a partially-failed vault init can leave an empty .hulak/
+// behind, and that shouldn't lock the user out of the classic path.
 func InitClassicProject() error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("could not determine current directory: %w", err)
 	}
-	if utils.DirExists(filepath.Join(cwd, utils.HiddenProjectName)) {
+	storePath := filepath.Join(cwd, utils.HiddenProjectName, utils.StoreFile)
+	if utils.FileExists(storePath) {
 		return fmt.Errorf(
-			"refusing to create plaintext env/ layout: %s/ already exists "+
+			"refusing to create plaintext env/ layout: %s exists "+
 				"(this project is using the encrypted vault) — "+
 				"remove %s/ first if you really want to switch",
-			utils.HiddenProjectName, utils.HiddenProjectName,
+			storePath, utils.HiddenProjectName,
 		)
 	}
 
@@ -129,10 +130,12 @@ func InitVaultProject(envNames []string) error {
 	}
 
 	if wasFresh {
+		// EnsureKeypair just succeeded, which proves UserConfigDir resolves;
+		// IdentityPath uses the same call, so failure here is unreachable in
+		// practice — surface it as an error rather than papering over it.
 		identityPath, err := vault.IdentityPath()
 		if err != nil {
-			// Non-fatal: vault is initialized; we just can't show the path.
-			identityPath = "(unable to resolve identity path)"
+			return fmt.Errorf("could not resolve identity path: %w", err)
 		}
 		utils.PrintSuccessStderr(
 			fmt.Sprintf("Initialized vault at %s/", utils.HiddenProjectName),
@@ -167,22 +170,16 @@ func InitVaultProject(envNames []string) error {
 // case-insensitively are folded into "global" rather than creating duplicates.
 func ensureStoreSections(store *vault.Store, names []string) []string {
 	var added []string
-	if store.Envs == nil {
-		store.Envs = make(map[string]vault.Env)
-	}
-	if _, ok := store.Envs[utils.DefaultEnvVal]; !ok {
-		store.Envs[utils.DefaultEnvVal] = make(vault.Env)
+	if store.EnsureSection(utils.DefaultEnvVal) {
 		added = append(added, utils.DefaultEnvVal)
 	}
 	for _, name := range names {
 		if strings.EqualFold(name, utils.DefaultEnvVal) {
 			continue
 		}
-		if _, ok := store.Envs[name]; ok {
-			continue
+		if store.EnsureSection(name) {
+			added = append(added, name)
 		}
-		store.Envs[name] = make(vault.Env)
-		added = append(added, name)
 	}
 	return added
 }

--- a/pkg/userFlags/init.go
+++ b/pkg/userFlags/init.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/xaaha/hulak/pkg/envparser"
 	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
 )
 
 //go:embed apiOptions.hk.yaml
@@ -46,33 +47,173 @@ func InitClassicProject() error {
 		utils.PrintWarningStderr(fmt.Sprintf("could not update .gitignore: %v", err))
 	}
 
-	root, err := utils.CreatePath(utils.APIOptions)
+	if _, err := writeAPIOptionsExample(); err != nil {
+		return err
+	}
+
+	utils.PrintSuccessStderr("Done")
+	return nil
+}
+
+// InitVaultProject sets up the encrypted vault layout: .hulak/store.age,
+// .hulak/key.pub, and the user's age identity at ~/.config/hulak/identity.txt.
+// Also writes the apiOptions.hk.yaml example.
+//
+// Behaviour notes:
+//   - If env/ exists but .hulak/ does not, returns nil after printing a one-line
+//     migration nudge — the user should choose between `hulak migrate env`
+//     (vault) and `hulak init classic` (stay plaintext) rather than have hulak
+//     silently bolt a vault next to existing plaintext.
+//   - Idempotent: re-running on a project that already has .hulak/ does not
+//     regenerate the identity, does not overwrite the store, and does not
+//     clobber a customized apiOptions.hk.yaml.
+//   - envNames seeds extra empty environment sections in the store (in
+//     addition to the always-present "global"). Each name is validated up
+//     front; an invalid name aborts before any I/O.
+//   - On first-run identity creation, prints the public key and identity path
+//     to stderr so the user knows what to back up. Subsequent runs do not
+//     repeat this — the identity file already exists at a known location.
+func InitVaultProject(envNames []string) error {
+	// Validate input BEFORE touching the filesystem so a typo'd env name
+	// can't leave a half-initialised .hulak/ behind.
+	for _, name := range envNames {
+		if err := utils.ValidateEnvName(name); err != nil {
+			return err
+		}
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("could not determine current directory: %w", err)
+	}
+	hulakDir := filepath.Join(cwd, utils.HiddenProjectName)
+	envDir := filepath.Join(cwd, utils.EnvironmentFolder)
+
+	// Pre-existing classic layout, no vault yet → don't surprise the user
+	// by creating .hulak/ next to their env/ files. Point at migrate, exit.
+	if !utils.DirExists(hulakDir) && utils.DirExists(envDir) {
+		utils.PrintInfoStderr(
+			"This project uses the legacy env/ layout. " +
+				"Run 'hulak migrate env' to upgrade, or 'hulak init classic' to stay plaintext.",
+		)
+		return nil
+	}
+
+	if err := os.MkdirAll(hulakDir, utils.DirPer); err != nil {
+		return fmt.Errorf("could not create %s: %w", utils.HiddenProjectName, err)
+	}
+
+	// Snapshot identity presence BEFORE EnsureKeypair: the difference between
+	// "fresh identity just generated" (show backup nudge) and "reused existing
+	// identity" (already documented elsewhere) hangs on this check.
+	wasFresh := !vault.IdentityExists()
+
+	ageKey, err := vault.EnsureKeypair()
 	if err != nil {
 		return err
 	}
 
-	// Don't clobber a customized example file. `hulak init` is designed to be
-	// safe to re-run; overwriting user-edited content would defeat that.
+	store, err := vault.ReadStore(ageKey.Identity)
+	if err != nil {
+		return err
+	}
+
+	added := ensureStoreSections(store, envNames)
+
+	if err := vault.WriteStore(store, ageKey.Recipient); err != nil {
+		return err
+	}
+
+	if _, err := writeAPIOptionsExample(); err != nil {
+		return err
+	}
+
+	if wasFresh {
+		identityPath, err := vault.IdentityPath()
+		if err != nil {
+			// Non-fatal: vault is initialized; we just can't show the path.
+			identityPath = "(unable to resolve identity path)"
+		}
+		utils.PrintSuccessStderr(
+			fmt.Sprintf("Initialized vault at %s/", utils.HiddenProjectName),
+		)
+		fmt.Fprintf(os.Stderr, "  Public key:    %s\n", ageKey.Recipient)
+		fmt.Fprintf(os.Stderr, "  Identity file: %s\n", identityPath)
+		utils.PrintWarningStderr(
+			"Back up the identity file — losing it means losing access to the vault.",
+		)
+	} else {
+		utils.PrintSuccessStderr(
+			fmt.Sprintf("Vault ready at %s/", utils.HiddenProjectName),
+		)
+	}
+	// Don't report "global" — it's the implicit default and showing it on
+	// every fresh init reads as noise. Only mention explicit extras.
+	var extras []string
+	for _, name := range added {
+		if name != utils.DefaultEnvVal {
+			extras = append(extras, name)
+		}
+	}
+	if len(extras) > 0 {
+		utils.PrintInfoStderr("Added envs: " + strings.Join(extras, ", "))
+	}
+	return nil
+}
+
+// ensureStoreSections makes sure every env in `names` (plus the default
+// "global") exists as an empty section in store. Returns the names that were
+// newly created so the caller can report them. Names that match the default
+// case-insensitively are folded into "global" rather than creating duplicates.
+func ensureStoreSections(store *vault.Store, names []string) []string {
+	var added []string
+	if store.Envs == nil {
+		store.Envs = make(map[string]vault.Env)
+	}
+	if _, ok := store.Envs[utils.DefaultEnvVal]; !ok {
+		store.Envs[utils.DefaultEnvVal] = make(vault.Env)
+		added = append(added, utils.DefaultEnvVal)
+	}
+	for _, name := range names {
+		if strings.EqualFold(name, utils.DefaultEnvVal) {
+			continue
+		}
+		if _, ok := store.Envs[name]; ok {
+			continue
+		}
+		store.Envs[name] = make(vault.Env)
+		added = append(added, name)
+	}
+	return added
+}
+
+// writeAPIOptionsExample writes the embedded apiOptions.hk.yaml to the project
+// root if absent. Returns whether the file was newly written. Skips with a
+// "kept existing" warning if the user has customized it — re-running init
+// must never clobber edited content.
+func writeAPIOptionsExample() (bool, error) {
+	root, err := utils.CreatePath(utils.APIOptions)
+	if err != nil {
+		return false, err
+	}
 	if utils.FileExists(root) {
 		utils.PrintWarningStderr(
 			fmt.Sprintf("Kept existing '%s' (delete it to regenerate)", utils.APIOptions),
 		)
-		utils.PrintSuccessStderr("Done")
-		return nil
+		return false, nil
 	}
 
 	content, err := embeddedFiles.ReadFile(utils.APIOptions)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if err := os.WriteFile(root, content, utils.FilePer); err != nil {
-		return fmt.Errorf("error on writing '%s' file: %s", utils.APIOptions, err)
+		return false, fmt.Errorf("error on writing '%s' file: %w", utils.APIOptions, err)
 	}
 
 	utils.PrintSuccessStderr(fmt.Sprintf("Created '%s'", utils.APIOptions))
-	utils.PrintSuccessStderr("Done")
-	return nil
+	return true, nil
 }
 
 // ensureGitignoreEntry adds env/ to .gitignore if not already present.

--- a/pkg/userFlags/init.go
+++ b/pkg/userFlags/init.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/xaaha/hulak/pkg/envparser"
@@ -15,10 +16,28 @@ import (
 //go:embed apiOptions.hk.yaml
 var embeddedFiles embed.FS
 
-// InitDefaultProject performs the default hulak project initialization:
-// creates env/ directory, global.env, and the apiOptions.hk.yaml example file.
-// It also adds env/ to .gitignore if not already present.
-func InitDefaultProject() error {
+// InitClassicProject sets up the plaintext env/ layout: env/ directory,
+// global.env, the apiOptions.hk.yaml example, and an env/ entry in .gitignore.
+//
+// Refuses to run if .hulak/ already exists in the current directory — that
+// signals the user has already initialized the encrypted vault, and bolting
+// a parallel plaintext layout next to it would create two sources of truth
+// for environment values. The user has to remove .hulak/ explicitly to opt
+// out of the vault.
+func InitClassicProject() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("could not determine current directory: %w", err)
+	}
+	if utils.DirExists(filepath.Join(cwd, utils.HiddenProjectName)) {
+		return fmt.Errorf(
+			"refusing to create plaintext env/ layout: %s/ already exists "+
+				"(this project is using the encrypted vault) — "+
+				"remove %s/ first if you really want to switch",
+			utils.HiddenProjectName, utils.HiddenProjectName,
+		)
+	}
+
 	if err := envparser.CreateDefaultEnvs(nil); err != nil {
 		return err
 	}

--- a/pkg/userFlags/init_test.go
+++ b/pkg/userFlags/init_test.go
@@ -72,26 +72,53 @@ func TestInitClassicProject_PreservesUserCustomizedAPIOptions(t *testing.T) {
 }
 
 // TestInitClassicProject_RefusesWhenVaultExists verifies that running classic
-// init in a directory that already has .hulak/ refuses with an error,
-// preventing two parallel sources of truth for env values.
+// init in a directory with an initialized vault (store.age present) refuses
+// with an error, preventing two parallel sources of truth for env values.
 func TestInitClassicProject_RefusesWhenVaultExists(t *testing.T) {
 	dir := t.TempDir()
 	t.Cleanup(chdirTemp(t, dir))
 
-	// Pretend the vault is already initialized.
-	if err := os.Mkdir(filepath.Join(dir, utils.HiddenProjectName), utils.DirPer); err != nil {
+	hulakDir := filepath.Join(dir, utils.HiddenProjectName)
+	if err := os.Mkdir(hulakDir, utils.DirPer); err != nil {
 		t.Fatalf("create %s: %v", utils.HiddenProjectName, err)
+	}
+	// store.age presence — not just the .hulak/ dir — is what marks the
+	// vault as initialized. An empty .hulak/ (e.g. from a partially failed
+	// vault init) must not lock the user out of the classic path.
+	if err := os.WriteFile(
+		filepath.Join(hulakDir, utils.StoreFile), []byte("encrypted"), utils.SecretPer,
+	); err != nil {
+		t.Fatalf("create %s: %v", utils.StoreFile, err)
 	}
 
 	err := InitClassicProject()
 	if err == nil {
-		t.Fatal("expected error when .hulak/ already exists, got nil")
+		t.Fatal("expected error when store.age exists, got nil")
 	}
 
-	// env/ must not have been created.
 	envDir := filepath.Join(dir, utils.EnvironmentFolder)
 	if utils.DirExists(envDir) {
-		t.Errorf("env/ should not have been created when .hulak/ exists")
+		t.Errorf("env/ should not have been created when store.age exists")
+	}
+}
+
+// TestInitClassicProject_AllowsEmptyHulakDir verifies that an empty .hulak/
+// (e.g. left behind by a partially-failed vault init) does NOT block classic
+// init. Only an actual store.age signals "vault initialized."
+func TestInitClassicProject_AllowsEmptyHulakDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Cleanup(chdirTemp(t, dir))
+
+	if err := os.Mkdir(filepath.Join(dir, utils.HiddenProjectName), utils.DirPer); err != nil {
+		t.Fatalf("create %s: %v", utils.HiddenProjectName, err)
+	}
+
+	if err := InitClassicProject(); err != nil {
+		t.Fatalf("InitClassicProject should succeed when .hulak/ is empty, got: %v", err)
+	}
+
+	if !utils.DirExists(filepath.Join(dir, utils.EnvironmentFolder)) {
+		t.Error("env/ should have been created")
 	}
 }
 

--- a/pkg/userFlags/init_test.go
+++ b/pkg/userFlags/init_test.go
@@ -9,17 +9,17 @@ import (
 	"github.com/xaaha/hulak/pkg/utils"
 )
 
-// TestInitDefaultProject_PreservesUserCustomizedAPIOptions verifies that
-// re-running `hulak init` does NOT overwrite a user-edited apiOptions.hk.yaml.
-// Init is designed to be safe to re-run; clobbering customizations would
-// defeat that property.
-func TestInitDefaultProject_PreservesUserCustomizedAPIOptions(t *testing.T) {
+// TestInitClassicProject_PreservesUserCustomizedAPIOptions verifies that
+// re-running `hulak init classic` does NOT overwrite a user-edited
+// apiOptions.hk.yaml. Init is designed to be safe to re-run; clobbering
+// customizations would defeat that property.
+func TestInitClassicProject_PreservesUserCustomizedAPIOptions(t *testing.T) {
 	dir := t.TempDir()
 	t.Cleanup(chdirTemp(t, dir))
 
 	// First init: creates the example file.
-	if err := InitDefaultProject(); err != nil {
-		t.Fatalf("first InitDefaultProject: %v", err)
+	if err := InitClassicProject(); err != nil {
+		t.Fatalf("first InitClassicProject: %v", err)
 	}
 
 	apiPath := filepath.Join(dir, utils.APIOptions)
@@ -29,8 +29,8 @@ func TestInitDefaultProject_PreservesUserCustomizedAPIOptions(t *testing.T) {
 	}
 
 	// Second init: must not clobber the custom content.
-	if err := InitDefaultProject(); err != nil {
-		t.Fatalf("second InitDefaultProject: %v", err)
+	if err := InitClassicProject(); err != nil {
+		t.Fatalf("second InitClassicProject: %v", err)
 	}
 
 	got, err := os.ReadFile(apiPath)
@@ -39,5 +39,29 @@ func TestInitDefaultProject_PreservesUserCustomizedAPIOptions(t *testing.T) {
 	}
 	if !bytes.Equal(got, custom) {
 		t.Errorf("re-init overwrote customized %s", utils.APIOptions)
+	}
+}
+
+// TestInitClassicProject_RefusesWhenVaultExists verifies that running classic
+// init in a directory that already has .hulak/ refuses with an error,
+// preventing two parallel sources of truth for env values.
+func TestInitClassicProject_RefusesWhenVaultExists(t *testing.T) {
+	dir := t.TempDir()
+	t.Cleanup(chdirTemp(t, dir))
+
+	// Pretend the vault is already initialized.
+	if err := os.Mkdir(filepath.Join(dir, utils.HiddenProjectName), utils.DirPer); err != nil {
+		t.Fatalf("create %s: %v", utils.HiddenProjectName, err)
+	}
+
+	err := InitClassicProject()
+	if err == nil {
+		t.Fatal("expected error when .hulak/ already exists, got nil")
+	}
+
+	// env/ must not have been created.
+	envDir := filepath.Join(dir, utils.EnvironmentFolder)
+	if utils.DirExists(envDir) {
+		t.Errorf("env/ should not have been created when .hulak/ exists")
 	}
 }

--- a/pkg/userFlags/init_test.go
+++ b/pkg/userFlags/init_test.go
@@ -4,10 +4,39 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
 )
+
+// vaultTestSetup chdirs into a fresh project root and points
+// $XDG_CONFIG_HOME at a separate tmpdir so the user's real identity file is
+// never touched. Returns the project dir for follow-up assertions.
+func vaultTestSetup(t *testing.T) string {
+	t.Helper()
+	projectDir := t.TempDir()
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	t.Cleanup(chdirTemp(t, projectDir))
+	return projectDir
+}
+
+// readVaultStore decrypts and returns the store at .hulak/store.age in the
+// current working directory. Tests use this to assert post-init state.
+func readVaultStore(t *testing.T) *vault.Store {
+	t.Helper()
+	identity, err := vault.LoadIdentity()
+	if err != nil {
+		t.Fatalf("LoadIdentity: %v", err)
+	}
+	store, err := vault.ReadStore(identity)
+	if err != nil {
+		t.Fatalf("ReadStore: %v", err)
+	}
+	return store
+}
 
 // TestInitClassicProject_PreservesUserCustomizedAPIOptions verifies that
 // re-running `hulak init classic` does NOT overwrite a user-edited
@@ -63,5 +92,210 @@ func TestInitClassicProject_RefusesWhenVaultExists(t *testing.T) {
 	envDir := filepath.Join(dir, utils.EnvironmentFolder)
 	if utils.DirExists(envDir) {
 		t.Errorf("env/ should not have been created when .hulak/ exists")
+	}
+}
+
+// TestInitVaultProject_FreshSetup verifies the happy path: empty directory
+// gets .hulak/store.age, .hulak/key.pub, an identity file under the test
+// XDG dir, an apiOptions example, and a decryptable store containing
+// only the implicit "global" section.
+func TestInitVaultProject_FreshSetup(t *testing.T) {
+	dir := vaultTestSetup(t)
+
+	if err := InitVaultProject(nil); err != nil {
+		t.Fatalf("InitVaultProject: %v", err)
+	}
+
+	// .hulak/ + store.age + key.pub
+	wantFiles := []string{
+		filepath.Join(dir, utils.HiddenProjectName, utils.StoreFile),
+		filepath.Join(dir, utils.HiddenProjectName, "key.pub"),
+		filepath.Join(dir, utils.APIOptions),
+	}
+	for _, f := range wantFiles {
+		if !utils.FileExists(f) {
+			t.Errorf("expected %s to exist", f)
+		}
+	}
+
+	// Identity must land in XDG_CONFIG_HOME/hulak (not the user's real config)
+	if !vault.IdentityExists() {
+		t.Error("expected identity file to exist in XDG_CONFIG_HOME")
+	}
+
+	// Store must decrypt and contain exactly { global: {} }
+	store := readVaultStore(t)
+	if len(store.Envs) != 1 {
+		t.Errorf("expected 1 env section, got %d: %v", len(store.Envs), store.ListEnvs())
+	}
+	if store.GetEnv(utils.DefaultEnvVal) == nil {
+		t.Errorf("expected %q section to exist", utils.DefaultEnvVal)
+	}
+}
+
+// TestInitVaultProject_Idempotent verifies that re-running init on an already
+// initialized vault does not regenerate the identity, does not overwrite
+// existing store contents, and does not clobber a customized apiOptions.
+func TestInitVaultProject_Idempotent(t *testing.T) {
+	dir := vaultTestSetup(t)
+
+	if err := InitVaultProject(nil); err != nil {
+		t.Fatalf("first InitVaultProject: %v", err)
+	}
+
+	identityPath, err := vault.IdentityPath()
+	if err != nil {
+		t.Fatalf("IdentityPath: %v", err)
+	}
+	identityBefore, err := os.ReadFile(identityPath)
+	if err != nil {
+		t.Fatalf("read identity: %v", err)
+	}
+
+	// Customize apiOptions to verify it survives re-init.
+	apiPath := filepath.Join(dir, utils.APIOptions)
+	custom := []byte("# custom edits\nkind: API\n")
+	if err := os.WriteFile(apiPath, custom, utils.FilePer); err != nil {
+		t.Fatalf("simulate user edit: %v", err)
+	}
+
+	// Set a value in the vault, so we can also verify the store wasn't reset.
+	identity, err := vault.LoadIdentity()
+	if err != nil {
+		t.Fatalf("LoadIdentity: %v", err)
+	}
+	store, err := vault.ReadStore(identity)
+	if err != nil {
+		t.Fatalf("ReadStore: %v", err)
+	}
+	store.SetKey(utils.DefaultEnvVal, "FOO", "bar")
+	if err := vault.WriteStore(store, identity.Recipient()); err != nil {
+		t.Fatalf("WriteStore: %v", err)
+	}
+
+	// Second init: must not regenerate identity, must not lose the FOO key.
+	if err := InitVaultProject(nil); err != nil {
+		t.Fatalf("second InitVaultProject: %v", err)
+	}
+
+	identityAfter, err := os.ReadFile(identityPath)
+	if err != nil {
+		t.Fatalf("re-read identity: %v", err)
+	}
+	if !bytes.Equal(identityBefore, identityAfter) {
+		t.Error("identity file changed across re-init — must be idempotent")
+	}
+
+	got, err := os.ReadFile(apiPath)
+	if err != nil {
+		t.Fatalf("re-read apiOptions: %v", err)
+	}
+	if !bytes.Equal(got, custom) {
+		t.Error("re-init clobbered customized apiOptions.hk.yaml")
+	}
+
+	storeAfter := readVaultStore(t)
+	env := storeAfter.GetEnv(utils.DefaultEnvVal)
+	if env == nil || env["FOO"] != "bar" {
+		t.Errorf("re-init lost previously-set value: env=%v", env)
+	}
+}
+
+// TestInitVaultProject_WithExtraEnvs verifies that -env arg names land as
+// empty sections in the store alongside the implicit "global".
+func TestInitVaultProject_WithExtraEnvs(t *testing.T) {
+	vaultTestSetup(t)
+
+	if err := InitVaultProject([]string{"staging", "prod"}); err != nil {
+		t.Fatalf("InitVaultProject: %v", err)
+	}
+
+	store := readVaultStore(t)
+	got := store.ListEnvs() // sorted
+	want := []string{utils.DefaultEnvVal, "prod", "staging"}
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("ListEnvs() = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("ListEnvs()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	for _, name := range []string{"staging", "prod"} {
+		env := store.GetEnv(name)
+		if env == nil {
+			t.Errorf("expected %q section to exist", name)
+			continue
+		}
+		if len(env) != 0 {
+			t.Errorf("expected %q to be empty, got %d keys", name, len(env))
+		}
+	}
+}
+
+// TestInitVaultProject_LegacyEnvNudge verifies that init in a directory with
+// pre-existing env/ but no .hulak/ returns nil without creating .hulak/, so
+// the user can run `hulak migrate env` deliberately.
+func TestInitVaultProject_LegacyEnvNudge(t *testing.T) {
+	dir := vaultTestSetup(t)
+
+	// Pre-create env/ to simulate a legacy classic project.
+	envDir := filepath.Join(dir, utils.EnvironmentFolder)
+	if err := os.Mkdir(envDir, utils.DirPer); err != nil {
+		t.Fatalf("mkdir env/: %v", err)
+	}
+
+	if err := InitVaultProject(nil); err != nil {
+		t.Fatalf("expected nil err on legacy nudge path, got: %v", err)
+	}
+
+	hulakDir := filepath.Join(dir, utils.HiddenProjectName)
+	if utils.DirExists(hulakDir) {
+		t.Error(".hulak/ should not have been created when env/ exists")
+	}
+	if vault.IdentityExists() {
+		t.Error("identity should not have been generated when nudging")
+	}
+}
+
+// TestInitVaultProject_RejectsInvalidEnvName verifies that an invalid env
+// name aborts before any filesystem mutation — no .hulak/, no identity.
+func TestInitVaultProject_RejectsInvalidEnvName(t *testing.T) {
+	dir := vaultTestSetup(t)
+
+	err := InitVaultProject([]string{"good_name", "bad name!"})
+	if err == nil {
+		t.Fatal("expected error for invalid env name, got nil")
+	}
+
+	hulakDir := filepath.Join(dir, utils.HiddenProjectName)
+	if utils.DirExists(hulakDir) {
+		t.Error(".hulak/ should not have been created when validation fails")
+	}
+	if vault.IdentityExists() {
+		t.Error("identity should not have been generated when validation fails")
+	}
+}
+
+// TestInitVaultProject_DedupesGlobal verifies that passing "Global" (any
+// case) in -env args does not create a duplicate section — the
+// case-insensitive match folds it into the implicit "global".
+func TestInitVaultProject_DedupesGlobal(t *testing.T) {
+	vaultTestSetup(t)
+
+	if err := InitVaultProject([]string{"Global", "GLOBAL"}); err != nil {
+		t.Fatalf("InitVaultProject: %v", err)
+	}
+
+	store := readVaultStore(t)
+	if len(store.Envs) != 1 {
+		t.Errorf(
+			"expected exactly 1 section after dedup, got %d: %v",
+			len(store.Envs), store.ListEnvs(),
+		)
+	}
+	if store.GetEnv(utils.DefaultEnvVal) == nil {
+		t.Errorf("expected canonical %q section", utils.DefaultEnvVal)
 	}
 }

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -82,6 +82,26 @@ func newVersionCmd() *command {
 	}
 }
 
+// runInitEnvScaffold creates one .env file per name in args under the legacy
+// env/ layout. Used by both `hulak init -env ...` (vault mode, until Slice C
+// swaps to store sections) and `hulak init classic -env ...`.
+func runInitEnvScaffold(args []string) error {
+	if len(args) == 0 {
+		utils.PrintWarningStderr("No environment names provided after -env flag")
+		return nil
+	}
+	var firstErr error
+	for _, env := range args {
+		if err := envparser.CreateDefaultEnvs(&env); err != nil {
+			utils.PrintErrorStderr(err.Error())
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
 func newInitCmd() *command {
 	fs := flag.NewFlagSet("init", flag.ContinueOnError)
 	createEnvFlag := fs.Bool(
@@ -95,15 +115,80 @@ func newInitCmd() *command {
 		Short: "Initialize a hulak project",
 		Long: fmt.Sprintf(
 			"Set up a new hulak project in the current directory.\n\n"+
-				"Creates an env/ directory with global.env, a .gitignore entry,\n"+
-				"and an example '%s' file. Use -env to create specific environments.",
+				"By default, creates an encrypted vault (.hulak/store.age) plus an example '%s'.\n"+
+				"Run 'hulak init classic' (aliases: plain, no-vault) to use the plaintext env/\n"+
+				"layout instead. Use -env to scaffold specific environments.",
 			utils.APIOptions,
 		),
 		Examples: []*utils.CommandHelp{
-			{Command: "hulak init", Description: "Default setup (global.env + example file)"},
+			{Command: "hulak init", Description: "Default setup (encrypted vault + example file)"},
 			{
 				Command:     "hulak init -env staging prod",
-				Description: "Create staging.env and prod.env",
+				Description: "Scaffold staging and prod environments alongside global",
+			},
+			{
+				Command:     "hulak init classic",
+				Description: "Use the plaintext env/ layout (global.env + example file)",
+			},
+			{
+				Command:     "hulak init plain",
+				Description: "Same as 'classic' (alias — see also: 'no-vault')",
+			},
+			{
+				Command:     "hulak init classic -env staging prod",
+				Description: "Plaintext layout with extra environments scaffolded",
+			},
+			{
+				Command:     "hulak init classic --help",
+				Description: "Show full help for the classic subcommand",
+			},
+		},
+		Flags: fs,
+		Args: []argDef{
+			{Name: "envNames", Desc: "Environment names to create (used with -env)"},
+		},
+		SubCommands: []*command{newInitClassicCmd()},
+		Run: func(args []string) error {
+			// TODO(#130): swap to InitVaultProject in Slice C. For now this
+			// still runs the classic path so existing behavior is preserved.
+			if *createEnvFlag {
+				return runInitEnvScaffold(args)
+			}
+			return InitClassicProject()
+		},
+	}
+}
+
+func newInitClassicCmd() *command {
+	fs := flag.NewFlagSet("init classic", flag.ContinueOnError)
+	createEnvFlag := fs.Bool(
+		"env",
+		false,
+		"Create specific environment files instead of the default setup",
+	)
+
+	return &command{
+		Name:    "classic",
+		Aliases: []string{"plain", "no-vault"},
+		Short:   "Initialize with the plaintext env/ layout",
+		Long: fmt.Sprintf(
+			"Initialize a hulak project using the plaintext env/ layout.\n\n"+
+				"Creates an env/ directory with global.env, a .gitignore entry,\n"+
+				"and an example '%s' file. Use this when you don't want the\n"+
+				"encrypted vault — for example, in throwaway scripts or when\n"+
+				"secrets are managed entirely outside hulak.",
+			utils.APIOptions,
+		),
+		Examples: []*utils.CommandHelp{
+			{
+				Command:     "hulak init classic",
+				Description: "Plaintext setup (global.env + example file)",
+			},
+			{Command: "hulak init plain", Description: "Same as classic (alias)"},
+			{Command: "hulak init no-vault", Description: "Same as classic (alias)"},
+			{
+				Command:     "hulak init classic -env staging prod",
+				Description: "Create staging.env and prod.env in the env/ directory",
 			},
 		},
 		Flags: fs,
@@ -112,24 +197,9 @@ func newInitCmd() *command {
 		},
 		Run: func(args []string) error {
 			if *createEnvFlag {
-				if len(args) == 0 {
-					utils.PrintWarningStderr("No environment names provided after -env flag")
-					return nil
-				}
-				// Collect failures so the user sees every one, but bail at the
-				// end so the exit code reflects that something went wrong.
-				var firstErr error
-				for _, env := range args {
-					if err := envparser.CreateDefaultEnvs(&env); err != nil {
-						utils.PrintErrorStderr(err.Error())
-						if firstErr == nil {
-							firstErr = err
-						}
-					}
-				}
-				return firstErr
+				return runInitEnvScaffold(args)
 			}
-			return InitDefaultProject()
+			return InitClassicProject()
 		},
 	}
 }

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -149,12 +149,15 @@ func newInitCmd() *command {
 		},
 		SubCommands: []*command{newInitClassicCmd()},
 		Run: func(args []string) error {
-			// TODO(#130): swap to InitVaultProject in Slice C. For now this
-			// still runs the classic path so existing behavior is preserved.
+			var envNames []string
 			if *createEnvFlag {
-				return runInitEnvScaffold(args)
+				if len(args) == 0 {
+					utils.PrintWarningStderr("No environment names provided after -env flag")
+				} else {
+					envNames = args
+				}
 			}
-			return InitClassicProject()
+			return InitVaultProject(envNames)
 		},
 	}
 }

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -82,26 +82,6 @@ func newVersionCmd() *command {
 	}
 }
 
-// runInitEnvScaffold creates one .env file per name in args under the legacy
-// env/ layout. Used by both `hulak init -env ...` (vault mode, until Slice C
-// swaps to store sections) and `hulak init classic -env ...`.
-func runInitEnvScaffold(args []string) error {
-	if len(args) == 0 {
-		utils.PrintWarningStderr("No environment names provided after -env flag")
-		return nil
-	}
-	var firstErr error
-	for _, env := range args {
-		if err := envparser.CreateDefaultEnvs(&env); err != nil {
-			utils.PrintErrorStderr(err.Error())
-			if firstErr == nil {
-				firstErr = err
-			}
-		}
-	}
-	return firstErr
-}
-
 func newInitCmd() *command {
 	fs := flag.NewFlagSet("init", flag.ContinueOnError)
 	createEnvFlag := fs.Bool(
@@ -199,10 +179,25 @@ func newInitClassicCmd() *command {
 			{Name: "envNames", Desc: "Environment names to create (used with -env)"},
 		},
 		Run: func(args []string) error {
-			if *createEnvFlag {
-				return runInitEnvScaffold(args)
+			if !*createEnvFlag {
+				return InitClassicProject()
 			}
-			return InitClassicProject()
+			if len(args) == 0 {
+				utils.PrintWarningStderr("No environment names provided after -env flag")
+				return nil
+			}
+			// Collect failures so the user sees every one, but return the
+			// first error so the exit code reflects that something went wrong.
+			var firstErr error
+			for _, env := range args {
+				if err := envparser.CreateDefaultEnvs(&env); err != nil {
+					utils.PrintErrorStderr(err.Error())
+					if firstErr == nil {
+						firstErr = err
+					}
+				}
+			}
+			return firstErr
 		},
 	}
 }

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -279,7 +279,10 @@ func newGQLCmd() *command {
 			gqlCmd.printHelp()
 			return nil
 		}
-		data, refreshFn, warnings := loadGraphQLOperations(args[0], *envFlagVal)
+		data, refreshFn, warnings, err := loadGraphQLOperations(args[0], *envFlagVal)
+		if err != nil {
+			return err
+		}
 		if data.Operations == nil {
 			return nil
 		}

--- a/pkg/vault/keys.go
+++ b/pkg/vault/keys.go
@@ -27,6 +27,23 @@ func getIdentityFilePath() (string, error) {
 	return filepath.Join(configDir, identityFile), nil
 }
 
+// IdentityPath returns the absolute path to the user's age identity file.
+// Exposed for callers (e.g. `hulak init`) that want to display the path to
+// the user without resolving the config dir themselves.
+func IdentityPath() (string, error) {
+	return getIdentityFilePath()
+}
+
+// IdentityExists reports whether the identity file is already present on disk.
+// Cheaper than LoadIdentity when the caller only needs the boolean.
+func IdentityExists() bool {
+	path, err := getIdentityFilePath()
+	if err != nil {
+		return false
+	}
+	return utils.FileExists(path)
+}
+
 // getPublicKeyFilePath returns the 'key.pub' path from the project marker (.hulak/)
 func getPublicKeyFilePath() (string, error) {
 	markerPath, err := utils.GetProjectMarker()

--- a/pkg/vault/keys.go
+++ b/pkg/vault/keys.go
@@ -18,8 +18,10 @@ const (
 	publicKeyFile = "key.pub"
 )
 
-// getIdentityFilePath returns the 'identity.txt' from the global conifg location
-func getIdentityFilePath() (string, error) {
+// IdentityPath returns the absolute path to the user's age identity file
+// under the platform config dir (~/.config/hulak/identity.txt on Linux,
+// the macOS equivalent, etc.).
+func IdentityPath() (string, error) {
 	configDir, err := utils.UserConfigDir()
 	if err != nil {
 		return "", err
@@ -27,17 +29,10 @@ func getIdentityFilePath() (string, error) {
 	return filepath.Join(configDir, identityFile), nil
 }
 
-// IdentityPath returns the absolute path to the user's age identity file.
-// Exposed for callers (e.g. `hulak init`) that want to display the path to
-// the user without resolving the config dir themselves.
-func IdentityPath() (string, error) {
-	return getIdentityFilePath()
-}
-
 // IdentityExists reports whether the identity file is already present on disk.
 // Cheaper than LoadIdentity when the caller only needs the boolean.
 func IdentityExists() bool {
-	path, err := getIdentityFilePath()
+	path, err := IdentityPath()
 	if err != nil {
 		return false
 	}
@@ -55,7 +50,7 @@ func getPublicKeyFilePath() (string, error) {
 
 // GetIdentity reads and returns the raw private key string from the identity file.
 func GetIdentity() (string, error) {
-	path, err := getIdentityFilePath()
+	path, err := IdentityPath()
 	if err != nil {
 		return "", err
 	}
@@ -84,7 +79,7 @@ func LoadIdentity() (*age.X25519Identity, error) {
 // Creates the parent directory if it doesn't exist so first-use bootstrap
 // works without a separate "init the config dir" step.
 func SetIdentity(privateKey string) error {
-	identityFilePath, err := getIdentityFilePath()
+	identityFilePath, err := IdentityPath()
 	if err != nil {
 		return err
 	}
@@ -121,7 +116,7 @@ func VerifyKeypair(rawPrivateKey, rawPublicKey string) (AgeKey, error) {
 
 // DeleteIdentity removes the identity file from the global config directory.
 func DeleteIdentity() error {
-	identityFilePath, err := getIdentityFilePath()
+	identityFilePath, err := IdentityPath()
 	if err != nil {
 		return err
 	}

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -125,6 +125,20 @@ func (s *Store) ListEnvs() []string {
 	return envs
 }
 
+// EnsureSection creates an empty section for envName if absent. Returns true
+// when a new section was created, false when one already existed. Lets
+// callers seed environments without reaching into the Envs map directly.
+func (s *Store) EnsureSection(envName string) bool {
+	if s.Envs == nil {
+		s.Envs = make(map[string]Env)
+	}
+	if _, ok := s.Envs[envName]; ok {
+		return false
+	}
+	s.Envs[envName] = make(Env)
+	return true
+}
+
 // SetKey upserts a key-value pair in the given environment.
 // Creates the environment if it does not exist.
 func (s *Store) SetKey(envName, key string, value any) {

--- a/pkg/vault/store_test.go
+++ b/pkg/vault/store_test.go
@@ -92,6 +92,41 @@ func TestStoreListEnvs(t *testing.T) {
 	}
 }
 
+func TestStoreEnsureSection(t *testing.T) {
+	t.Run("creates section on nil Envs map", func(t *testing.T) {
+		s := &Store{}
+		if !s.EnsureSection("global") {
+			t.Error("EnsureSection on nil Envs should return true")
+		}
+		if s.GetEnv("global") == nil {
+			t.Error("EnsureSection did not create section")
+		}
+	})
+
+	t.Run("returns false when section already exists", func(t *testing.T) {
+		s := &Store{Envs: map[string]Env{"prod": {"K": "v"}}}
+		if s.EnsureSection("prod") {
+			t.Error("EnsureSection on existing section should return false")
+		}
+		if s.Envs["prod"]["K"] != "v" {
+			t.Error("EnsureSection clobbered existing section contents")
+		}
+	})
+
+	t.Run("creates new section alongside existing", func(t *testing.T) {
+		s := &Store{Envs: map[string]Env{"global": {"K": "v"}}}
+		if !s.EnsureSection("staging") {
+			t.Error("EnsureSection on new name should return true")
+		}
+		if s.GetEnv("staging") == nil || len(s.GetEnv("staging")) != 0 {
+			t.Errorf("expected empty staging section, got %v", s.GetEnv("staging"))
+		}
+		if s.Envs["global"]["K"] != "v" {
+			t.Error("EnsureSection disturbed unrelated section")
+		}
+	})
+}
+
 func TestStoreSetKey(t *testing.T) {
 	t.Run("set key in new env", func(t *testing.T) {
 		s := &Store{Envs: make(map[string]Env)}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -78,7 +78,7 @@ func SetPublicKey(publicEncKey string) error {
 //   - identity missing, no store.age   → generate a fresh keypair and write
 //     both files. Any orphan pubkey from a previous identity is overwritten.
 func EnsureKeypair() (AgeKey, error) {
-	identityPath, err := getIdentityFilePath()
+	identityPath, err := IdentityPath()
 	if err != nil {
 		return AgeKey{}, err
 	}


### PR DESCRIPTION
Closes #130.

## Summary

- `hulak init` now bootstraps the encrypted vault by default — creates `.hulak/store.age`, `.hulak/key.pub`, an age identity at `~/.config/hulak/identity.txt`, and the `apiOptions.hk.yaml` example.
- `hulak init classic` (aliases: `plain`, `no-vault`) keeps the legacy `env/` plaintext layout for users who don't want encryption.
- `hulak init -env staging prod` seeds extra empty sections in the store; same flag on `init classic` still creates `staging.env`/`prod.env`.

The `Aliases []string` field on the existing subcommand machinery handles the spelling variants — no flag aliasing required.

## Behaviour matrix

| State of cwd | `hulak init` (vault) | `hulak init classic` |
|---|---|---|
| Empty | bootstrap vault | bootstrap classic |
| `.hulak/` already exists | idempotent — no overwrites, no key regen | error: vault already initialized |
| `env/` already exists, no `.hulak/` | one-line nudge: run `hulak migrate env` | unchanged |

Validation runs **before** any filesystem mutation: `hulak init -env \"bad name!\"` fails up front via `utils.ValidateEnvName`, leaving the project untouched.

First-run identity creation prints the public key, identity path, and a backup nudge to stderr. Re-runs skip the nudge (identity already on disk).

## Notes

- Internal `vault.StoreClassic` enum left as-is; it's a code-only term. The user-facing word is `classic` (subcommand name), not a deprecation signal.
- `recipients.txt` is **not** introduced here — multi-recipient flow is #144. Single-user bootstrap reuses the existing `.hulak/key.pub` from `EnsureKeypair`.
- `import-key` / `export-key` UX is #131.

## Test plan

- [x] Unit tests for vault init: fresh setup, idempotent re-run, `-env` scaffolding, legacy env/ nudge, invalid env-name rejection, case-insensitive global dedup
- [x] Unit tests for classic guard: refuses when `.hulak/` exists; preserves customized `apiOptions.hk.yaml`
- [x] Manual e2e on a clean dir: bare init, env CRUD round-trip, idempotent re-init, scaffolding, validation rejection, classic guard
- [x] `go test ./...` green across 13 packages
- [x] `golangci-lint run ./...` clean