### PR TITLE
feat: add {{os}} template func + vault $VAR parity

### DIFF
--- a/pkg/envparser/envparser.go
+++ b/pkg/envparser/envparser.go
@@ -169,6 +169,18 @@ func inferType(val string, wasTrimmed bool) any {
 	return val
 }
 
+// resolveEnvRefs applies $VAR → os.LookupEnv resolution to string values
+// in the map. Matches the behavior of handleEnvVarValue used by LoadEnvVars
+// for .env files, giving vault store values the same $VAR semantics.
+func resolveEnvRefs(m map[string]any) map[string]any {
+	for key, val := range m {
+		if str, ok := val.(string); ok {
+			m[key] = handleEnvVarValue(str)
+		}
+	}
+	return m
+}
+
 // loadSecretsFromVault decrypts the store and returns merged env vars.
 // Uses the same merge pattern as classic: global base + custom overlay.
 func loadSecretsFromVault(envName string) (map[string]any, error) {
@@ -189,7 +201,7 @@ func loadSecretsFromVault(envName string) (map[string]any, error) {
 	resultMap := utils.CopyEnvMap(globalMap)
 
 	if envName == "" || strings.EqualFold(envName, utils.DefaultEnvVal) {
-		return resultMap, nil
+		return resolveEnvRefs(resultMap), nil
 	}
 
 	custom := store.GetEnv(envName)
@@ -197,7 +209,7 @@ func loadSecretsFromVault(envName string) (map[string]any, error) {
 		return nil, fmt.Errorf("environment %q not found in vault store", envName)
 	}
 	maps.Copy(resultMap, custom)
-	return resultMap, nil
+	return resolveEnvRefs(resultMap), nil
 }
 
 /*

--- a/pkg/envparser/replaceVars.go
+++ b/pkg/envparser/replaceVars.go
@@ -64,6 +64,7 @@ func replaceVariables(
 		utils.TemplateFuncGetValueOf: actions.GetValueOf,
 		utils.TemplateFuncGetFile:    actions.GetFile,
 		utils.TemplateFuncBasicAuth:  actions.BasicAuth,
+		utils.TemplateFuncOs:         os.Getenv,
 	}
 
 	tmpl, err := template.New("template").

--- a/pkg/envparser/replaceVars_test.go
+++ b/pkg/envparser/replaceVars_test.go
@@ -90,6 +90,10 @@ func TestSubstituteVariables(t *testing.T) {
 	// Set OS env for {{os}} tests
 	os.Setenv("HULAK_TEST_OS_TOKEN", "test_os_value")
 	defer os.Unsetenv("HULAK_TEST_OS_TOKEN")
+	os.Setenv("HULAK_TEST_A", "val_a")
+	os.Setenv("HULAK_TEST_B", "val_b")
+	defer os.Unsetenv("HULAK_TEST_A")
+	defer os.Unsetenv("HULAK_TEST_B")
 
 	varMap := map[string]any{
 		"varName":       "replacedValue",
@@ -213,6 +217,34 @@ func TestSubstituteVariables(t *testing.T) {
 			expectedErr:    nil,
 			varMap:         map[string]any{},
 		},
+		{
+			name:           "os func unset var returns empty string",
+			stringToChange: `{{os "HULAK_TEST_UNSET_VAR_XYZ"}}`,
+			expectedOutput: "",
+			expectedErr:    nil,
+			varMap:         map[string]any{},
+		},
+		{
+			name:           "os func alongside store var",
+			stringToChange: `{{.HOST}}/{{os "HULAK_TEST_OS_TOKEN"}}`,
+			expectedOutput: "api.com/test_os_value",
+			expectedErr:    nil,
+			varMap:         map[string]any{"HOST": "api.com"},
+		},
+		{
+			name:           "os func is case sensitive",
+			stringToChange: `{{os "hulak_test_os_token"}}`,
+			expectedOutput: "",
+			expectedErr:    nil,
+			varMap:         map[string]any{},
+		},
+		{
+			name:           "multiple os funcs in one string",
+			stringToChange: `{{os "HULAK_TEST_A"}}-{{os "HULAK_TEST_B"}}`,
+			expectedOutput: "val_a-val_b",
+			expectedErr:    nil,
+			varMap:         map[string]any{},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -323,6 +355,60 @@ func TestFormatMissingKeyError(t *testing.T) {
 			for _, expectedStr := range tc.expectedInMsg {
 				if !strings.Contains(errMsg, expectedStr) {
 					t.Errorf("Expected error message to contain '%s', got:\n%s", expectedStr, errMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveEnvRefsInMap(t *testing.T) {
+	os.Setenv("HULAK_TEST_VAULT_TOKEN", "resolved_token")
+	defer os.Unsetenv("HULAK_TEST_VAULT_TOKEN")
+
+	tests := []struct {
+		name     string
+		input    map[string]any
+		expected map[string]any
+	}{
+		{
+			name:     "dollar var resolves from OS",
+			input:    map[string]any{"TOKEN": "$HULAK_TEST_VAULT_TOKEN"},
+			expected: map[string]any{"TOKEN": "resolved_token"},
+		},
+		{
+			name:     "dollar var unset returns empty",
+			input:    map[string]any{"TOKEN": "$HULAK_TEST_NONEXISTENT_XYZ"},
+			expected: map[string]any{"TOKEN": ""},
+		},
+		{
+			name:     "non-dollar string unchanged",
+			input:    map[string]any{"KEY": "literal_value"},
+			expected: map[string]any{"KEY": "literal_value"},
+		},
+		{
+			name:     "non-string values unchanged",
+			input:    map[string]any{"PORT": 8080, "DEBUG": true, "RATE": 1.5},
+			expected: map[string]any{"PORT": 8080, "DEBUG": true, "RATE": 1.5},
+		},
+		{
+			name:     "bare dollar returns empty",
+			input:    map[string]any{"KEY": "$"},
+			expected: map[string]any{"KEY": ""},
+		},
+		{
+			name:     "mixed dollar and non-dollar",
+			input:    map[string]any{"A": "$HULAK_TEST_VAULT_TOKEN", "B": "plain"},
+			expected: map[string]any{"A": "resolved_token", "B": "plain"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := resolveEnvRefs(tc.input)
+			for k, want := range tc.expected {
+				got := result[k]
+				if got != want {
+					t.Errorf("key %q: got %v (%T), want %v (%T)", k, got, got, want, want)
 				}
 			}
 		})

--- a/pkg/envparser/replaceVars_test.go
+++ b/pkg/envparser/replaceVars_test.go
@@ -87,6 +87,10 @@ func TestHandleEnvVarValue(t *testing.T) {
 }
 
 func TestSubstituteVariables(t *testing.T) {
+	// Set OS env for {{os}} tests
+	os.Setenv("HULAK_TEST_OS_TOKEN", "test_os_value")
+	defer os.Unsetenv("HULAK_TEST_OS_TOKEN")
+
 	varMap := map[string]any{
 		"varName":       "replacedValue",
 		"secondName":    "John",
@@ -201,6 +205,13 @@ func TestSubstituteVariables(t *testing.T) {
 			expectedOutput: "Authorization: Basic dXNlcjpwYXNz",
 			expectedErr:    nil,
 			varMap:         map[string]any{"user": "user", "pass": "pass"},
+		},
+		{
+			name:           "os func resolves OS env var",
+			stringToChange: `Bearer {{os "HULAK_TEST_OS_TOKEN"}}`,
+			expectedOutput: "Bearer test_os_value",
+			expectedErr:    nil,
+			varMap:         map[string]any{},
 		},
 	}
 

--- a/pkg/utils/actions.go
+++ b/pkg/utils/actions.go
@@ -4,4 +4,5 @@ const (
 	TemplateFuncGetFile    = "getFile"
 	TemplateFuncGetValueOf = "getValueOf"
 	TemplateFuncBasicAuth  = "basicAuth"
+	TemplateFuncOs         = "os"
 )

--- a/pkg/utils/template_test.go
+++ b/pkg/utils/template_test.go
@@ -79,6 +79,16 @@ func TestFileHasTemplateVars(t *testing.T) {
 			content:  "---\nkind: GraphQL\nurl: \"https://{{.domain}}/graphql\"\nheaders:\n  Authorization: \"Bearer {{.token}}\"\n",
 			expected: true,
 		},
+		{
+			name:     "os_func_only_no_env_loading_needed",
+			content:  "---\nurl: http://example.com\nheaders:\n  Authorization: '{{os \"GITHUB_TOKEN\"}}'\n",
+			expected: false,
+		},
+		{
+			name:     "os_func_with_spaces_no_env_loading_needed",
+			content:  "---\nurl: http://example.com\nheaders:\n  Authorization: '{{ os \"TOKEN\" }}'\n",
+			expected: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -330,6 +340,20 @@ func TestMapHasEnvVars(t *testing.T) {
 				},
 			},
 			expected: true,
+		},
+		{
+			name:     "os_func_in_value_no_env_loading_needed",
+			data:     map[string]any{"auth": `{{os "GITHUB_TOKEN"}}`},
+			expected: false,
+		},
+		{
+			name: "os_func_nested_no_env_loading_needed",
+			data: map[string]any{
+				"headers": map[string]any{
+					"X-Token": `{{os "CI_TOKEN"}}`,
+				},
+			},
+			expected: false,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Add `{{os "VAR"}}` template function for direct OS env var access in YAML request files
- Fix `$VAR` resolution parity: vault store values now resolve `$VAR` from OS env, matching `.env` file behavior

## Why

- Users can reference shell env vars (`GITHUB_TOKEN`, `CI_BUILD_ID`) without defining intermediaries in the store
- `{{os "VAR"}}` is lazy — only resolves what's referenced, no sensitive vars leaked
- Vault `$VAR` gap meant `KEY=$OS_VAR` worked in `.env` but not in encrypted store

## Test plan

- [x] `{{os "VAR"}}` resolves set OS env vars
- [x] Unset vars return empty string (matches shell behavior)
- [x] Case sensitive lookup
- [x] Mix `{{.KEY}}` and `{{os "KEY"}}` in same template
- [x] Multiple `{{os}}` calls in one string
- [x] Vault `$VAR` resolves from OS
- [x] Non-string vault values unchanged
- [x] `go test ./... -count=1` — all pass, zero regressions