### PR TITLE
feat: import-key/export-key + HULAK_MASTER_KEY fallback

### DIFF
--- a/pkg/envparser/envparser.go
+++ b/pkg/envparser/envparser.go
@@ -172,7 +172,7 @@ func inferType(val string, wasTrimmed bool) any {
 // loadSecretsFromVault decrypts the store and returns merged env vars.
 // Uses the same merge pattern as classic: global base + custom overlay.
 func loadSecretsFromVault(envName string) (map[string]any, error) {
-	identity, err := vault.LoadIdentity()
+	identity, err := vault.ResolveIdentity()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load identity: %w", err)
 	}

--- a/pkg/tui/envselect/envselect.go
+++ b/pkg/tui/envselect/envselect.go
@@ -49,7 +49,7 @@ func noEnvFilesError() error {
 // Reads from encrypted store when available, otherwise from env/ directory.
 func envItems() []string {
 	if vault.DetectStore() == vault.StoreAge {
-		identity, err := vault.LoadIdentity()
+		identity, err := vault.ResolveIdentity()
 		if err != nil {
 			utils.PrintErrorStderr(fmt.Sprintf("vault: %v", err))
 			return nil

--- a/pkg/userFlags/cli_contract_test.go
+++ b/pkg/userFlags/cli_contract_test.go
@@ -419,6 +419,7 @@ func TestEnvSubCommandSpecificFlags(t *testing.T) {
 		{"keys", "show"},
 		{"keys", "search"},
 		{"import-key", "stdin"},
+		{"import-key", "force"},
 		{"export-key", "out"},
 	}
 

--- a/pkg/userFlags/cli_contract_test.go
+++ b/pkg/userFlags/cli_contract_test.go
@@ -419,7 +419,7 @@ func TestEnvSubCommandSpecificFlags(t *testing.T) {
 		{"keys", "show"},
 		{"keys", "search"},
 		{"import-key", "stdin"},
-		{"export-key", "armor"},
+		{"export-key", "out"},
 	}
 
 	for _, tc := range tests {

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -601,6 +601,49 @@ func launchEditor(path string) error {
 	return nil
 }
 
+// --- IMPORT-KEY ---
+
+// runImportKey handles `hulak env import-key [path] [--stdin] [--force]`.
+func runImportKey(args []string, useStdin, force bool) error {
+	if useStdin && len(args) > 0 {
+		return errors.New("cannot use both --stdin and a positional path — pick one")
+	}
+
+	var raw string
+	switch {
+	case useStdin:
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("failed to read stdin: %w", err)
+		}
+		raw = string(data)
+
+	case len(args) > 0:
+		if len(args) > 1 {
+			return fmt.Errorf("too many arguments: got %d, expected 1 (path)", len(args))
+		}
+		data, err := os.ReadFile(args[0])
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %w", args[0], err)
+		}
+		raw = string(data)
+
+	default:
+		return errors.New("missing required argument: path (or use --stdin)")
+	}
+
+	if err := vault.ImportKey(raw, force); err != nil {
+		return err
+	}
+
+	identityPath, err := vault.IdentityPath()
+	if err != nil {
+		return err
+	}
+	utils.PrintSuccessStderr(fmt.Sprintf("Identity imported to %s", identityPath))
+	return nil
+}
+
 // --- EXPORT-KEY ---
 
 // runExportKey handles `hulak env export-key [--out path]`.

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -179,7 +179,7 @@ func runEnvGet(args []string, envName string) error {
 		return err
 	}
 
-	identity, err := vault.LoadIdentity()
+	identity, err := vault.ResolveIdentity()
 	if err != nil {
 		return fmt.Errorf("failed to load identity: %w", err)
 	}
@@ -242,7 +242,7 @@ func runEnvDelete(args []string, envName string) error {
 	}
 
 	return vault.WithStoreLock(func() error {
-		identity, err := vault.LoadIdentity()
+		identity, err := vault.ResolveIdentity()
 		if err != nil {
 			return fmt.Errorf("failed to load identity: %w", err)
 		}
@@ -280,7 +280,7 @@ func runEnvList(args []string) error {
 		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
 	}
 
-	identity, err := vault.LoadIdentity()
+	identity, err := vault.ResolveIdentity()
 	if err != nil {
 		return fmt.Errorf("failed to load identity: %w", err)
 	}
@@ -313,7 +313,7 @@ func runEnvKeys(args []string, envName, search string, show bool) error {
 		return err
 	}
 
-	identity, err := vault.LoadIdentity()
+	identity, err := vault.ResolveIdentity()
 	if err != nil {
 		return fmt.Errorf("failed to load identity: %w", err)
 	}
@@ -669,7 +669,7 @@ func runAddRecipient(args []string, name string, useStdin bool) error {
 		}
 
 		// Re-encrypt store to all recipients including new ones
-		identity, err := vault.LoadIdentity()
+		identity, err := vault.ResolveIdentity()
 		if err != nil {
 			return fmt.Errorf("failed to load identity: %w", err)
 		}
@@ -745,7 +745,7 @@ func runRemoveRecipient(args []string) error {
 		}
 
 		// Re-encrypt to remaining recipients
-		identity, err := vault.LoadIdentity()
+		identity, err := vault.ResolveIdentity()
 		if err != nil {
 			return fmt.Errorf("failed to load identity: %w", err)
 		}
@@ -824,7 +824,7 @@ func runSync(args []string) error {
 	}
 
 	return vault.WithStoreLock(func() error {
-		identity, err := vault.LoadIdentity()
+		identity, err := vault.ResolveIdentity()
 		if err != nil {
 			return fmt.Errorf("failed to load identity: %w", err)
 		}

--- a/pkg/userFlags/env.go
+++ b/pkg/userFlags/env.go
@@ -601,6 +601,37 @@ func launchEditor(path string) error {
 	return nil
 }
 
+// --- EXPORT-KEY ---
+
+// runExportKey handles `hulak env export-key [--out path]`.
+func runExportKey(args []string, outPath string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
+	}
+
+	key, err := vault.ExportKey()
+	if err != nil {
+		return err
+	}
+
+	if outPath != "" {
+		if utils.FileExists(outPath) {
+			return fmt.Errorf("file %q already exists — use a different path or remove it first", outPath)
+		}
+		if err := os.WriteFile(outPath, []byte(key+"\n"), utils.SecretPer); err != nil {
+			return fmt.Errorf("failed to write key to %s: %w", outPath, err)
+		}
+		utils.PrintSuccessStderr(fmt.Sprintf("Key written to %s (mode 0600)", outPath))
+		return nil
+	}
+
+	// Print to stdout with a security warning on stderr.
+	utils.PrintWarningStderr("This is your age private key. Treat it like a password.")
+	utils.PrintWarningStderr("Do not commit it or share it. Store it in a password manager.")
+	fmt.Println(key)
+	return nil
+}
+
 // --- ADD-RECIPIENT ---
 
 // resolveRecipientKeys returns public keys to add. From --stdin (one per line,

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -445,7 +445,10 @@ func newEnvCmd() *command {
 
 	// export-key — export the age identity
 	exportKeyFs := flag.NewFlagSet("env export-key", flag.ContinueOnError)
-	exportKeyFs.Bool("armor", false, "Output in ASCII-armored format")
+	var exportKeyOutVal string
+	exportKeyFs.StringVar(&exportKeyOutVal, "out", "", "Write key to file instead of stdout (mode 0600)")
+	exportKeyFs.StringVar(&exportKeyOutVal, "o", "", "Write key to file instead of stdout (mode 0600)")
+	exportKeyOut := &exportKeyOutVal
 
 	// add-recipient
 	addRecipientFs := flag.NewFlagSet("env add-recipient", flag.ContinueOnError)
@@ -626,24 +629,20 @@ func newEnvCmd() *command {
 		},
 		{
 			Name:  "export-key",
-			Short: "Export the age identity file",
-			Long:  "Print the age private key to stdout for backup or transfer to another machine.\n\nUse --armor for ASCII-armored output suitable for copy-paste.",
+			Short: "Export the age identity (private key)",
+			Long:  "Print the age private key to stdout for backup or transfer.\n\nUse --out to write directly to a file with 0600 permissions instead of stdout.",
 			Flags: exportKeyFs,
 			Examples: []*utils.CommandHelp{
 				{
 					Command:     "hulak env export-key",
-					Description: "Print the private key (with security warning)",
+					Description: "Print the private key (with security warning on stderr)",
 				},
 				{
-					Command:     "hulak env export-key > ~/backup.txt",
-					Description: "Save to a backup file",
-				},
-				{
-					Command:     "hulak env export-key --armor",
-					Description: "ASCII-armored output for copy-paste",
+					Command:     "hulak env export-key --out ~/backup-identity.txt",
+					Description: "Save to a file with 0600 permissions",
 				},
 			},
-			Run: notImplemented("export-key"),
+			Run: func(args []string) error { return runExportKey(args, *exportKeyOut) },
 		},
 		{
 			Name:  "add-recipient",

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -441,7 +441,8 @@ func newEnvCmd() *command {
 
 	// import-key — import an age identity
 	importKeyFs := flag.NewFlagSet("env import-key", flag.ContinueOnError)
-	importKeyFs.Bool("stdin", false, "Read key from stdin")
+	importKeyStdin := importKeyFs.Bool("stdin", false, "Read key from stdin")
+	importKeyForce := importKeyFs.Bool("force", false, "Overwrite existing identity file")
 
 	// export-key — export the age identity
 	exportKeyFs := flag.NewFlagSet("env export-key", flag.ContinueOnError)
@@ -454,15 +455,6 @@ func newEnvCmd() *command {
 	addRecipientFs := flag.NewFlagSet("env add-recipient", flag.ContinueOnError)
 	addRecipientName := addRecipientFs.String("name", "", "Human-readable label for the recipient")
 	addRecipientStdin := addRecipientFs.Bool("stdin", false, "Read keys from stdin (one per line)")
-
-	notImplemented := func(name string) func([]string) error {
-		return func(_ []string) error {
-			// Stderr — this is a status notice, not the data the user asked for.
-			// If the user pipes the output, $() must not capture this line.
-			fmt.Fprintf(os.Stderr, "hulak env %s is not yet implemented\n", name)
-			return nil
-		}
-	}
 
 	envCmd.SubCommands = []*command{
 		{
@@ -609,23 +601,27 @@ func newEnvCmd() *command {
 		},
 		{
 			Name:  "import-key",
-			Short: "Import an age identity file",
-			Long:  "Import an age private key from a file or stdin into the hulak config directory.\n\nValidates the key format before storing. Writes to ~/.config/hulak/identity.txt\n(or the platform-specific config dir).",
+			Short: "Import an age identity (private key)",
+			Long:  "Import an age private key from a file or stdin into the hulak config directory.\n\nValidates the key before writing. Refuses to overwrite an existing identity unless --force is passed.\nAtomic write (tmp + rename) so an interrupted import can never corrupt an existing identity.",
 			Flags: importKeyFs,
 			Args: []argDef{
-				{Name: "path", Desc: "Path to the identity file (omit to read from stdin)"},
+				{Name: "path", Desc: "Path to the identity file (omit with --stdin)"},
 			},
 			Examples: []*utils.CommandHelp{
 				{
-					Command:     "hulak env import-key /path/to/backup.txt",
+					Command:     "hulak env import-key ~/backup-identity.txt",
 					Description: "Import from a backup file",
 				},
 				{
+					Command:     "hulak env import-key ~/backup.txt --force",
+					Description: "Overwrite existing identity",
+				},
+				{
 					Command:     "echo \"AGE-SECRET-KEY-1QF...\" | hulak env import-key --stdin",
-					Description: "Import from stdin (scripts)",
+					Description: "Import from stdin (password manager pipe)",
 				},
 			},
-			Run: notImplemented("import-key"),
+			Run: func(args []string) error { return runImportKey(args, *importKeyStdin, *importKeyForce) },
 		},
 		{
 			Name:  "export-key",

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -38,6 +38,10 @@ const (
 	StoreFile      = "store.age"
 	RecipientsFile = "recipients.txt"
 	IdentityFile   = "identity.txt"
+
+	// MasterKey is the environment variable that overrides the on-disk identity.
+	// Intended for CI where the identity file isn't practical.
+	MasterKey = "HULAK_MASTER_KEY"
 )
 
 // Editor is the fallback editor used when $EDITOR is unset. POSIX guarantees

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -279,3 +279,23 @@ func DirExists(path string) bool {
 	info, err := stat(path)
 	return err == nil && info.IsDir()
 }
+
+// AtomicWriteFile writes data to path via a temporary file + rename.
+// An interrupted or failed write never leaves a corrupted target file.
+// Creates parent directories with dirPerm if they don't exist.
+func AtomicWriteFile(path string, data []byte, filePerm, dirPerm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, filePerm); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to finalize file: %w", err)
+	}
+	return nil
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -900,3 +900,98 @@ func TestSanitizeDirPathWithSpecialPaths(t *testing.T) {
 		})
 	}
 }
+
+func TestAtomicWriteFile(t *testing.T) {
+	t.Run("writes file with correct content and permissions", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.txt")
+
+		err := AtomicWriteFile(path, []byte("hello"), SecretPer, DirPer)
+		if err != nil {
+			t.Fatalf("AtomicWriteFile() error: %v", err)
+		}
+
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile() error: %v", err)
+		}
+		if string(got) != "hello" {
+			t.Errorf("content = %q, want %q", string(got), "hello")
+		}
+
+		info, _ := os.Stat(path)
+		if info.Mode().Perm() != SecretPer {
+			t.Errorf("permissions = %o, want %o", info.Mode().Perm(), SecretPer)
+		}
+	})
+
+	t.Run("creates parent directories", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "nested", "deep", "file.txt")
+
+		err := AtomicWriteFile(path, []byte("nested"), SecretPer, SecretDirPer)
+		if err != nil {
+			t.Fatalf("AtomicWriteFile() error: %v", err)
+		}
+
+		got, _ := os.ReadFile(path)
+		if string(got) != "nested" {
+			t.Errorf("content = %q, want %q", string(got), "nested")
+		}
+
+		// Check parent dir permissions
+		parentInfo, _ := os.Stat(filepath.Join(dir, "nested"))
+		if parentInfo.Mode().Perm() != SecretDirPer {
+			t.Errorf("parent dir permissions = %o, want %o", parentInfo.Mode().Perm(), SecretDirPer)
+		}
+	})
+
+	t.Run("overwrites existing file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "overwrite.txt")
+
+		if err := os.WriteFile(path, []byte("old"), FilePer); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		err := AtomicWriteFile(path, []byte("new"), SecretPer, DirPer)
+		if err != nil {
+			t.Fatalf("AtomicWriteFile() error: %v", err)
+		}
+
+		got, _ := os.ReadFile(path)
+		if string(got) != "new" {
+			t.Errorf("content = %q, want %q", string(got), "new")
+		}
+	})
+
+	t.Run("no leftover tmp file on success", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "clean.txt")
+
+		err := AtomicWriteFile(path, []byte("data"), FilePer, DirPer)
+		if err != nil {
+			t.Fatalf("AtomicWriteFile() error: %v", err)
+		}
+
+		tmpPath := path + ".tmp"
+		if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+			t.Error("AtomicWriteFile() left behind .tmp file")
+		}
+	})
+
+	t.Run("empty data writes empty file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "empty.txt")
+
+		err := AtomicWriteFile(path, []byte{}, FilePer, DirPer)
+		if err != nil {
+			t.Fatalf("AtomicWriteFile() error: %v", err)
+		}
+
+		info, _ := os.Stat(path)
+		if info.Size() != 0 {
+			t.Errorf("file size = %d, want 0", info.Size())
+		}
+	})
+}

--- a/pkg/vault/keys.go
+++ b/pkg/vault/keys.go
@@ -216,7 +216,12 @@ func ImportKey(raw string, force bool) error {
 		)
 	}
 
