### PR TITLE
feat: multi-recipient encryption for team sharing

### DIFF
--- a/docs/store.md
+++ b/docs/store.md
@@ -66,8 +66,11 @@ age1yr5tpz76yxqeg5ktrp7g2wgkxfmq9rmef0gxhvsky2pyv6lsf8msgmd00n
 ```bash
 mkdir my-apis && cd my-apis
 hulak init
-# ✓ Identity saved to ~/.config/hulak/identity.txt
-# ✓ Recipients file written to .hulak/recipients.txt (1 recipient: you)
+# ✓ Initialized vault at .hulak/
+#   Public key:    age1ql3z...
+#   Recipients:    .hulak/recipients.txt
+#   Identity file: ~/.config/hulak/identity.txt
+# ⚠ Back up the identity file — losing it means losing access to the vault.
 
 hulak env set API_KEY --env prod
 # Enter value for API_KEY: ▊
@@ -123,18 +126,19 @@ A single `store.age` can be encrypted to many recipients. Each teammate has thei
 ```bash
 # === New member's machine ===
 hulak init
-# Generates the new member's own keypair locally
-cat .hulak/recipients.txt | tail -1
-# age1bob...
+# Shows their public key in the output:
+#   Public key: age1bob...
+
+hulak env list-recipients
+# Shows their own key
 ```
 
 The new member sends their **public key** (`age1bob...`) to an existing team member via Slack, email, or a PR. **Public keys are not secret.** Never share the private key from `~/.config/hulak/identity.txt`.
 
 ```bash
 # === Existing team member ===
-hulak env add-recipient age1bob... --name "Bob"
-# ✓ Added Bob to .hulak/recipients.txt
-# ✓ Re-encrypted store.age for 3 recipients
+hulak env add-recipient age1bob... --name Bob
+# ✓ Added recipient age1bob...
 
 git add .hulak/recipients.txt .hulak/store.age
 git commit -m "add Bob as recipient"
@@ -148,15 +152,14 @@ hulak env list   # ✓ works — Bob's identity can decrypt
 ### Leaving a team
 
 ```bash
-hulak env remove-recipient --name "Alice"
-# ✓ Removed Alice from .hulak/recipients.txt
-# ✓ Re-encrypted store.age for 2 recipients
-#
-# ⚠ Reminder: Alice may have already read any secrets in this store.
-#   remove-recipient only prevents FUTURE access. To fully revoke:
-#     1. Rotate the actual secret values upstream (API keys, passwords, etc.)
-#     2. hulak env set <KEY> <new-value> for each rotated secret
-#     3. Commit and push
+hulak env remove-recipient Alice
+# ✓ Removed recipient
+# ⚠ Note: Alice can still decrypt copies of store.age from before this point.
+#   Rotate upstream secrets if compromise is suspected.
+
+git add .hulak/recipients.txt .hulak/store.age
+git commit -m "remove Alice as recipient"
+git push
 ```
 
 ### Why rotation matters
@@ -178,12 +181,8 @@ You cannot remove yourself if you are the only recipient — that would brick th
 
 ```bash
 hulak env remove-recipient age1ql3z...
-# error: cannot remove the last recipient — this would brick the store.
-#
-#   Add another recipient first:
-#     hulak env add-recipient <new-public-key>
-#
-#   Or, if you intended to delete the project, remove .hulak/store.age manually.
+# error: refusing to remove the last recipient — the store would become
+# unrecoverable. Add another recipient first, or delete .hulak/store.age manually
 ```
 
 ## Commands
@@ -199,10 +198,10 @@ hulak env remove-recipient age1ql3z...
 | `hulak env edit [--env name]`                        | Open `$EDITOR` on the env (TUI picker if no `--env`)   |
 | `hulak env export-key [--out path]`                  | Print or save your private key                         |
 | `hulak env import-key path [--force]`                | Restore an identity from a file                        |
-| `hulak env add-recipient KEY [--name n]`             | Authorize a new public key                             |
-| `hulak env remove-recipient KEY [--name n]`          | Revoke a public key                                    |
+| `hulak env add-recipient KEY [--name n] [--stdin]`   | Authorize a new public key (or many via stdin)         |
+| `hulak env remove-recipient <key-or-name>`           | Revoke by public key or name label                     |
 | `hulak env list-recipients`                          | Show all authorized public keys                        |
-| `hulak env rotate`                                   | Re-encrypt to the current recipient set                |
+| `hulak env rotate` (aliases: `sync`, `reencrypt`)    | Re-encrypt to the current recipient set                |
 | `hulak env rotate-key`                               | Generate a new identity, re-encrypt                    |
 | `hulak migrate env`                                  | Convert `env/*.env` to `store.age`                     |
 
