### PR TITLE
feat: hulak env migrate — convert env/*.env to encrypted store (#143)

### DIFF
--- a/pkg/envparser/envparser.go
+++ b/pkg/envparser/envparser.go
@@ -105,8 +105,7 @@ func handleEnvVarValue(val string) string {
 	return val
 }
 
-// LoadEnvVars returns map of the key-value pair from the provided .env filepath
-func LoadEnvVars(filePath string) (map[string]any, error) {
+func loadEnvVarsFromFile(filePath string, resolveOsVar bool) (map[string]any, error) {
 	hulakEnvironmentVariable := make(map[string]any)
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -138,10 +137,12 @@ func LoadEnvVars(filePath string) (map[string]any, error) {
 		}
 		key := strings.TrimSpace(secret[0])
 		val := strings.TrimSpace(secret[1])
-		val = handleEnvVarValue(val)
+
+		if resolveOsVar {
+			val = handleEnvVarValue(val)
+		}
 
 		val, wasTrimmed := trimQuotes(val)
-
 		// Infer value type and assign to the map
 		hulakEnvironmentVariable[key] = inferType(val, wasTrimmed)
 	}
@@ -151,6 +152,17 @@ func LoadEnvVars(filePath string) (map[string]any, error) {
 	}
 
 	return hulakEnvironmentVariable, nil
+}
+
+// LoadEnvVars returns map of the key-value pair from the provided .env filepath
+func LoadEnvVars(filePath string) (map[string]any, error) {
+	return loadEnvVarsFromFile(filePath, true)
+}
+
+// LoadEnvVarsRaw returns raw key-value pairs without resolving $VAR references.
+// Used by migration to preserve literal $VAR strings in the vault store.
+func LoadEnvVarsRaw(filePath string) (map[string]any, error) {
+	return loadEnvVarsFromFile(filePath, false)
 }
 
 // Helper function to infer type of a value

--- a/pkg/envparser/envparser_test.go
+++ b/pkg/envparser/envparser_test.go
@@ -91,6 +91,82 @@ KEY3='value3'
 	}
 }
 
+func TestLoadEnvVarsRaw(t *testing.T) {
+	t.Setenv("HULAK_TEST_RAW_TOKEN", "resolved_value")
+
+	content := `
+# comment line
+TOKEN=$HULAK_TEST_RAW_TOKEN
+MISSING=$HULAK_TEST_DOES_NOT_EXIST
+PLAIN=hello
+PORT=8080
+RATE=3.14
+DEBUG=true
+QUOTED="some string"
+`
+	filePath, err := createTempEnvFile(content)
+	if err != nil {
+		t.Fatalf("Failed to create temp env file: %v", err)
+	}
+	defer os.Remove(filePath)
+
+	raw, err := LoadEnvVarsRaw(filePath)
+	if err != nil {
+		t.Fatalf("LoadEnvVarsRaw error: %v", err)
+	}
+
+	t.Run("preserves dollar var as literal", func(t *testing.T) {
+		if raw["TOKEN"] != "$HULAK_TEST_RAW_TOKEN" {
+			t.Errorf("TOKEN = %v, want literal $HULAK_TEST_RAW_TOKEN", raw["TOKEN"])
+		}
+	})
+
+	t.Run("preserves missing dollar var as literal", func(t *testing.T) {
+		if raw["MISSING"] != "$HULAK_TEST_DOES_NOT_EXIST" {
+			t.Errorf("MISSING = %v, want literal $HULAK_TEST_DOES_NOT_EXIST", raw["MISSING"])
+		}
+	})
+
+	t.Run("plain string unchanged", func(t *testing.T) {
+		if raw["PLAIN"] != "hello" {
+			t.Errorf("PLAIN = %v, want hello", raw["PLAIN"])
+		}
+	})
+
+	t.Run("type inference still works", func(t *testing.T) {
+		if raw["PORT"] != 8080 {
+			t.Errorf("PORT = %v (%T), want int 8080", raw["PORT"], raw["PORT"])
+		}
+		if raw["RATE"] != 3.14 {
+			t.Errorf("RATE = %v (%T), want float 3.14", raw["RATE"], raw["RATE"])
+		}
+		if raw["DEBUG"] != true {
+			t.Errorf("DEBUG = %v (%T), want bool true", raw["DEBUG"], raw["DEBUG"])
+		}
+	})
+
+	t.Run("quoted string stays string", func(t *testing.T) {
+		if raw["QUOTED"] != "some string" {
+			t.Errorf("QUOTED = %v, want 'some string'", raw["QUOTED"])
+		}
+	})
+
+	// Regression: LoadEnvVars still resolves $VAR
+	t.Run("LoadEnvVars still resolves dollar var", func(t *testing.T) {
+		resolved, err := LoadEnvVars(filePath)
+		if err != nil {
+			t.Fatalf("LoadEnvVars error: %v", err)
+		}
+		if resolved["TOKEN"] != "resolved_value" {
+			t.Errorf("TOKEN = %v, want resolved_value", resolved["TOKEN"])
+		}
+		// $MISSING resolves to empty string (var not set)
+		if resolved["MISSING"] != "" {
+			t.Errorf("MISSING = %v, want empty string", resolved["MISSING"])
+		}
+	})
+}
+
 func setupVaultProject(t *testing.T, store *vault.Store) {
 	t.Helper()
 

--- a/pkg/userFlags/env_migrate.go
+++ b/pkg/userFlags/env_migrate.go
@@ -42,8 +42,7 @@ func runEnvMigrate() error {
 		return err
 	}
 
-	printMigrateSummary(wasFresh, ageKey)
-	return nil
+	return printMigrateSummary(wasFresh, ageKey)
 }
 
 // requireDirectory checks that path exists and is a directory.
@@ -159,13 +158,14 @@ func mergeEnvFileIntoStore(filePath, envName string, store *vault.Store) error {
 
 // printMigrateSummary shows identity details on first-time setup
 // and reminds the user that env/ is untouched.
-func printMigrateSummary(wasFresh bool, ageKey vault.AgeKey) {
+func printMigrateSummary(wasFresh bool, ageKey vault.AgeKey) error {
 	if wasFresh {
 		identityPath, err := vault.IdentityPath()
-		if err == nil {
-			fmt.Fprintf(os.Stderr, "\n  Identity file: %s\n", identityPath)
-			fmt.Fprintf(os.Stderr, "  Public key:    %s\n", ageKey.Recipient)
+		if err != nil {
+			return fmt.Errorf("could not resolve identity path: %w", err)
 		}
+		fmt.Fprintf(os.Stderr, "\n  Identity file: %s\n", identityPath)
+		fmt.Fprintf(os.Stderr, "  Public key:    %s\n", ageKey.Recipient)
 		utils.PrintWarningStderr(
 			"Back up the identity file — losing it means losing access to the vault.",
 		)
@@ -176,4 +176,5 @@ func printMigrateSummary(wasFresh bool, ageKey vault.AgeKey) {
 		"env/ is untouched. The encrypted store now takes priority.\n" +
 			"Delete it manually when ready: rm -rf env/",
 	)
+	return nil
 }

--- a/pkg/userFlags/env_migrate.go
+++ b/pkg/userFlags/env_migrate.go
@@ -1,0 +1,179 @@
+package userflags
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/xaaha/hulak/pkg/envparser"
+	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
+)
+
+// runEnvMigrate converts env/*.env files into the encrypted vault store.
+// Existing store values win on conflicts, making re-runs safe.
+// The env/ directory is NOT deleted — users do that manually.
+func runEnvMigrate() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("could not determine current directory: %w", err)
+	}
+
+	envDir := filepath.Join(cwd, utils.EnvironmentFolder)
+	if err := requireDirectory(envDir); err != nil {
+		return err
+	}
+
+	// Snapshot before EnsureKeypair so we only show the backup
+	// warning when a brand-new identity is generated.
+	wasFresh := !vault.IdentityExists()
+
+	ageKey, store, err := bootstrapVault(cwd)
+	if err != nil {
+		return err
+	}
+
+	if err := migrateEnvFiles(envDir, store); err != nil {
+		return err
+	}
+
+	if err := vault.WriteStoreToRecipients(store); err != nil {
+		return err
+	}
+
+	printMigrateSummary(wasFresh, ageKey)
+	return nil
+}
+
+// requireDirectory checks that path exists and is a directory.
+func requireDirectory(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("no %s/ directory found — nothing to migrate", filepath.Base(path))
+		}
+		return fmt.Errorf("cannot access %s/: %w", filepath.Base(path), err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("expected %s/ to be a directory, got a file", filepath.Base(path))
+	}
+	return nil
+}
+
+// bootstrapVault ensures .hulak/, identity, and recipients exist,
+// then returns the keypair and the current store (empty if first run).
+func bootstrapVault(projectRoot string) (vault.AgeKey, *vault.Store, error) {
+	hulakDir := filepath.Join(projectRoot, utils.HiddenProjectName)
+	if err := os.MkdirAll(hulakDir, utils.DirPer); err != nil {
+		return vault.AgeKey{}, nil, fmt.Errorf("could not create %s/: %w", utils.HiddenProjectName, err)
+	}
+
+	ageKey, err := vault.EnsureKeypair()
+	if err != nil {
+		return vault.AgeKey{}, nil, err
+	}
+
+	if err := ensureRecipientsFile(ageKey); err != nil {
+		return vault.AgeKey{}, nil, err
+	}
+
+	store, err := vault.ReadStore(ageKey.Identity)
+	if err != nil {
+		return vault.AgeKey{}, nil, err
+	}
+
+	return ageKey, store, nil
+}
+
+// migrateEnvFiles reads each *.env file in envDir and merges its
+// key-value pairs into store. Existing store values take precedence
+// so re-running migration never overwrites post-migration edits.
+// Non-.env files are skipped with a warning.
+func migrateEnvFiles(envDir string, store *vault.Store) error {
+	entries, err := os.ReadDir(envDir)
+	if err != nil {
+		return fmt.Errorf("failed to read %s/: %w", filepath.Base(envDir), err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if !strings.HasSuffix(name, utils.DefaultEnvFileSuffix) {
+			utils.PrintWarningStderr(fmt.Sprintf("Skipped: %s (not a .env file)", name))
+			continue
+		}
+
+		envName := strings.TrimSuffix(name, utils.DefaultEnvFileSuffix)
+		if err := utils.ValidateEnvName(envName); err != nil {
+			return fmt.Errorf("invalid env file %q: %w", name, err)
+		}
+
+		filePath := filepath.Join(envDir, name)
+		if err := mergeEnvFileIntoStore(filePath, envName, store); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// mergeEnvFileIntoStore parses a single .env file with raw values
+// (preserving $VAR literals) and adds new keys to the store section.
+// Keys that already exist in the store are skipped.
+func mergeEnvFileIntoStore(filePath, envName string, store *vault.Store) error {
+	parsed, err := envparser.LoadEnvVarsRaw(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s: %w", filepath.Base(filePath), err)
+	}
+
+	store.EnsureSection(envName)
+	existing := store.GetEnv(envName)
+
+	newKeys, skipped := 0, 0
+	for key, val := range parsed {
+		if _, exists := existing[key]; exists {
+			skipped++
+			continue
+		}
+		store.SetKey(envName, key, val)
+		newKeys++
+	}
+
+	fileName := filepath.Base(filePath)
+	if skipped > 0 {
+		utils.PrintSuccessStderr(fmt.Sprintf(
+			"Migrated %s → store.age[%s] (%d new, %d skipped)", fileName, envName, newKeys, skipped,
+		))
+	} else {
+		utils.PrintSuccessStderr(fmt.Sprintf(
+			"Migrated %s → store.age[%s] (%d keys)", fileName, envName, newKeys,
+		))
+	}
+
+	return nil
+}
+
+// printMigrateSummary shows identity details on first-time setup
+// and reminds the user that env/ is untouched.
+func printMigrateSummary(wasFresh bool, ageKey vault.AgeKey) {
+	if wasFresh {
+		identityPath, err := vault.IdentityPath()
+		if err == nil {
+			fmt.Fprintf(os.Stderr, "\n  Identity file: %s\n", identityPath)
+			fmt.Fprintf(os.Stderr, "  Public key:    %s\n", ageKey.Recipient)
+		}
+		utils.PrintWarningStderr(
+			"Back up the identity file — losing it means losing access to the vault.",
+		)
+	}
+
+	fmt.Fprintln(os.Stderr)
+	utils.PrintInfoStderr(
+		"env/ is untouched. The encrypted store now takes priority.\n" +
+			"Delete it manually when ready: rm -rf env/",
+	)
+}

--- a/pkg/userFlags/env_migrate_test.go
+++ b/pkg/userFlags/env_migrate_test.go
@@ -1,0 +1,248 @@
+package userflags
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"filippo.io/age"
+
+	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
+)
+
+// setupMigrateTest creates a temp project dir with env/ files and optional pre-existing vault.
+func setupMigrateTest(t *testing.T, envFiles map[string]string, existingStore *vault.Store) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	envDir := filepath.Join(tmpDir, utils.EnvironmentFolder)
+	if err := os.Mkdir(envDir, utils.DirPer); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range envFiles {
+		path := filepath.Join(envDir, name)
+		if err := os.WriteFile(path, []byte(content), utils.FilePer); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	configTmp := t.TempDir()
+	configTmp, _ = filepath.EvalSymlinks(configTmp)
+	t.Setenv("XDG_CONFIG_HOME", configTmp)
+
+	configDir, err := utils.UserConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(configDir, utils.DirPer); err != nil {
+		t.Fatal(err)
+	}
+
+	// Chdir before any vault calls so FindProjectRoot resolves to tmpDir.
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	if existingStore != nil {
+		hulakDir := filepath.Join(tmpDir, utils.HiddenProjectName)
+		if err := os.Mkdir(hulakDir, utils.DirPer); err != nil {
+			t.Fatal(err)
+		}
+
+		id, _ := age.GenerateX25519Identity()
+		if err := vault.SetIdentity(id.String()); err != nil {
+			t.Fatal(err)
+		}
+		if err := vault.SaveRecipients([]vault.RecipientEntry{
+			{Key: id.Recipient().String()},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := vault.WriteStore(existingStore, id.Recipient()); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestRunEnvMigrate(t *testing.T) {
+	t.Run("migrates single env file", func(t *testing.T) {
+		setupMigrateTest(t, map[string]string{
+			"global.env": "KEY1=value1\nKEY2=42\n",
+		}, nil)
+
+		if err := runEnvMigrate(); err != nil {
+			t.Fatalf("runEnvMigrate error: %v", err)
+		}
+
+		identity, err := vault.ResolveIdentity()
+		if err != nil {
+			t.Fatal(err)
+		}
+		store, err := vault.ReadStore(identity)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		env := store.GetEnv("global")
+		if env == nil {
+			t.Fatal("expected 'global' section in store")
+		}
+		if env["KEY1"] != "value1" {
+			t.Errorf("KEY1 = %v, want value1", env["KEY1"])
+		}
+	})
+
+	t.Run("migrates multiple env files", func(t *testing.T) {
+		setupMigrateTest(t, map[string]string{
+			"global.env":  "URL=https://example.com\n",
+			"staging.env": "URL=https://staging.example.com\nAPI_KEY=sk-123\n",
+		}, nil)
+
+		if err := runEnvMigrate(); err != nil {
+			t.Fatalf("runEnvMigrate error: %v", err)
+		}
+
+		identity, _ := vault.ResolveIdentity()
+		store, _ := vault.ReadStore(identity)
+
+		global := store.GetEnv("global")
+		if global["URL"] != "https://example.com" {
+			t.Errorf("global URL = %v", global["URL"])
+		}
+
+		staging := store.GetEnv("staging")
+		if staging == nil {
+			t.Fatal("expected 'staging' section")
+		}
+		if staging["API_KEY"] != "sk-123" {
+			t.Errorf("staging API_KEY = %v", staging["API_KEY"])
+		}
+	})
+
+	t.Run("existing store wins on conflicts", func(t *testing.T) {
+		setupMigrateTest(t, map[string]string{
+			"prod.env": "TOKEN=from_env\nNEW_KEY=new_value\n",
+		}, &vault.Store{Envs: map[string]vault.Env{
+			"prod": {"TOKEN": "from_store"},
+		}})
+
+		if err := runEnvMigrate(); err != nil {
+			t.Fatalf("runEnvMigrate error: %v", err)
+		}
+
+		identity, _ := vault.ResolveIdentity()
+		store, _ := vault.ReadStore(identity)
+
+		prod := store.GetEnv("prod")
+		if prod["TOKEN"] != "from_store" {
+			t.Errorf("TOKEN = %v, want from_store (existing wins)", prod["TOKEN"])
+		}
+		if prod["NEW_KEY"] != "new_value" {
+			t.Errorf("NEW_KEY = %v, want new_value (new key added)", prod["NEW_KEY"])
+		}
+	})
+
+	t.Run("preserves dollar var as literal", func(t *testing.T) {
+		setupMigrateTest(t, map[string]string{
+			"global.env": "TOKEN=$GITHUB_TOKEN\n",
+		}, nil)
+
+		if err := runEnvMigrate(); err != nil {
+			t.Fatalf("runEnvMigrate error: %v", err)
+		}
+
+		identity, _ := vault.ResolveIdentity()
+		store, _ := vault.ReadStore(identity)
+
+		env := store.GetEnv("global")
+		if env["TOKEN"] != "$GITHUB_TOKEN" {
+			t.Errorf("TOKEN = %v, want literal $GITHUB_TOKEN", env["TOKEN"])
+		}
+	})
+
+	t.Run("skips non-dot-env files", func(t *testing.T) {
+		setupMigrateTest(t, map[string]string{
+			"global.env": "KEY=val\n",
+			".env.bak":   "OLD=stale\n",
+			"notes.txt":  "not an env file\n",
+		}, nil)
+
+		if err := runEnvMigrate(); err != nil {
+			t.Fatalf("runEnvMigrate error: %v", err)
+		}
+
+		identity, _ := vault.ResolveIdentity()
+		store, _ := vault.ReadStore(identity)
+
+		envs := store.ListEnvs()
+		for _, name := range envs {
+			if name == ".env" || name == "notes" {
+				t.Errorf("unexpected env section %q — non-.env file was migrated", name)
+			}
+		}
+	})
+
+	t.Run("empty env file creates empty section", func(t *testing.T) {
+		setupMigrateTest(t, map[string]string{
+			"staging.env": "# only comments\n\n",
+		}, nil)
+
+		if err := runEnvMigrate(); err != nil {
+			t.Fatalf("runEnvMigrate error: %v", err)
+		}
+
+		identity, _ := vault.ResolveIdentity()
+		store, _ := vault.ReadStore(identity)
+
+		staging := store.GetEnv("staging")
+		if staging == nil {
+			t.Fatal("expected 'staging' section for empty .env file")
+		}
+		if len(staging) != 0 {
+			t.Errorf("expected empty section, got %d keys", len(staging))
+		}
+	})
+
+	t.Run("errors when env dir missing", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+		configTmp := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", configTmp)
+		oldWd, _ := os.Getwd()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+		err := runEnvMigrate()
+		if err == nil {
+			t.Fatal("expected error when env/ missing")
+		}
+	})
+
+	t.Run("errors when env is a file not directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+		envPath := filepath.Join(tmpDir, utils.EnvironmentFolder)
+		if err := os.WriteFile(envPath, []byte("not a dir"), utils.FilePer); err != nil {
+			t.Fatal(err)
+		}
+		configTmp := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", configTmp)
+		oldWd, _ := os.Getwd()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+		err := runEnvMigrate()
+		if err == nil {
+			t.Fatal("expected error when env/ is a file")
+		}
+	})
+}

--- a/pkg/userFlags/init.go
+++ b/pkg/userFlags/init.go
@@ -62,7 +62,7 @@ func InitClassicProject() error {
 //
 // Behaviour notes:
 //   - If env/ exists but .hulak/ does not, returns nil after printing a one-line
-//     migration nudge — the user should choose between `hulak migrate env`
+//     migration nudge — the user should choose between `hulak env migrate`
 //     (vault) and `hulak init classic` (stay plaintext) rather than have hulak
 //     silently bolt a vault next to existing plaintext.
 //   - Idempotent: re-running on a project that already has .hulak/ does not
@@ -95,7 +95,7 @@ func InitVaultProject(envNames []string) error {
 	if !utils.DirExists(hulakDir) && utils.DirExists(envDir) {
 		utils.PrintInfoStderr(
 			"This project uses the legacy env/ layout. " +
-				"Run 'hulak migrate env' to upgrade, or 'hulak init classic' to stay plaintext.",
+				"Run 'hulak env migrate' to upgrade, or 'hulak init classic' to stay plaintext.",
 		)
 		return nil
 	}

--- a/pkg/userFlags/init.go
+++ b/pkg/userFlags/init.go
@@ -100,26 +100,9 @@ func InitVaultProject(envNames []string) error {
 		return nil
 	}
 
-	if err := os.MkdirAll(hulakDir, utils.DirPer); err != nil {
-		return fmt.Errorf("could not create %s: %w", utils.HiddenProjectName, err)
-	}
-
-	// Snapshot identity presence BEFORE EnsureKeypair: the difference between
-	// "fresh identity just generated" (show backup nudge) and "reused existing
-	// identity" (already documented elsewhere) hangs on this check.
 	wasFresh := !vault.IdentityExists()
 
-	ageKey, err := vault.EnsureKeypair()
-	if err != nil {
-		return err
-	}
-
-	// Ensure recipients.txt exists with at least the user's own key.
-	if err := ensureRecipientsFile(ageKey); err != nil {
-		return err
-	}
-
-	store, err := vault.ReadStore(ageKey.Identity)
+	ageKey, store, err := bootstrapVault(cwd)
 	if err != nil {
 		return err
 	}

--- a/pkg/userFlags/init_test.go
+++ b/pkg/userFlags/init_test.go
@@ -263,7 +263,7 @@ func TestInitVaultProject_WithExtraEnvs(t *testing.T) {
 
 // TestInitVaultProject_LegacyEnvNudge verifies that init in a directory with
 // pre-existing env/ but no .hulak/ returns nil without creating .hulak/, so
-// the user can run `hulak migrate env` deliberately.
+// the user can run `hulak env migrate` deliberately.
 func TestInitVaultProject_LegacyEnvNudge(t *testing.T) {
 	dir := vaultTestSetup(t)
 

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -710,6 +710,18 @@ func newEnvCmd() *command {
 			},
 			Run: runSync,
 		},
+		{
+			Name:  "migrate",
+			Short: "Migrate env/*.env files to the encrypted vault",
+			Long: "Convert plaintext env/*.env files into the encrypted vault (.hulak/store.age).\n\n" +
+				"Parses each .env file, creates environment sections in the store, and encrypts.\n" +
+				"If the store already has values, existing values win on conflicts (safe to re-run).\n" +
+				"The env/ directory is NOT deleted — remove it manually after verifying the migration.",
+			Examples: []*utils.CommandHelp{
+				{Command: "hulak env migrate", Description: "Migrate all env/*.env files to the vault"},
+			},
+			Run: func(_ []string) error { return runEnvMigrate() },
+		},
 	}
 
 	return envCmd


### PR DESCRIPTION
## Summary

- Add `hulak env migrate` command that converts `env/*.env` files into `.hulak/store.age`
- Refactor `LoadEnvVars` → extract `LoadEnvVarsRaw` for `$VAR`-preserving parsing
- Extract `bootstrapVault` helper, reuse in `InitVaultProject` (−15 lines)
- Update `hulak migrate env` references → `hulak env migrate`

## Behavior

- Scans `env/` for `*.env` files, parses each with `LoadEnvVarsRaw`
- Existing store values win on conflicts (re-running is safe/idempotent)
- `$VAR` values stored as literals — resolved at runtime by `resolveEnvRefs`
- Non-`.env` files skipped with warning
- Empty `.env` files create empty sections
- `env/` directory NOT deleted — user does that manually
- Recovery key warning only on first-time keypair generation

## Test plan

- [x] Single/multiple `.env` file migration
- [x] Existing store wins on key conflicts
- [x] `$VAR` preserved as literal string
- [x] Non-`.env` files skipped
- [x] Empty `.env` creates empty section
- [x] Error: `env/` missing
- [x] Error: `env/` is a file
- [x] `LoadEnvVarsRaw` preserves raw values + type inference
- [x] `LoadEnvVars` regression: still resolves `$VAR`
- [x] `mise check` — 0 lint issues, all tests pass

Closes #143