-	return utils.AtomicWriteFile(identityPath, []byte(key+"\n"), utils.SecretPer, utils.SecretDirPer)
+	return utils.AtomicWriteFile(
+		identityPath,
+		[]byte(key+"\n"),
+		utils.SecretPer,
+		utils.SecretDirPer,
+	)
 }
 
 // extractKeyLine returns the first non-empty, non-comment line from raw input.

--- a/pkg/vault/keys.go
+++ b/pkg/vault/keys.go
@@ -112,3 +112,36 @@ func DeleteIdentity() error {
 	}
 	return nil
 }
+
+// ResolveIdentity returns the age identity to use for decryption.
+// Precedence: HULAK_MASTER_KEY env var → ~/.config/hulak/identity.txt.
+//
+// Wraps parse errors with user-friendly messages:
+//   - public key in env var → "this looks like a public key"
+//   - garbage in env var → hint at AGE-SECRET-KEY- format
+func ResolveIdentity() (*age.X25519Identity, error) {
+	if raw := strings.TrimSpace(os.Getenv(utils.MasterKey)); raw != "" {
+		return parseMasterKey(raw)
+	}
+	return LoadIdentity()
+}
+
+// parseMasterKey parses the HULAK_MASTER_KEY value with friendly errors.
+func parseMasterKey(raw string) (*age.X25519Identity, error) {
+	identity, err := age.ParseX25519Identity(raw)
+	if err != nil {
+		if strings.HasPrefix(raw, "age1") {
+			return nil, fmt.Errorf(
+				"%s contains what looks like a public key (age1...), not a private key. "+
+					"Private keys start with AGE-SECRET-KEY-",
+				utils.MasterKey,
+			)
+		}
+		return nil, fmt.Errorf(
+			"%s is set but could not be parsed as an age private key: %w\n"+
+				"Expected format: AGE-SECRET-KEY-1... ",
+			utils.MasterKey, err,
+		)
+	}
+	return identity, nil
+}