@@ -231,7 +230,7 @@ git add .hulak/store.age .hulak/recipients.txt
 git commit
 ```
 
-`hulak env rotate` (see #144) re-encrypts the store to the current `recipients.txt` without changing keys — exactly what you need after a merge.
+`hulak env rotate` re-encrypts the store to the current `recipients.txt` without changing keys — exactly what you need after a merge.
 
 > [!Tip]
 > For frequent recipient churn (large teams), consider squashing multiple `add-recipient` / `remove-recipient` commits into one to reduce merge surface area.

--- a/pkg/envparser/envparser.go
+++ b/pkg/envparser/envparser.go
@@ -118,7 +118,7 @@ func LoadEnvVars(filePath string) (map[string]any, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		// Skip empty lines and comments
-		if len(line) == 0 || strings.HasPrefix(line, "#") {
+		if len(line) == 0 || strings.HasPrefix(line, utils.Comment) {
 			continue
 		}
 		// Remove empty lines

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -603,15 +603,47 @@ func launchEditor(path string) error {
 
 // --- ADD-RECIPIENT ---
 
-// runAddRecipient handles `hulak env add-recipient <public-key> [--name n]`.
-func runAddRecipient(args []string, name string) error {
+// resolveRecipientKeys returns public keys to add. From --stdin (one per line,
+// blank lines and # comments ignored) or from positional arg. Error if both.
+func resolveRecipientKeys(args []string, useStdin bool) ([]string, error) {
+	if useStdin && len(args) > 0 {
+		return nil, errors.New("cannot use both --stdin and a positional key — pick one")
+	}
+
+	if useStdin {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read stdin: %w", err)
+		}
+		var keys []string
+		for line := range strings.SplitSeq(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, utils.Comment) {
+				continue
+			}
+			keys = append(keys, line)
+		}
+		if len(keys) == 0 {
+			return nil, errors.New("no keys found in stdin")
+		}
+		return keys, nil
+	}
+
 	if len(args) == 0 {
-		return errors.New("missing required argument: public-key")
+		return nil, errors.New("missing required argument: public-key")
 	}
 	if len(args) > 1 {
-		return fmt.Errorf("too many arguments: got %d, expected 1 (public-key)", len(args))
+		return nil, fmt.Errorf("too many arguments: got %d, expected 1 (public-key)", len(args))
 	}
-	pubKey := args[0]
+	return []string{args[0]}, nil
+}
+
+// runAddRecipient handles `hulak env add-recipient <public-key> [--name n] [--stdin]`.
+func runAddRecipient(args []string, name string, useStdin bool) error {
+	pubKeys, err := resolveRecipientKeys(args, useStdin)
+	if err != nil {
+		return err
+	}
 
 	return vault.WithStoreLock(func() error {
 		// Read current entries
@@ -628,13 +660,15 @@ func runAddRecipient(args []string, name string) error {
 			return err
 		}
 
-		// Add new entry (validates key, rejects dupes)
-		entries, err = vault.AddRecipientEntry(entries, pubKey, name)
-		if err != nil {
-			return err
+		// Add each key
+		for _, pubKey := range pubKeys {
+			entries, err = vault.AddRecipientEntry(entries, pubKey, name)
+			if err != nil {
+				return err
+			}
 		}
 
-		// Re-encrypt store to all recipients including new one
+		// Re-encrypt store to all recipients including new ones
 		identity, err := vault.LoadIdentity()
 		if err != nil {
 			return fmt.Errorf("failed to load identity: %w", err)
@@ -657,11 +691,15 @@ func runAddRecipient(args []string, name string) error {
 			return err
 		}
 
-		keyPrefix := pubKey
-		if len(keyPrefix) > EllipsisLength {
-			keyPrefix = keyPrefix[:20] + utils.Ellipsis
+		if len(pubKeys) == 1 {
+			keyPrefix := pubKeys[0]
+			if len(keyPrefix) > EllipsisLength {
+				keyPrefix = keyPrefix[:EllipsisLength] + utils.Ellipsis
+			}
+			utils.PrintSuccessStderr(fmt.Sprintf("Added recipient %s", keyPrefix))
+		} else {
+			utils.PrintSuccessStderr(fmt.Sprintf("Added %d recipients", len(pubKeys)))
 		}
-		utils.PrintSuccessStderr(fmt.Sprintf("Added recipient %s", keyPrefix))
 		return nil
 	})
 }

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -19,8 +19,12 @@ import (
 	"github.com/xaaha/hulak/pkg/vault"
 )
 
-// maskedValue is what `keys` prints in place of secret values when --show is off.
-const maskedValue = "••••"
+const (
+	// maskedValue is what `keys` prints in place of secret values when --show is off.
+	maskedValue = "••••"
+	// Length after which Ellipsis start
+	EllipsisLength = 20
+)
 
 // envPicker is the function called to interactively pick an environment when
 // the user omits --env on `hulak env edit`. Indirected as a package variable
@@ -654,7 +658,7 @@ func runAddRecipient(args []string, name string) error {
 		}
 
 		keyPrefix := pubKey
-		if len(keyPrefix) > 20 {
+		if len(keyPrefix) > EllipsisLength {
 			keyPrefix = keyPrefix[:20] + utils.Ellipsis
 		}
 		utils.PrintSuccessStderr(fmt.Sprintf("Added recipient %s", keyPrefix))
@@ -696,7 +700,9 @@ func runRemoveRecipient(args []string) error {
 			return err
 		}
 		if !removed {
-			utils.PrintWarningStderr(fmt.Sprintf("No recipient matching %q found — no changes made", query))
+			utils.PrintWarningStderr(
+				fmt.Sprintf("No recipient matching %q found — no changes made", query),
+			)
 			return nil
 		}
 
@@ -724,6 +730,77 @@ func runRemoveRecipient(args []string) error {
 
 		utils.PrintSuccessStderr("Removed recipient")
 		utils.PrintWarningStderr(fmt.Sprintf(RotationReminder, query))
+		return nil
+	})
+}
+
+// --- LIST-RECIPIENTS ---
+
+// runListRecipients handles `hulak env list-recipients`.
+func runListRecipients(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
+	}
+
+	recipPath, err := vault.RecipientsFilePath()
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(recipPath)
+	if err != nil {
+		return fmt.Errorf("failed to read recipients file: %w", err)
+	}
+	entries, err := vault.ParseRecipientsFileContent(data)
+	if err != nil {
+		return err
+	}
+
+	rows := make([][]string, len(entries))
+	for idx, entry := range entries {
+		name := entry.Name
+		if name == "" {
+			name = "(no label)"
+		}
+		keyPrefix := entry.Key
+		if len(keyPrefix) > EllipsisLength {
+			keyPrefix = keyPrefix[:20] + utils.Ellipsis
+		}
+		rows[idx] = []string{name, keyPrefix}
+	}
+	return utils.PrintTable(
+		os.Stdout,
+		stdoutHeaders([]string{"NAME", "KEY"}),
+		rows,
+		0,
+	)
+}
+
+// --- SYNC ---
+
+// runSync handles `hulak env sync`.
+// Re-encrypts store.age to match the current recipients.txt.
+// Useful after manually editing recipients.txt.
+func runSync(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
+	}
+
+	return vault.WithStoreLock(func() error {
+		identity, err := vault.LoadIdentity()
+		if err != nil {
+			return fmt.Errorf("failed to load identity: %w", err)
+		}
+
+		store, err := vault.ReadStore(identity)
+		if err != nil {
+			return err
+		}
+
+		if err := vault.WriteStoreToRecipients(store); err != nil {
+			return err
+		}
+
+		utils.PrintSuccessStderr("Re-encrypted store to current recipients")
 		return nil
 	})
 }

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -94,7 +94,7 @@ func runEnvSet(args []string, envName string, useStdin bool) error {
 		store.SetKey(envName, key, value)
 
 		// write  (atomic .tmp+rename)
-		if err := vault.WriteStore(store, ageKey.Recipient); err != nil {
+		if err := vault.WriteStoreToRecipients(store); err != nil {
 			return err
 		}
 
@@ -258,7 +258,7 @@ func runEnvDelete(args []string, envName string) error {
 
 		store.DeleteKey(envName, key)
 
-		if err := vault.WriteStore(store, identity.Recipient()); err != nil {
+		if err := vault.WriteStoreToRecipients(store); err != nil {
 			return err
 		}
 
@@ -561,7 +561,7 @@ func runEnvEdit(args []string, envName string) error {
 
 		store.Envs[envName] = newEnv
 
-		if err := vault.WriteStore(store, ageKey.Recipient); err != nil {
+		if err := vault.WriteStoreToRecipients(store); err != nil {
 			return err
 		}
 

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -661,3 +661,69 @@ func runAddRecipient(args []string, name string) error {
 		return nil
 	})
 }
+
+// --- REMOVE-RECIPIENT ---
+
+// RotationReminder is the security notice printed after removing a recipient.
+const RotationReminder = "Note: %s can still decrypt copies of store.age from before this point. Rotate upstream secrets if compromise is suspected."
+
+// runRemoveRecipient handles `hulak env remove-recipient <key-or-name>`.
+func runRemoveRecipient(args []string) error {
+	if len(args) == 0 {
+		return errors.New("missing required argument: public-key or name label")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments: got %d, expected 1", len(args))
+	}
+	query := args[0]
+
+	return vault.WithStoreLock(func() error {
+		recipPath, err := vault.RecipientsFilePath()
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(recipPath)
+		if err != nil {
+			return fmt.Errorf("failed to read recipients file: %w", err)
+		}
+		entries, err := vault.ParseRecipientsFileContent(data)
+		if err != nil {
+			return err
+		}
+
+		entries, removed, err := vault.RemoveRecipientEntry(entries, query)
+		if err != nil {
+			return err
+		}
+		if !removed {
+			utils.PrintWarningStderr(fmt.Sprintf("No recipient matching %q found — no changes made", query))
+			return nil
+		}
+
+		// Re-encrypt to remaining recipients
+		identity, err := vault.LoadIdentity()
+		if err != nil {
+			return fmt.Errorf("failed to load identity: %w", err)
+		}
+		store, err := vault.ReadStore(identity)
+		if err != nil {
+			return err
+		}
+
+		// Write store first (same atomicity reasoning as add-recipient)
+		recipients, err := vault.RecipientsFromEntries(entries)
+		if err != nil {
+			return err
+		}
+		if err := vault.WriteStore(store, recipients...); err != nil {
+			return err
+		}
+		if err := vault.SaveRecipients(entries); err != nil {
+			return err
+		}
+
+		utils.PrintSuccessStderr("Removed recipient")
+		utils.PrintWarningStderr(fmt.Sprintf(RotationReminder, query))
+		return nil
+	})
+}

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -596,3 +596,68 @@ func launchEditor(path string) error {
 	}
 	return nil
 }
+
+// --- ADD-RECIPIENT ---
+
+// runAddRecipient handles `hulak env add-recipient <public-key> [--name n]`.
+func runAddRecipient(args []string, name string) error {
+	if len(args) == 0 {
+		return errors.New("missing required argument: public-key")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments: got %d, expected 1 (public-key)", len(args))
+	}
+	pubKey := args[0]
+
+	return vault.WithStoreLock(func() error {
+		// Read current entries
+		recipPath, err := vault.RecipientsFilePath()
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(recipPath)
+		if err != nil {
+			return fmt.Errorf("failed to read recipients file: %w", err)
+		}
+		entries, err := vault.ParseRecipientsFileContent(data)
+		if err != nil {
+			return err
+		}
+
+		// Add new entry (validates key, rejects dupes)
+		entries, err = vault.AddRecipientEntry(entries, pubKey, name)
+		if err != nil {
+			return err
+		}
+
+		// Re-encrypt store to all recipients including new one
+		identity, err := vault.LoadIdentity()
+		if err != nil {
+			return fmt.Errorf("failed to load identity: %w", err)
+		}
+		store, err := vault.ReadStore(identity)
+		if err != nil {
+			return err
+		}
+
+		// Write store first (prefer store updated + stale recipients
+		//	over recipients updated + stale store)
+		recipients, err := vault.RecipientsFromEntries(entries)
+		if err != nil {
+			return err
+		}
+		if err := vault.WriteStore(store, recipients...); err != nil {
+			return err
+		}
+		if err := vault.SaveRecipients(entries); err != nil {
+			return err
+		}
+
+		keyPrefix := pubKey
+		if len(keyPrefix) > 20 {
+			keyPrefix = keyPrefix[:20] + utils.Ellipsis
+		}
+		utils.PrintSuccessStderr(fmt.Sprintf("Added recipient %s", keyPrefix))
+		return nil
+	})
+}

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -801,7 +801,7 @@ func runListRecipients(args []string) error {
 		}
 		keyPrefix := entry.Key
 		if len(keyPrefix) > EllipsisLength {
-			keyPrefix = keyPrefix[:20] + utils.Ellipsis
+			keyPrefix = keyPrefix[:EllipsisLength] + utils.Ellipsis
 		}
 		rows[idx] = []string{name, keyPrefix}
 	}

--- a/pkg/userFlags/env_test.go
+++ b/pkg/userFlags/env_test.go
@@ -37,6 +37,20 @@ func setupVaultProject(t *testing.T) string {
 	}
 
 	t.Cleanup(chdirTemp(t, projectDir))
+
+	// EnsureKeypair creates identity + recipients.txt (via ensureRecipientsFile
+	// in init.go flow). Tests that call runEnvSet get this for free, but tests
+	// that call runEnvGet/Delete/List/Keys need the recipients file pre-seeded.
+	ageKey, err := vault.EnsureKeypair()
+	if err != nil {
+		t.Fatalf("EnsureKeypair: %v", err)
+	}
+	if err := vault.SaveRecipients([]vault.RecipientEntry{
+		{Key: ageKey.Recipient.String()},
+	}); err != nil {
+		t.Fatalf("SaveRecipients: %v", err)
+	}
+
 	return projectDir
 }
 

--- a/pkg/userFlags/init.go
+++ b/pkg/userFlags/init.go
@@ -57,7 +57,7 @@ func InitClassicProject() error {
 }
 
 // InitVaultProject sets up the encrypted vault layout: .hulak/store.age,
-// .hulak/key.pub, and the user's age identity at ~/.config/hulak/identity.txt.
+// .hulak/recipients.txt, and the user's age identity at ~/.config/hulak/identity.txt.
 // Also writes the apiOptions.hk.yaml example.
 //
 // Behaviour notes:
@@ -114,6 +114,11 @@ func InitVaultProject(envNames []string) error {
 		return err
 	}
 
+	// Ensure recipients.txt exists with at least the user's own key.
+	if err := ensureRecipientsFile(ageKey); err != nil {
+		return err
+	}
+
 	store, err := vault.ReadStore(ageKey.Identity)
 	if err != nil {
 		return err
@@ -121,7 +126,7 @@ func InitVaultProject(envNames []string) error {
 
 	added := ensureStoreSections(store, envNames)
 
-	if err := vault.WriteStore(store, ageKey.Recipient); err != nil {
+	if err := vault.WriteStoreToRecipients(store); err != nil {
 		return err
 	}
 
@@ -141,6 +146,7 @@ func InitVaultProject(envNames []string) error {
 			fmt.Sprintf("Initialized vault at %s/", utils.HiddenProjectName),
 		)
 		fmt.Fprintf(os.Stderr, "  Public key:    %s\n", ageKey.Recipient)
+		fmt.Fprintf(os.Stderr, "  Recipients:    %s/%s\n", utils.HiddenProjectName, utils.RecipientsFile)
 		fmt.Fprintf(os.Stderr, "  Identity file: %s\n", identityPath)
 		utils.PrintWarningStderr(
 			"Back up the identity file — losing it means losing access to the vault.",
@@ -182,6 +188,22 @@ func ensureStoreSections(store *vault.Store, names []string) []string {
 		}
 	}
 	return added
+}
+
+// ensureRecipientsFile creates .hulak/recipients.txt with the user's own
+// public key if the file doesn't already exist. Idempotent — re-running
+// init on an existing project is a no-op.
+func ensureRecipientsFile(ageKey vault.AgeKey) error {
+	path, err := vault.RecipientsFilePath()
+	if err != nil {
+		return err
+	}
+	if utils.FileExists(path) {
+		return nil
+	}
+	return vault.SaveRecipients([]vault.RecipientEntry{
+		{Key: ageKey.Recipient.String(), Name: vault.FormatRecipientName("owner")},
+	})
 }
 
 // writeAPIOptionsExample writes the embedded apiOptions.hk.yaml to the project

--- a/pkg/userFlags/init_test.go
+++ b/pkg/userFlags/init_test.go
@@ -123,8 +123,8 @@ func TestInitClassicProject_AllowsEmptyHulakDir(t *testing.T) {
 }
 
 // TestInitVaultProject_FreshSetup verifies the happy path: empty directory
-// gets .hulak/store.age, .hulak/key.pub, an identity file under the test
-// XDG dir, an apiOptions example, and a decryptable store containing
+// gets .hulak/store.age, .hulak/recipients.txt, an identity file under the
+// test XDG dir, an apiOptions example, and a decryptable store containing
 // only the implicit "global" section.
 func TestInitVaultProject_FreshSetup(t *testing.T) {
 	dir := vaultTestSetup(t)
@@ -133,10 +133,10 @@ func TestInitVaultProject_FreshSetup(t *testing.T) {
 		t.Fatalf("InitVaultProject: %v", err)
 	}
 
-	// .hulak/ + store.age + key.pub
+	// .hulak/ + store.age + recipients.txt
 	wantFiles := []string{
 		filepath.Join(dir, utils.HiddenProjectName, utils.StoreFile),
-		filepath.Join(dir, utils.HiddenProjectName, "key.pub"),
+		filepath.Join(dir, utils.HiddenProjectName, utils.RecipientsFile),
 		filepath.Join(dir, utils.APIOptions),
 	}
 	for _, f := range wantFiles {

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -682,14 +682,33 @@ func newEnvCmd() *command {
 		{
 			Name:  "list-recipients",
 			Short: "List all recipients",
-			Long:  "Show all age public keys that can decrypt the vault.",
+			Long:  "Show all age public keys that can decrypt the vault, with labels.",
 			Examples: []*utils.CommandHelp{
 				{
 					Command:     "hulak env list-recipients",
 					Description: "Show all recipients with names and key prefixes",
 				},
 			},
-			Run: notImplemented("list-recipients"),
+			Run: runListRecipients,
+		},
+		{
+			Name:    "rotate",
+			Aliases: []string{"sync", "reencrypt"},
+			Short:   "Re-encrypt the store to current recipients",
+			Long: "Re-encrypt store.age to match the current recipients.txt.\n\n" +
+				"Use this after manually editing recipients.txt. Not needed after\n" +
+				"add-recipient or remove-recipient — those re-encrypt automatically.",
+			Examples: []*utils.CommandHelp{
+				{
+					Command:     "hulak env rotate",
+					Description: "Re-encrypt store to match recipients.txt",
+				},
+				{
+					Command:     "hulak env sync",
+					Description: "Same as rotate (alias)",
+				},
+			},
+			Run: runSync,
 		},
 	}
 

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -665,15 +665,19 @@ func newEnvCmd() *command {
 		{
 			Name:  "remove-recipient",
 			Short: "Remove a recipient",
-			Long:  "Remove an age public key from the recipient list and re-encrypt the vault.\n\nNote: removed users can still decrypt copies of the vault from before this point.\nIf revocation matters, also rotate the underlying secrets.",
-			Args:  []argDef{{Name: "public-key", Required: true, Desc: "Age public key to remove"}},
+			Long:  "Remove an age public key from the recipient list and re-encrypt the vault.\n\nMatch by key string or name label. Refuses to remove the last recipient.\nNote: removed users can still decrypt copies from before this point.",
+			Args:  []argDef{{Name: "key-or-name", Required: true, Desc: "Age public key or name label to remove"}},
 			Examples: []*utils.CommandHelp{
 				{
 					Command:     "hulak env remove-recipient age1ql3z...",
-					Description: "Remove a teammate's public key",
+					Description: "Remove by public key",
+				},
+				{
+					Command:     "hulak env remove-recipient Alice",
+					Description: "Remove by name label",
 				},
 			},
-			Run: notImplemented("remove-recipient"),
+			Run: runRemoveRecipient,
 		},
 		{
 			Name:  "list-recipients",

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -447,6 +447,10 @@ func newEnvCmd() *command {
 	exportKeyFs := flag.NewFlagSet("env export-key", flag.ContinueOnError)
 	exportKeyFs.Bool("armor", false, "Output in ASCII-armored format")
 
+	// add-recipient
+	addRecipientFs := flag.NewFlagSet("env add-recipient", flag.ContinueOnError)
+	addRecipientName := addRecipientFs.String("name", "", "Human-readable label for the recipient")
+
 	notImplemented := func(name string) func([]string) error {
 		return func(_ []string) error {
 			// Stderr — this is a status notice, not the data the user asked for.
@@ -643,15 +647,20 @@ func newEnvCmd() *command {
 		{
 			Name:  "add-recipient",
 			Short: "Add a recipient for shared vault access",
-			Long:  "Add an age public key as a recipient so another user can decrypt the vault.\n\nThe vault is re-encrypted to all current recipients plus the new one.",
+			Long:  "Add an age public key as a recipient so another user can decrypt the vault.\n\nThe vault is re-encrypted to all current recipients plus the new one.\nUse --name to add a human-readable label.",
+			Flags: addRecipientFs,
 			Args:  []argDef{{Name: "public-key", Required: true, Desc: "Age public key to add"}},
 			Examples: []*utils.CommandHelp{
 				{
 					Command:     "hulak env add-recipient age1ql3z...",
 					Description: "Add a teammate's public key",
 				},
+				{
+					Command:     "hulak env add-recipient age1ql3z... --name Alice",
+					Description: "Add with a label",
+				},
 			},
-			Run: notImplemented("add-recipient"),
+			Run: func(args []string) error { return runAddRecipient(args, *addRecipientName) },
 		},
 		{
 			Name:  "remove-recipient",

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -450,6 +450,7 @@ func newEnvCmd() *command {
 	// add-recipient
 	addRecipientFs := flag.NewFlagSet("env add-recipient", flag.ContinueOnError)
 	addRecipientName := addRecipientFs.String("name", "", "Human-readable label for the recipient")
+	addRecipientStdin := addRecipientFs.Bool("stdin", false, "Read keys from stdin (one per line)")
 
 	notImplemented := func(name string) func([]string) error {
 		return func(_ []string) error {
@@ -659,8 +660,12 @@ func newEnvCmd() *command {
 					Command:     "hulak env add-recipient age1ql3z... --name Alice",
 					Description: "Add with a label",
 				},
+				{
+					Command:     "cat keys.txt | hulak env add-recipient --stdin --name Team",
+					Description: "Add multiple keys from stdin",
+				},
 			},
-			Run: func(args []string) error { return runAddRecipient(args, *addRecipientName) },
+			Run: func(args []string) error { return runAddRecipient(args, *addRecipientName, *addRecipientStdin) },
 		},
 		{
 			Name:  "remove-recipient",

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -37,6 +37,7 @@ const (
 const (
 	StoreFile      = "store.age"
 	RecipientsFile = "recipients.txt"
+	IdentityFile   = "identity.txt"
 )
 
 // Editor is the fallback editor used when $EDITOR is unset. POSIX guarantees

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -34,7 +34,10 @@ const (
 	DefaultEnvFileSuffix = ".env"
 )
 
-const StoreFile = "store.age"
+const (
+	StoreFile      = "store.age"
+	RecipientsFile = "recipients.txt"
+)
 
 // Editor is the fallback editor used when $EDITOR is unset. POSIX guarantees
 // `vi`, so this works in bare/minimal environments (Alpine, distroless, etc.)

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -98,4 +98,7 @@ const (
 	ConnectorVertical   = "|"
 )
 
-const Ellipsis = "..."
+const (
+	Ellipsis = "..."
+	Comment  = "#"
+)

--- a/pkg/vault/keys.go
+++ b/pkg/vault/keys.go
@@ -13,11 +13,6 @@ import (
 
 // Contains everythig about public and private keys (identity)
 
-const (
-	identityFile  = "identity.txt"
-	publicKeyFile = "key.pub"
-)
-
 // IdentityPath returns the absolute path to the user's age identity file
 // under the platform config dir (~/.config/hulak/identity.txt on Linux,
 // the macOS equivalent, etc.).
@@ -26,7 +21,7 @@ func IdentityPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(configDir, identityFile), nil
+	return filepath.Join(configDir, utils.IdentityFile), nil
 }
 
 // IdentityExists reports whether the identity file is already present on disk.
@@ -37,15 +32,6 @@ func IdentityExists() bool {
 		return false
 	}
 	return utils.FileExists(path)
-}
-
-// getPublicKeyFilePath returns the 'key.pub' path from the project marker (.hulak/)
-func getPublicKeyFilePath() (string, error) {
-	markerPath, err := utils.GetProjectMarker()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(markerPath, publicKeyFile), nil
 }
 
 // GetIdentity reads and returns the raw private key string from the identity file.

--- a/pkg/vault/keys_test.go
+++ b/pkg/vault/keys_test.go
@@ -110,7 +110,7 @@ func TestSetIdentityGetIdentityRoundTrip(t *testing.T) {
 	}
 
 	// Verify file exists with correct permissions
-	identityPath := filepath.Join(configDir, identityFile)
+	identityPath := filepath.Join(configDir, utils.IdentityFile)
 	info, err := os.Stat(identityPath)
 	if err != nil {
 		t.Fatalf("identity file not created: %v", err)
@@ -153,36 +153,6 @@ func TestDeleteIdentityNonexistent(t *testing.T) {
 	err := DeleteIdentity()
 	if err == nil {
 		t.Error("DeleteIdentity() on nonexistent file should return error")
-	}
-}
-
-func TestSetPublicKey(t *testing.T) {
-	projectDir := setupHulakProject(t)
-
-	id, _ := age.GenerateX25519Identity()
-	pubKey := id.Recipient().String()
-
-	if err := SetPublicKey(pubKey); err != nil {
-		t.Fatalf("SetPublicKey() error: %v", err)
-	}
-
-	pubKeyPath := filepath.Join(projectDir, utils.HiddenProjectName, publicKeyFile)
-	got, err := os.ReadFile(pubKeyPath)
-	if err != nil {
-		t.Fatalf("failed to read key.pub: %v", err)
-	}
-
-	if strings.TrimSpace(string(got)) != pubKey {
-		t.Errorf("key.pub content = %q, want %q", strings.TrimSpace(string(got)), pubKey)
-	}
-
-	// Verify file permissions
-	info, err := os.Stat(pubKeyPath)
-	if err != nil {
-		t.Fatalf("failed to stat key.pub: %v", err)
-	}
-	if info.Mode().Perm() != utils.FilePer {
-		t.Errorf("key.pub permissions = %o, want %o", info.Mode().Perm(), utils.FilePer)
 	}
 }
 
@@ -240,38 +210,8 @@ func TestEnsureKeypairIdempotent(t *testing.T) {
 	}
 }
 
-func TestEnsureKeypairDetectsMismatch(t *testing.T) {
-	projectDir := setupHulakProject(t)
-	setupConfigDir(t)
-
-	// Generate and store a keypair
-	_, err := EnsureKeypair()
-	if err != nil {
-		t.Fatalf("EnsureKeypair() error: %v", err)
-	}
-
-	// Replace key.pub with a different key
-	id2, _ := age.GenerateX25519Identity()
-	pubKeyPath := filepath.Join(projectDir, utils.HiddenProjectName, publicKeyFile)
-	if err := os.WriteFile(pubKeyPath, []byte(id2.Recipient().String()+"\n"), utils.FilePer); err != nil {
-		t.Fatalf("failed to overwrite key.pub: %v", err)
-	}
-
-	_, err = EnsureKeypair()
-	if err == nil {
-		t.Error("EnsureKeypair() with mismatched keys should return error")
-	}
-	if !strings.Contains(err.Error(), "mismatch") {
-		t.Errorf("error = %q, want it to contain 'mismatch'", err.Error())
-	}
-}
-
-// TestEnsureKeypairRecoversMissingPubKey verifies that if .hulak/key.pub
-// goes missing but the identity is intact, EnsureKeypair derives the
-// pubkey from the identity and writes it back — without generating a
-// new keypair (which would silently brick any existing store.age).
-func TestEnsureKeypairRecoversMissingPubKey(t *testing.T) {
-	projectDir := setupHulakProject(t)
+func TestEnsureKeypairDerivesRecipient(t *testing.T) {
+	setupHulakProject(t)
 	setupConfigDir(t)
 
 	first, err := EnsureKeypair()
@@ -279,32 +219,21 @@ func TestEnsureKeypairRecoversMissingPubKey(t *testing.T) {
 		t.Fatalf("EnsureKeypair() initial: %v", err)
 	}
 
-	// Simulate accidental deletion of key.pub.
-	pubKeyPath := filepath.Join(projectDir, utils.HiddenProjectName, publicKeyFile)
-	if err := os.Remove(pubKeyPath); err != nil {
-		t.Fatalf("failed to remove key.pub: %v", err)
-	}
-
+	// Call again — should derive same recipient from identity on disk.
 	second, err := EnsureKeypair()
 	if err != nil {
-		t.Fatalf("EnsureKeypair() after pub-key loss: %v", err)
+		t.Fatalf("EnsureKeypair() second call: %v", err)
 	}
 
-	// Identity must NOT have rotated.
 	if second.Identity.String() != first.Identity.String() {
-		t.Error("EnsureKeypair() rotated identity on missing pubkey — would brick existing store.age")
+		t.Error("identity changed between calls")
 	}
-	// Recipient must derive from the same identity.
 	if second.Recipient.String() != first.Recipient.String() {
-		t.Errorf("recipient mismatch: got %q, want %q", second.Recipient.String(), first.Recipient.String())
-	}
-	// key.pub must be on disk again.
-	got, err := os.ReadFile(pubKeyPath)
-	if err != nil {
-		t.Fatalf("key.pub not re-created: %v", err)
-	}
-	if strings.TrimSpace(string(got)) != first.Recipient.String() {
-		t.Errorf("re-derived key.pub = %q, want %q", strings.TrimSpace(string(got)), first.Recipient.String())
+		t.Errorf(
+			"recipient mismatch: got %q, want %q",
+			second.Recipient.String(),
+			first.Recipient.String(),
+		)
 	}
 }
 
@@ -319,7 +248,7 @@ func TestEnsureKeypairRecoversMissingPubKey(t *testing.T) {
 // SSH session with no XDG, etc.). The error guides the user to fix the
 // path rather than silently destroying their data.
 func TestEnsureKeypairRefusesToOverwriteExistingStore(t *testing.T) {
-	projectDir := setupHulakProject(t)
+	setupHulakProject(t)
 	configDir := setupConfigDir(t)
 
 	// Create a real keypair and write a store encrypted to it.
@@ -334,12 +263,8 @@ func TestEnsureKeypairRefusesToOverwriteExistingStore(t *testing.T) {
 
 	// Simulate the "XDG changed; identity not at the resolved path" scenario:
 	// remove identity.txt while leaving store.age intact.
-	if err := os.Remove(filepath.Join(configDir, identityFile)); err != nil {
+	if err := os.Remove(filepath.Join(configDir, utils.IdentityFile)); err != nil {
 		t.Fatalf("remove identity: %v", err)
-	}
-	// Also remove key.pub so we can't take the "derive from identity" path.
-	if err := os.Remove(filepath.Join(projectDir, utils.HiddenProjectName, publicKeyFile)); err != nil {
-		t.Fatalf("remove key.pub: %v", err)
 	}
 
 	_, err = EnsureKeypair()

--- a/pkg/vault/recipients.go
+++ b/pkg/vault/recipients.go
@@ -121,6 +121,38 @@ func SaveRecipients(entries []RecipientEntry) error {
 	return os.WriteFile(path, buf.Bytes(), utils.FilePer)
 }
 
+// AddRecipientEntry validates the new key, checks for duplicates, and returns
+// the updated entry list. Does not write to disk — caller does that.
+func AddRecipientEntry(entries []RecipientEntry, pubKey, name string) ([]RecipientEntry, error) {
+	if _, err := age.ParseX25519Recipient(pubKey); err != nil {
+		return nil, fmt.Errorf("invalid age public key: %w", err)
+	}
+
+	for _, e := range entries {
+		if e.Key == pubKey {
+			return nil, fmt.Errorf("key already in recipients list")
+		}
+	}
+
+	return append(entries, RecipientEntry{
+		Key:  pubKey,
+		Name: FormatRecipientName(name),
+	}), nil
+}
+
+// RecipientsFromEntries converts RecipientEntry slice to age.Recipient slice.
+func RecipientsFromEntries(entries []RecipientEntry) ([]age.Recipient, error) {
+	recipients := make([]age.Recipient, len(entries))
+	for i, e := range entries {
+		r, err := age.ParseX25519Recipient(e.Key)
+		if err != nil {
+			return nil, fmt.Errorf("invalid key in recipients: %w", err)
+		}
+		recipients[i] = r
+	}
+	return recipients, nil
+}
+
 // FormatRecipientName builds a comment label with today's date.
 // Empty name returns empty string.
 func FormatRecipientName(name string) string {

--- a/pkg/vault/recipients.go
+++ b/pkg/vault/recipients.go
@@ -144,17 +144,11 @@ func AddRecipientEntry(entries []RecipientEntry, pubKey, name string) ([]Recipie
 // by name substring). Returns error if removing would leave zero recipients.
 // Returns the original list unchanged if no match found.
 func RemoveRecipientEntry(entries []RecipientEntry, query string) ([]RecipientEntry, bool, error) {
-	if len(entries) <= 1 {
-		return nil, false, fmt.Errorf(
-			"refusing to remove the last recipient — the store would become unrecoverable. " +
-				"Add another recipient first, or delete .hulak/store.age manually",
-		)
-	}
-
 	var remaining []RecipientEntry
 	var removed bool
 
 	for _, e := range entries {
+		// if entry matches the query, add to skip and don't add to remaining
 		if e.Key == query || (e.Name != "" && strings.Contains(e.Name, query)) {
 			removed = true
 			continue
@@ -162,7 +156,18 @@ func RemoveRecipientEntry(entries []RecipientEntry, query string) ([]RecipientEn
 		remaining = append(remaining, e)
 	}
 
-	return remaining, removed, nil
+	if !removed {
+		return entries, false, nil
+	}
+
+	if len(remaining) == 0 {
+		return entries, false, fmt.Errorf(
+			"refusing to remove the last recipient — the store would become unrecoverable. " +
+				"Add another recipient first, or delete .hulak/store.age manually",
+		)
+	}
+
+	return remaining, true, nil
 }
 
 // RecipientsFromEntries converts RecipientEntry slice to age.Recipient slice.

--- a/pkg/vault/recipients.go
+++ b/pkg/vault/recipients.go
@@ -140,6 +140,31 @@ func AddRecipientEntry(entries []RecipientEntry, pubKey, name string) ([]Recipie
 	}), nil
 }
 
+// RemoveRecipientEntry removes entries matching query (by full key string or
+// by name substring). Returns error if removing would leave zero recipients.
+// Returns the original list unchanged if no match found.
+func RemoveRecipientEntry(entries []RecipientEntry, query string) ([]RecipientEntry, bool, error) {
+	if len(entries) <= 1 {
+		return nil, false, fmt.Errorf(
+			"refusing to remove the last recipient — the store would become unrecoverable. " +
+				"Add another recipient first, or delete .hulak/store.age manually",
+		)
+	}
+
+	var remaining []RecipientEntry
+	var removed bool
+
+	for _, e := range entries {
+		if e.Key == query || (e.Name != "" && strings.Contains(e.Name, query)) {
+			removed = true
+			continue
+		}
+		remaining = append(remaining, e)
+	}
+
+	return remaining, removed, nil
+}
+
 // RecipientsFromEntries converts RecipientEntry slice to age.Recipient slice.
 func RecipientsFromEntries(entries []RecipientEntry) ([]age.Recipient, error) {
 	recipients := make([]age.Recipient, len(entries))

--- a/pkg/vault/recipients.go
+++ b/pkg/vault/recipients.go
@@ -127,6 +127,6 @@ func FormatRecipientName(name string) string {
 	if name == "" {
 		return ""
 	}
-	today := time.Now().Format("2006-01-02")
+	today := time.Now().Format(time.DateOnly)
 	return fmt.Sprintf("%s (added %s)", name, today)
 }

--- a/pkg/vault/recipients.go
+++ b/pkg/vault/recipients.go
@@ -1,0 +1,132 @@
+package vault
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"filippo.io/age"
+
+	"github.com/xaaha/hulak/pkg/utils"
+)
+
+// Contains recipients.txt file I/O for multi-recipient encryption.
+
+// RecipientEntry pairs an age public key string with an optional human label.
+type RecipientEntry struct {
+	Key  string // age1... public key
+	Name string // from the # comment line (empty if none)
+}
+
+// RecipientsFilePath returns the absolute path to .hulak/recipients.txt.
+func RecipientsFilePath() (string, error) {
+	markerPath, err := utils.GetProjectMarker()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(markerPath, utils.RecipientsFile), nil
+}
+
+// LoadRecipients reads .hulak/recipients.txt via age.ParseRecipients.
+// Returns error if the file is missing or contains zero recipients.
+func LoadRecipients() ([]age.Recipient, error) {
+	path, err := RecipientsFilePath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read recipients file: %w", err)
+	}
+
+	recipients, err := age.ParseRecipients(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse recipients: %w", err)
+	}
+
+	if len(recipients) == 0 {
+		return nil, fmt.Errorf("recipients file contains no valid recipients")
+	}
+
+	return recipients, nil
+}
+
+// ParseRecipientsFileContent reads raw bytes and returns structured entries
+// (key + name from preceding # comment). Used by list/remove-recipient.
+// age.ParseRecipients discards comments, so this does its own line-by-line parse.
+func ParseRecipientsFileContent(data []byte) ([]RecipientEntry, error) {
+	var entries []RecipientEntry
+	var pendingName string
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "" {
+			continue
+		}
+
+		// if comment, starting with #
+		if comment, ok := strings.CutPrefix(line, utils.Comment); ok {
+			pendingName = strings.TrimSpace(comment)
+			continue
+		}
+
+		// Non-comment, non-blank line is a key
+		// It's intentional that we are not checking age1
+		entries = append(entries, RecipientEntry{
+			Key:  line,
+			Name: pendingName,
+		})
+		pendingName = ""
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to scan recipients file: %w", err)
+	}
+
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("recipients file contains no valid entries")
+	}
+
+	return entries, nil
+}
+
+// SaveRecipients writes entries to .hulak/recipients.txt.
+// Each entry gets an optional "# Name" comment header followed by the key.
+func SaveRecipients(entries []RecipientEntry) error {
+	path, err := RecipientsFilePath()
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	for i, entry := range entries {
+		if entry.Name != "" {
+			fmt.Fprintf(&buf, "# %s\n", entry.Name)
+		}
+		buf.WriteString(entry.Key)
+		buf.WriteByte('\n')
+		// Blank line between entries for readability, but not after the last one
+		if i < len(entries)-1 {
+			buf.WriteByte('\n')
+		}
+	}
+
+	return os.WriteFile(path, buf.Bytes(), utils.FilePer)
+}
+
+// FormatRecipientName builds a comment label with today's date.
+// Empty name returns empty string.
+func FormatRecipientName(name string) string {
+	if name == "" {
+		return ""
+	}
+	today := time.Now().Format("2006-01-02")
+	return fmt.Sprintf("%s (added %s)", name, today)
+}

--- a/pkg/vault/recipients_test.go
+++ b/pkg/vault/recipients_test.go
@@ -1,0 +1,231 @@
+package vault
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xaaha/hulak/pkg/utils"
+)
+
+func TestRecipientsFilePath(t *testing.T) {
+	projectDir := setupHulakProject(t)
+
+	got, err := RecipientsFilePath()
+	if err != nil {
+		t.Fatalf("RecipientsFilePath() error: %v", err)
+	}
+
+	want := filepath.Join(projectDir, utils.HiddenProjectName, utils.RecipientsFile)
+	if got != want {
+		t.Errorf("RecipientsFilePath() = %q, want %q", got, want)
+	}
+}
+
+func TestLoadRecipients(t *testing.T) {
+	t.Run("reads multiple recipients", func(t *testing.T) {
+		projectDir := setupHulakProject(t)
+
+		// Generate two keypairs and write them to recipients.txt
+		key1, err := GenerateKeyPair()
+		if err != nil {
+			t.Fatalf("GenerateKeyPair: %v", err)
+		}
+		key2, err := GenerateKeyPair()
+		if err != nil {
+			t.Fatalf("GenerateKeyPair: %v", err)
+		}
+
+		content := "# Alice\n" + key1.Recipient.String() + "\n# Bob\n" + key2.Recipient.String() + "\n"
+		recipientsPath := filepath.Join(projectDir, utils.HiddenProjectName, utils.RecipientsFile)
+		if err := os.WriteFile(recipientsPath, []byte(content), utils.FilePer); err != nil {
+			t.Fatalf("write recipients: %v", err)
+		}
+
+		recipients, err := LoadRecipients()
+		if err != nil {
+			t.Fatalf("LoadRecipients() error: %v", err)
+		}
+		if len(recipients) != 2 {
+			t.Errorf("LoadRecipients() count = %d, want 2", len(recipients))
+		}
+	})
+
+	t.Run("errors on missing file", func(t *testing.T) {
+		setupHulakProject(t) // no recipients.txt created
+
+		_, err := LoadRecipients()
+		if err == nil {
+			t.Error("LoadRecipients() should error on missing file")
+		}
+	})
+
+	t.Run("errors on empty file with comments only", func(t *testing.T) {
+		projectDir := setupHulakProject(t)
+
+		content := "# just a comment\n# another comment\n"
+		recipientsPath := filepath.Join(projectDir, utils.HiddenProjectName, utils.RecipientsFile)
+		if err := os.WriteFile(recipientsPath, []byte(content), utils.FilePer); err != nil {
+			t.Fatalf("write recipients: %v", err)
+		}
+
+		_, err := LoadRecipients()
+		if err == nil {
+			t.Error("LoadRecipients() should error when file has no recipients")
+		}
+	})
+}
+
+func TestParseRecipientsFileContent(t *testing.T) {
+	t.Run("parses entries with names from comments", func(t *testing.T) {
+		key1, _ := GenerateKeyPair()
+		key2, _ := GenerateKeyPair()
+
+		content := "# Alice (added 2026-04-27)\n" + key1.Recipient.String() + "\n" +
+			"# Bob (added 2026-04-27)\n" + key2.Recipient.String() + "\n"
+
+		entries, err := ParseRecipientsFileContent([]byte(content))
+		if err != nil {
+			t.Fatalf("ParseRecipientsFileContent() error: %v", err)
+		}
+		if len(entries) != 2 {
+			t.Fatalf("ParseRecipientsFileContent() count = %d, want 2", len(entries))
+		}
+
+		if entries[0].Key != key1.Recipient.String() {
+			t.Errorf("entry[0].Key = %q, want %q", entries[0].Key, key1.Recipient.String())
+		}
+		if entries[0].Name != "Alice (added 2026-04-27)" {
+			t.Errorf("entry[0].Name = %q, want %q", entries[0].Name, "Alice (added 2026-04-27)")
+		}
+
+		if entries[1].Key != key2.Recipient.String() {
+			t.Errorf("entry[1].Key = %q, want %q", entries[1].Key, key2.Recipient.String())
+		}
+		if entries[1].Name != "Bob (added 2026-04-27)" {
+			t.Errorf("entry[1].Name = %q, want %q", entries[1].Name, "Bob (added 2026-04-27)")
+		}
+	})
+
+	t.Run("key without preceding comment has empty name", func(t *testing.T) {
+		key1, _ := GenerateKeyPair()
+
+		content := key1.Recipient.String() + "\n"
+
+		entries, err := ParseRecipientsFileContent([]byte(content))
+		if err != nil {
+			t.Fatalf("ParseRecipientsFileContent() error: %v", err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("ParseRecipientsFileContent() count = %d, want 1", len(entries))
+		}
+
+		if entries[0].Key != key1.Recipient.String() {
+			t.Errorf("entry[0].Key = %q, want %q", entries[0].Key, key1.Recipient.String())
+		}
+		if entries[0].Name != "" {
+			t.Errorf("entry[0].Name = %q, want empty", entries[0].Name)
+		}
+	})
+
+	t.Run("errors on empty content", func(t *testing.T) {
+		_, err := ParseRecipientsFileContent([]byte(""))
+		if err == nil {
+			t.Error("ParseRecipientsFileContent() should error on empty content")
+		}
+	})
+}
+
+func TestSaveRecipients(t *testing.T) {
+	t.Run("writes file and round-trips", func(t *testing.T) {
+		projectDir := setupHulakProject(t)
+
+		key1, _ := GenerateKeyPair()
+		key2, _ := GenerateKeyPair()
+
+		entries := []RecipientEntry{
+			{Key: key1.Recipient.String(), Name: "Alice (added 2026-04-27)"},
+			{Key: key2.Recipient.String(), Name: "Bob (added 2026-04-27)"},
+		}
+
+		if err := SaveRecipients(entries); err != nil {
+			t.Fatalf("SaveRecipients() error: %v", err)
+		}
+
+		// Verify file was created
+		recipientsPath := filepath.Join(projectDir, utils.HiddenProjectName, utils.RecipientsFile)
+		data, err := os.ReadFile(recipientsPath)
+		if err != nil {
+			t.Fatalf("read recipients file: %v", err)
+		}
+
+		// Round-trip: parse it back
+		parsed, err := ParseRecipientsFileContent(data)
+		if err != nil {
+			t.Fatalf("ParseRecipientsFileContent() round-trip error: %v", err)
+		}
+		if len(parsed) != 2 {
+			t.Fatalf("round-trip count = %d, want 2", len(parsed))
+		}
+		if parsed[0].Key != key1.Recipient.String() {
+			t.Errorf("round-trip[0].Key = %q, want %q", parsed[0].Key, key1.Recipient.String())
+		}
+		if parsed[0].Name != "Alice (added 2026-04-27)" {
+			t.Errorf("round-trip[0].Name = %q, want %q", parsed[0].Name, "Alice (added 2026-04-27)")
+		}
+		if parsed[1].Key != key2.Recipient.String() {
+			t.Errorf("round-trip[1].Key = %q, want %q", parsed[1].Key, key2.Recipient.String())
+		}
+		if parsed[1].Name != "Bob (added 2026-04-27)" {
+			t.Errorf("round-trip[1].Name = %q, want %q", parsed[1].Name, "Bob (added 2026-04-27)")
+		}
+	})
+
+	t.Run("entry without name omits comment", func(t *testing.T) {
+		projectDir := setupHulakProject(t)
+
+		key1, _ := GenerateKeyPair()
+
+		entries := []RecipientEntry{
+			{Key: key1.Recipient.String(), Name: ""},
+		}
+
+		if err := SaveRecipients(entries); err != nil {
+			t.Fatalf("SaveRecipients() error: %v", err)
+		}
+
+		recipientsPath := filepath.Join(projectDir, utils.HiddenProjectName, utils.RecipientsFile)
+		data, err := os.ReadFile(recipientsPath)
+		if err != nil {
+			t.Fatalf("read recipients file: %v", err)
+		}
+
+		content := string(data)
+		if strings.Contains(content, "#") {
+			t.Errorf("expected no comment line for nameless entry, got:\n%s", content)
+		}
+		if !strings.Contains(content, key1.Recipient.String()) {
+			t.Errorf("expected key in file, got:\n%s", content)
+		}
+	})
+}
+
+func TestFormatRecipientName(t *testing.T) {
+	t.Run("formats name with date", func(t *testing.T) {
+		got := FormatRecipientName("Alice")
+		if !strings.HasPrefix(got, "Alice (added ") {
+			t.Errorf("FormatRecipientName(\"Alice\") = %q, want prefix \"Alice (added \"", got)
+		}
+		if !strings.HasSuffix(got, ")") {
+			t.Errorf("FormatRecipientName(\"Alice\") = %q, want suffix \")\"", got)
+		}
+	})
+
+	t.Run("empty name returns empty string", func(t *testing.T) {
+		got := FormatRecipientName("")
+		if got != "" {
+			t.Errorf("FormatRecipientName(\"\") = %q, want empty", got)
+		}
+	})
+}

--- a/pkg/vault/recipients_test.go
+++ b/pkg/vault/recipients_test.go
@@ -211,6 +211,49 @@ func TestSaveRecipients(t *testing.T) {
 	})
 }
 
+func TestAddRecipientEntry(t *testing.T) {
+	t.Run("adds new key", func(t *testing.T) {
+		key1, _ := GenerateKeyPair()
+		key2, _ := GenerateKeyPair()
+
+		existing := []RecipientEntry{{Key: key1.Recipient.String(), Name: "Alice"}}
+		got, err := AddRecipientEntry(existing, key2.Recipient.String(), "Bob")
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("got %d entries, want 2", len(got))
+		}
+	})
+
+	t.Run("rejects duplicate key", func(t *testing.T) {
+		key1, _ := GenerateKeyPair()
+		existing := []RecipientEntry{{Key: key1.Recipient.String(), Name: "Alice"}}
+		_, err := AddRecipientEntry(existing, key1.Recipient.String(), "Alice Again")
+		if err == nil {
+			t.Fatal("expected duplicate error")
+		}
+	})
+
+	t.Run("rejects malformed key", func(t *testing.T) {
+		_, err := AddRecipientEntry(nil, "not-a-valid-key", "Bad")
+		if err == nil {
+			t.Fatal("expected parse error")
+		}
+	})
+
+	t.Run("no name produces empty Name field", func(t *testing.T) {
+		key1, _ := GenerateKeyPair()
+		got, err := AddRecipientEntry(nil, key1.Recipient.String(), "")
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if got[0].Name != "" {
+			t.Errorf("expected empty Name, got %q", got[0].Name)
+		}
+	})
+}
+
 func TestFormatRecipientName(t *testing.T) {
 	t.Run("formats name with date", func(t *testing.T) {
 		got := FormatRecipientName("Alice")

--- a/pkg/vault/recipients_test.go
+++ b/pkg/vault/recipients_test.go
@@ -254,6 +254,66 @@ func TestAddRecipientEntry(t *testing.T) {
 	})
 }
 
+func TestRemoveRecipientEntry(t *testing.T) {
+	key1, _ := GenerateKeyPair()
+	key2, _ := GenerateKeyPair()
+
+	entries := []RecipientEntry{
+		{Key: key1.Recipient.String(), Name: "Alice"},
+		{Key: key2.Recipient.String(), Name: "Bob"},
+	}
+
+	t.Run("removes by key", func(t *testing.T) {
+		got, removed, err := RemoveRecipientEntry(entries, key1.Recipient.String())
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if !removed {
+			t.Fatal("expected removed=true")
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %d, want 1", len(got))
+		}
+		if got[0].Key != key2.Recipient.String() {
+			t.Error("wrong entry removed")
+		}
+	})
+
+	t.Run("removes by name", func(t *testing.T) {
+		got, removed, err := RemoveRecipientEntry(entries, "Bob")
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if !removed {
+			t.Fatal("expected removed=true")
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %d, want 1", len(got))
+		}
+	})
+
+	t.Run("refuses to remove last recipient", func(t *testing.T) {
+		single := []RecipientEntry{{Key: key1.Recipient.String(), Name: "Alice"}}
+		_, _, err := RemoveRecipientEntry(single, key1.Recipient.String())
+		if err == nil {
+			t.Fatal("expected error when removing last recipient")
+		}
+	})
+
+	t.Run("no-op for unknown query", func(t *testing.T) {
+		got, removed, err := RemoveRecipientEntry(entries, "unknown-query")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if removed {
+			t.Fatal("expected removed=false")
+		}
+		if len(got) != 2 {
+			t.Fatal("entries should be unchanged")
+		}
+	})
+}
+
 func TestFormatRecipientName(t *testing.T) {
 	t.Run("formats name with date", func(t *testing.T) {
 		got := FormatRecipientName("Alice")

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -249,6 +249,17 @@ func WriteStore(store *Store, recipients ...age.Recipient) error {
 	return nil
 }
 
+// WriteStoreToRecipients loads recipients from .hulak/recipients.txt and
+// encrypts the store to all of them. Most write-path callers should use
+// this instead of passing recipients manually.
+func WriteStoreToRecipients(store *Store) error {
+	recipients, err := LoadRecipients()
+	if err != nil {
+		return fmt.Errorf("failed to load recipients: %w", err)
+	}
+	return WriteStore(store, recipients...)
+}
+
 type StoreType int
 
 const (

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
-	"strings"
 
 	"filippo.io/age"
 
@@ -55,75 +53,25 @@ func DecryptText(cypherText []byte, identities ...age.Identity) ([]byte, error) 
 	return plaintext, nil
 }
 
-// SetPublicKey writes the public encryption key to .hulak/key.pub in the project root.
-func SetPublicKey(publicEncKey string) error {
-	pubKeyPath, err := getPublicKeyFilePath()
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(pubKeyPath, []byte(publicEncKey+"\n"), utils.FilePer)
-}
-
 // EnsureKeypair returns the age keypair for this project, lazily creating one
-// on first use. Identity is the source of truth; key.pub is derived. So:
+// on first use. Identity is the source of truth:
 //
-//   - identity + pubkey both present  → verify they match, return.
-//   - identity present, pubkey missing → derive pubkey from identity and write
-//     it back. Recovers from accidental key.pub deletion without generating
-//     a new identity (which would silently brick any existing store.age).
+//   - identity exists → parse and derive recipient from it, return.
 //   - identity missing, store.age exists → refuse. Generating a new identity
-//     would make the existing ciphertext permanently undecryptable. Likely
-//     cause: $XDG_CONFIG_HOME changed between runs, so the resolved path
-//     no longer points at the original identity file.
-//   - identity missing, no store.age   → generate a fresh keypair and write
-//     both files. Any orphan pubkey from a previous identity is overwritten.
+//     would make the existing ciphertext permanently undecryptable.
+//   - identity missing, no store.age → generate a fresh keypair, write identity.
 func EnsureKeypair() (AgeKey, error) {
 	identityPath, err := IdentityPath()
 	if err != nil {
 		return AgeKey{}, err
 	}
 
-	pubKeyPath, err := getPublicKeyFilePath()
-	if err != nil {
-		return AgeKey{}, err
+	if utils.FileExists(identityPath) {
+		return LoadKeypair()
 	}
 
-	identityExists := utils.FileExists(identityPath)
-	pubKeyExists := utils.FileExists(pubKeyPath)
-
-	if identityExists && pubKeyExists {
-		privKeyStr, err := GetIdentity()
-		if err != nil {
-			return AgeKey{}, err
-		}
-		pubKeyBytes, err := os.ReadFile(pubKeyPath)
-		if err != nil {
-			return AgeKey{}, err
-		}
-		return VerifyKeypair(privKeyStr, string(pubKeyBytes))
-	}
-
-	if identityExists {
-		// Pubkey is missing but identity is present — derive and re-write
-		// the pubkey instead of generating a new keypair.
-		privKeyStr, err := GetIdentity()
-		if err != nil {
-			return AgeKey{}, err
-		}
-		identity, err := age.ParseX25519Identity(strings.TrimSpace(privKeyStr))
-		if err != nil {
-			return AgeKey{}, fmt.Errorf("failed to parse identity: %w", err)
-		}
-		recipient := identity.Recipient()
-		if err := SetPublicKey(recipient.String()); err != nil {
-			return AgeKey{}, err
-		}
-		return AgeKey{Identity: identity, Recipient: recipient}, nil
-	}
-
-	// Identity missing. Refuse to generate a new keypair if a store already
-	// exists — the new identity wouldn't match the recipient store.age was
-	// encrypted to, and the ciphertext would be unrecoverable.
+	// Identity missing. Refuse if a store already exists — the new identity
+	// wouldn't match the recipient store.age was encrypted to.
 	if existingStore, err := storePath(); err == nil && utils.FileExists(existingStore) {
 		return AgeKey{}, utils.HelpfulError(
 			fmt.Sprintf(
@@ -144,14 +92,19 @@ func EnsureKeypair() (AgeKey, error) {
 		return AgeKey{}, err
 	}
 
-	if err := SetPublicKey(ageKey.Recipient.String()); err != nil {
-		return AgeKey{}, err
-	}
-
 	if err := SetIdentity(ageKey.Identity.String()); err != nil {
-		os.Remove(pubKeyPath)
 		return AgeKey{}, err
 	}
 
 	return ageKey, nil
+}
+
+// LoadKeypair reads the existing identity and derives the recipient from it.
+// Unlike EnsureKeypair, does not generate keys if missing.
+func LoadKeypair() (AgeKey, error) {
+	identity, err := LoadIdentity()
+	if err != nil {
+		return AgeKey{}, err
+	}
+	return AgeKey{Identity: identity, Recipient: identity.Recipient()}, nil
 }


### PR DESCRIPTION
## Summary

Closes #144. Part of epic #125 (Phase 6).

Replace single-key `.hulak/key.pub` with `.hulak/recipients.txt` so teams can share a vault via git.

## Changes

- **`recipients.txt` file I/O** — `LoadRecipients` (wraps `age.ParseRecipients`), `ParseRecipientsFileContent` (preserves comment labels), `SaveRecipients`, `RecipientsFromEntries`
- **`hulak init`** writes `recipients.txt` with owner's key instead of `key.pub`
- **All CRUD** (`set`, `delete`, `edit`) encrypt via `WriteStoreToRecipients` which loads recipients from disk
- **`hulak env add-recipient <key> [--name n] [--stdin]`** — validates key, rejects duplicates, re-encrypts store to all recipients
- **`hulak env remove-recipient <key-or-name>`** — matches by key or name label, last-recipient guard, rotation warning
- **`hulak env list-recipients`** — shows name labels and key prefixes
- **`hulak env rotate`** (aliases: `sync`, `reencrypt`) — re-encrypts store to current recipients
- **Removed** `SetPublicKey`, `getPublicKeyFilePath`, `key.pub` constant — `recipients.txt` is the sole authority
- **Simplified `EnsureKeypair`** — identity is source of truth, derives recipient via `LoadKeypair`
- **Updated `docs/store.md`** to reflect implemented commands

## Test plan

- [ ] Unit tests: `go test ./...` (all pass)
- [ ] E2E: `hulak init` creates `recipients.txt`
- [ ] E2E: `add-recipient` / `remove-recipient` / `list-recipients` round-trip
- [ ] E2E: last-recipient guard blocks removal
- [ ] E2E: `rotate` changes ciphertext, data still decryptable
- [ ] E2E: `--stdin` multi-key add