--- a/pkg/vault/keys.go
+++ b/pkg/vault/keys.go
@@ -177,3 +177,57 @@ func ExportKey() (string, error) {
 	}
 	return strings.TrimSpace(raw), nil
 }
+
+// ImportKey validates the raw key material, normalizes whitespace, and writes
+// it to the identity file atomically (tmp + rename). Refuses to overwrite an
+// existing identity unless force is true.
+//
+// The raw input may be multi-line (e.g. age-keygen output with comments).
+// Only the first non-empty, non-comment line is used as the key.
+//
+// Refuses to run if HULAK_MASTER_KEY is set — importing while the env var
+// shadows the on-disk identity makes the import dead-on-arrival.
+func ImportKey(raw string, force bool) error {
+	if os.Getenv(utils.MasterKey) != "" {
+		return fmt.Errorf(
+			"%s is set — unset it before importing an identity, "+
+				"otherwise the env var shadows the on-disk file",
+			utils.MasterKey,
+		)
+	}
+
+	key := extractKeyLine(raw)
+	if key == "" {
+		return fmt.Errorf("no age private key found in input")
+	}
+
+	if _, err := age.ParseX25519Identity(key); err != nil {
+		return fmt.Errorf("invalid age private key: %w", err)
+	}
+
+	identityPath, err := IdentityPath()
+	if err != nil {
+		return err
+	}
+
+	if !force && utils.FileExists(identityPath) {
+		return fmt.Errorf(
+			"identity already exists at %s — use --force to overwrite", identityPath,
+		)
+	}
+
+	return utils.AtomicWriteFile(identityPath, []byte(key+"\n"), utils.SecretPer, utils.SecretDirPer)
+}
+
+// extractKeyLine returns the first non-empty, non-comment line from raw input.
+// Handles age-keygen output where comments (# lines) precede the key.
+func extractKeyLine(raw string) string {
+	for line := range strings.SplitSeq(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		return line
+	}
+	return ""
+}

--- a/pkg/vault/keys.go
+++ b/pkg/vault/keys.go
@@ -145,3 +145,23 @@ func parseMasterKey(raw string) (*age.X25519Identity, error) {
 	}
 	return identity, nil
 }
+
+// WrapDecryptError checks if HULAK_MASTER_KEY is set and the error looks like
+// an age "no identity matched" failure. If so, wraps it with actionable hints.
+// Otherwise returns the original error unchanged.
+func WrapDecryptError(err error) error {
+	if os.Getenv(utils.MasterKey) == "" {
+		return err
+	}
+	if !strings.Contains(err.Error(), "no identity matched") {
+		return err
+	}
+	return fmt.Errorf(
+		"failed to decrypt store: %s is set but does not match any recipient in this project.\n"+
+			"Common causes:\n"+
+			"  - This key is for a different project\n"+
+			"  - You were removed as a recipient\n"+
+			"  - Stale whitespace or quotes from copy-paste",
+		utils.MasterKey,
+	)
+}

--- a/pkg/vault/keys.go
+++ b/pkg/vault/keys.go
@@ -165,3 +165,15 @@ func WrapDecryptError(err error) error {
 		utils.MasterKey,
 	)
 }
+
+// ExportKey reads the identity file and returns the raw private key string.
+// Returns a friendly error pointing to `hulak init` if no identity exists.
+func ExportKey() (string, error) {
+	raw, err := GetIdentity()
+	if err != nil {
+		return "", fmt.Errorf(
+			"no identity file found — run 'hulak init' to create one: %w", err,
+		)
+	}
+	return strings.TrimSpace(raw), nil
+}

--- a/pkg/vault/keys_test.go
+++ b/pkg/vault/keys_test.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -421,6 +422,42 @@ func TestResolveIdentity(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "no identity found") {
 			t.Errorf("error %q should say 'no identity found'", err.Error())
+		}
+	})
+}
+
+func TestWrapDecryptError(t *testing.T) {
+	t.Run("wraps no-match when HULAK_MASTER_KEY set", func(t *testing.T) {
+		raw := errors.New("no identity matched any of the recipients")
+		t.Setenv("HULAK_MASTER_KEY", "AGE-SECRET-KEY-fake")
+
+		got := WrapDecryptError(raw)
+		msg := got.Error()
+		if !strings.Contains(msg, "HULAK_MASTER_KEY") {
+			t.Errorf("error %q should mention HULAK_MASTER_KEY", msg)
+		}
+		if !strings.Contains(msg, "different project") {
+			t.Errorf("error %q should suggest 'different project'", msg)
+		}
+	})
+
+	t.Run("passes through when HULAK_MASTER_KEY unset", func(t *testing.T) {
+		raw := errors.New("no identity matched any of the recipients")
+		t.Setenv("HULAK_MASTER_KEY", "")
+
+		got := WrapDecryptError(raw)
+		if got.Error() != raw.Error() {
+			t.Errorf("got %q, want original error %q", got.Error(), raw.Error())
+		}
+	})
+
+	t.Run("passes through non-matching errors", func(t *testing.T) {
+		raw := errors.New("some other error")
+		t.Setenv("HULAK_MASTER_KEY", "something")
+
+		got := WrapDecryptError(raw)
+		if got.Error() != raw.Error() {
+			t.Errorf("got %q, want original error %q", got.Error(), raw.Error())
 		}
 	})
 }

--- a/pkg/vault/keys_test.go
+++ b/pkg/vault/keys_test.go
@@ -307,3 +307,120 @@ func TestLoadIdentity(t *testing.T) {
 		}
 	})
 }
+
+func TestResolveIdentity(t *testing.T) {
+	t.Run("prefers HULAK_MASTER_KEY over identity file", func(t *testing.T) {
+		setupConfigDir(t)
+
+		// Write a file-based identity
+		fileID, _ := age.GenerateX25519Identity()
+		if err := SetIdentity(fileID.String()); err != nil {
+			t.Fatalf("SetIdentity: %v", err)
+		}
+
+		// Set env var to a different identity
+		envID, _ := age.GenerateX25519Identity()
+		t.Setenv("HULAK_MASTER_KEY", envID.String())
+
+		got, err := ResolveIdentity()
+		if err != nil {
+			t.Fatalf("ResolveIdentity() error: %v", err)
+		}
+		if got.String() != envID.String() {
+			t.Errorf("got %q, want env var identity %q", got.String(), envID.String())
+		}
+	})
+
+	t.Run("falls back to identity file when env var unset", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+
+		fileID, _ := age.GenerateX25519Identity()
+		if err := SetIdentity(fileID.String()); err != nil {
+			t.Fatalf("SetIdentity: %v", err)
+		}
+
+		got, err := ResolveIdentity()
+		if err != nil {
+			t.Fatalf("ResolveIdentity() error: %v", err)
+		}
+		if got.String() != fileID.String() {
+			t.Errorf("got %q, want file identity %q", got.String(), fileID.String())
+		}
+	})
+
+	t.Run("empty env var is treated as unset", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+
+		fileID, _ := age.GenerateX25519Identity()
+		if err := SetIdentity(fileID.String()); err != nil {
+			t.Fatalf("SetIdentity: %v", err)
+		}
+
+		got, err := ResolveIdentity()
+		if err != nil {
+			t.Fatalf("ResolveIdentity() error: %v", err)
+		}
+		if got.String() != fileID.String() {
+			t.Errorf("got %q, want file identity %q", got.String(), fileID.String())
+		}
+	})
+
+	t.Run("env var with whitespace is trimmed", func(t *testing.T) {
+		setupConfigDir(t)
+		envID, _ := age.GenerateX25519Identity()
+		t.Setenv("HULAK_MASTER_KEY", "  "+envID.String()+"\n")
+
+		got, err := ResolveIdentity()
+		if err != nil {
+			t.Fatalf("ResolveIdentity() error: %v", err)
+		}
+		if got.String() != envID.String() {
+			t.Errorf("got %q, want %q", got.String(), envID.String())
+		}
+	})
+
+	t.Run("env var with public key gives helpful error", func(t *testing.T) {
+		setupConfigDir(t)
+		envID, _ := age.GenerateX25519Identity()
+		t.Setenv("HULAK_MASTER_KEY", envID.Recipient().String())
+
+		_, err := ResolveIdentity()
+		if err == nil {
+			t.Fatal("expected error for public key in HULAK_MASTER_KEY")
+		}
+		if !strings.Contains(err.Error(), "public key") {
+			t.Errorf("error %q should mention 'public key'", err.Error())
+		}
+	})
+
+	t.Run("env var with garbage gives helpful error", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "not-a-real-key")
+
+		_, err := ResolveIdentity()
+		if err == nil {
+			t.Fatal("expected error for garbage HULAK_MASTER_KEY")
+		}
+		if !strings.Contains(err.Error(), "HULAK_MASTER_KEY") {
+			t.Errorf("error %q should mention HULAK_MASTER_KEY", err.Error())
+		}
+		if !strings.Contains(err.Error(), "AGE-SECRET-KEY-") {
+			t.Errorf("error %q should hint at correct format", err.Error())
+		}
+	})
+
+	t.Run("no env var and no file gives original error", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+
+		_, err := ResolveIdentity()
+		if err == nil {
+			t.Fatal("expected error when no identity available")
+		}
+		if !strings.Contains(err.Error(), "no identity found") {
+			t.Errorf("error %q should say 'no identity found'", err.Error())
+		}
+	})
+}

--- a/pkg/vault/keys_test.go
+++ b/pkg/vault/keys_test.go
@@ -461,3 +461,34 @@ func TestWrapDecryptError(t *testing.T) {
 		}
 	})
 }
+
+func TestExportKey(t *testing.T) {
+	t.Run("returns identity string when file exists", func(t *testing.T) {
+		setupConfigDir(t)
+
+		id, _ := age.GenerateX25519Identity()
+		if err := SetIdentity(id.String()); err != nil {
+			t.Fatalf("SetIdentity: %v", err)
+		}
+
+		got, err := ExportKey()
+		if err != nil {
+			t.Fatalf("ExportKey() error: %v", err)
+		}
+		if got != id.String() {
+			t.Errorf("ExportKey() = %q, want %q", got, id.String())
+		}
+	})
+
+	t.Run("errors when no identity exists", func(t *testing.T) {
+		setupConfigDir(t)
+
+		_, err := ExportKey()
+		if err == nil {
+			t.Fatal("ExportKey() should error when no identity")
+		}
+		if !strings.Contains(err.Error(), "hulak init") {
+			t.Errorf("error %q should mention 'hulak init'", err.Error())
+		}
+	})
+}

--- a/pkg/vault/keys_test.go
+++ b/pkg/vault/keys_test.go
@@ -492,3 +492,134 @@ func TestExportKey(t *testing.T) {
 		}
 	})
 }
+
+func TestImportKey(t *testing.T) {
+	t.Run("imports valid key", func(t *testing.T) {
+		configDir := setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+
+		id, _ := age.GenerateX25519Identity()
+
+		err := ImportKey(id.String(), false)
+		if err != nil {
+			t.Fatalf("ImportKey() error: %v", err)
+		}
+
+		got, err := GetIdentity()
+		if err != nil {
+			t.Fatalf("GetIdentity() after import: %v", err)
+		}
+		if strings.TrimSpace(got) != id.String() {
+			t.Errorf("imported key = %q, want %q", strings.TrimSpace(got), id.String())
+		}
+
+		info, _ := os.Stat(filepath.Join(configDir, utils.IdentityFile))
+		if info.Mode().Perm() != utils.SecretPer {
+			t.Errorf("permissions = %o, want %o", info.Mode().Perm(), utils.SecretPer)
+		}
+	})
+
+	t.Run("trims whitespace and extra newlines", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+
+		id, _ := age.GenerateX25519Identity()
+
+		err := ImportKey("  "+id.String()+"\n\n", false)
+		if err != nil {
+			t.Fatalf("ImportKey() error: %v", err)
+		}
+
+		loaded, _ := LoadIdentity()
+		if loaded.String() != id.String() {
+			t.Errorf("got %q, want %q", loaded.String(), id.String())
+		}
+	})
+
+	t.Run("rejects malformed key", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+
+		err := ImportKey("not-a-key", false)
+		if err == nil {
+			t.Fatal("expected error for malformed key")
+		}
+	})
+
+	t.Run("refuses overwrite without force", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+
+		id1, _ := age.GenerateX25519Identity()
+		if err := SetIdentity(id1.String()); err != nil {
+			t.Fatalf("SetIdentity: %v", err)
+		}
+
+		id2, _ := age.GenerateX25519Identity()
+		err := ImportKey(id2.String(), false)
+		if err == nil {
+			t.Fatal("expected error when overwriting without --force")
+		}
+		if !strings.Contains(err.Error(), "already exists") {
+			t.Errorf("error %q should mention 'already exists'", err.Error())
+		}
+
+		loaded, _ := LoadIdentity()
+		if loaded.String() != id1.String() {
+			t.Error("original identity was overwritten without --force")
+		}
+	})
+
+	t.Run("overwrites with force", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+
+		id1, _ := age.GenerateX25519Identity()
+		if err := SetIdentity(id1.String()); err != nil {
+			t.Fatalf("SetIdentity: %v", err)
+		}
+
+		id2, _ := age.GenerateX25519Identity()
+		err := ImportKey(id2.String(), true)
+		if err != nil {
+			t.Fatalf("ImportKey with force error: %v", err)
+		}
+
+		loaded, _ := LoadIdentity()
+		if loaded.String() != id2.String() {
+			t.Errorf("got %q, want %q", loaded.String(), id2.String())
+		}
+	})
+
+	t.Run("refuses when HULAK_MASTER_KEY is set", func(t *testing.T) {
+		setupConfigDir(t)
+		envID, _ := age.GenerateX25519Identity()
+		t.Setenv("HULAK_MASTER_KEY", envID.String())
+
+		id, _ := age.GenerateX25519Identity()
+		err := ImportKey(id.String(), false)
+		if err == nil {
+			t.Fatal("expected error when HULAK_MASTER_KEY is set")
+		}
+		if !strings.Contains(err.Error(), "HULAK_MASTER_KEY") {
+			t.Errorf("error %q should mention HULAK_MASTER_KEY", err.Error())
+		}
+	})
+
+	t.Run("extracts key from multi-line input with comments", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+
+		id, _ := age.GenerateX25519Identity()
+		input := "# created: 2026-04-28\n# public key: " + id.Recipient().String() + "\n" + id.String() + "\n"
+
+		err := ImportKey(input, false)
+		if err != nil {
+			t.Fatalf("ImportKey() error: %v", err)
+		}
+		loaded, _ := LoadIdentity()
+		if loaded.String() != id.String() {
+			t.Errorf("got %q, want %q", loaded.String(), id.String())
+		}
+	})
+}

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -189,7 +189,7 @@ func ReadStore(identity age.Identity) (*Store, error) {
 
 	plainText, err := DecryptText(cipherText, identity)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt store: %w", err)
+		return nil, WrapDecryptError(fmt.Errorf("failed to decrypt store: %w", err))
 	}
 
 	maybeWarnStoreSize(len(plainText))

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -235,18 +235,7 @@ func WriteStore(store *Store, recipients ...age.Recipient) error {
 		return fmt.Errorf("failed to encrypt store: %w", err)
 	}
 
-	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, cipherText, utils.SecretPer); err != nil {
-		os.Remove(tmpPath) // remove tmp, might be corrupted
-		return fmt.Errorf("failed to write store: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, path); err != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("failed to finalize store: %w", err)
-	}
-
-	return nil
+	return utils.AtomicWriteFile(path, cipherText, utils.SecretPer, utils.DirPer)
 }
 
 // WriteStoreToRecipients loads recipients from .hulak/recipients.txt and


### PR DESCRIPTION
## Summary

Closes #131

- `ResolveIdentity()` — fallback chain: `HULAK_MASTER_KEY` env var → `identity.txt` file
- All decrypt call sites switched from `LoadIdentity()` → `ResolveIdentity()`
- Friendly error wrapping when `HULAK_MASTER_KEY` doesn't match recipients
- `hulak env export-key` with `--out`/`-o` flag
- `hulak env import-key` with `--stdin`, `--force`, atomic tmp+rename
- Extracted `utils.AtomicWriteFile` (used by both `ImportKey` and `WriteStore`)
- Removed `notImplemented` stub — all env commands wired

## Test plan

- [ ] `go test ./...` passes
- [ ] `go vet ./...` clean
- [ ] E2E: `hulak env export-key` prints key with stderr warning
- [ ] E2E: `hulak env export-key --out /tmp/test.txt` writes 0600 file
- [ ] E2E: `hulak env import-key /tmp/test.txt --force` imports successfully
- [ ] E2E: `echo "$KEY" | hulak env import-key --stdin` works
- [ ] E2E: `HULAK_MASTER_KEY=<valid-key> hulak env get KEY --env prod` decrypts
- [ ] E2E: `HULAK_MASTER_KEY=<wrong-key> hulak env get KEY` shows friendly error
- [ ] E2E: `HULAK_MASTER_KEY=age1... hulak env get KEY` says "looks like a public key"