### PR TITLE
feat: handle non-ASCII and encoding edge cases in env parsing and migration

### DIFF
--- a/pkg/envparser/envparser.go
+++ b/pkg/envparser/envparser.go
@@ -3,6 +3,7 @@ package envparser
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"maps"
 	"os"
@@ -105,15 +106,49 @@ func handleEnvVarValue(val string) string {
 	return val
 }
 
+// utf8BOM is the 3-byte byte order mark prepended by some editors (notably Windows).
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// nonUTF8BOMs lists BOMs for encodings hulak does not support. Ordered
+// longest-first so UTF-32 LE (which shares a 2-byte prefix with UTF-16 LE)
+// is detected before the shorter match.
+var nonUTF8BOMs = []struct {
+	bom  []byte
+	name string
+}{
+	{[]byte{0xFF, 0xFE, 0x00, 0x00}, "UTF-32 LE"},
+	{[]byte{0x00, 0x00, 0xFE, 0xFF}, "UTF-32 BE"},
+	{[]byte{0xFE, 0xFF}, "UTF-16 BE"},
+	{[]byte{0xFF, 0xFE}, "UTF-16 LE"},
+}
+
+// stripBOM removes a UTF-8 BOM from data if present. Returns an error
+// for non-UTF-8 BOMs (UTF-16, UTF-32) since hulak only supports UTF-8.
+func stripBOM(data []byte) ([]byte, error) {
+	for _, nb := range nonUTF8BOMs {
+		if bytes.HasPrefix(data, nb.bom) {
+			return nil, fmt.Errorf(
+				"file has %s BOM — hulak only supports UTF-8 encoded .env files",
+				nb.name,
+			)
+		}
+	}
+	return bytes.TrimPrefix(data, utf8BOM), nil
+}
+
 func loadEnvVarsFromFile(filePath string, resolveOsVar bool) (map[string]any, error) {
 	hulakEnvironmentVariable := make(map[string]any)
-	file, err := os.Open(filePath)
+	raw, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
 
-	scanner := bufio.NewScanner(file)
+	content, err := stripBOM(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", filepath.Base(filePath), err)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(content))
 	for scanner.Scan() {
 		line := scanner.Text()
 		// Skip empty lines and comments

--- a/pkg/envparser/envparser_test.go
+++ b/pkg/envparser/envparser_test.go
@@ -167,6 +167,175 @@ QUOTED="some string"
 	})
 }
 
+// createTempEnvFileBytes writes raw bytes to a temp .env file.
+// Use this instead of createTempEnvFile when you need to write BOM bytes.
+func createTempEnvFileBytes(data []byte) (string, error) {
+	file, err := os.CreateTemp("", "*.env")
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	if _, err := file.Write(data); err != nil {
+		return "", err
+	}
+	return file.Name(), nil
+}
+
+func TestBOMHandling(t *testing.T) {
+	t.Run("strips UTF-8 BOM", func(t *testing.T) {
+		content := append([]byte{0xEF, 0xBB, 0xBF}, []byte("KEY1=value1\nKEY2=value2\n")...)
+
+		path, err := createTempEnvFileBytes(content)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(path)
+
+		result, err := LoadEnvVars(path)
+		if err != nil {
+			t.Fatalf("LoadEnvVars error: %v", err)
+		}
+		if result["KEY1"] != "value1" {
+			t.Errorf("KEY1 = %v, want value1", result["KEY1"])
+		}
+		if result["KEY2"] != "value2" {
+			t.Errorf("KEY2 = %v, want value2", result["KEY2"])
+		}
+	})
+
+	t.Run("rejects UTF-16 BE BOM", func(t *testing.T) {
+		content := append([]byte{0xFE, 0xFF}, []byte("KEY=val\n")...)
+
+		path, err := createTempEnvFileBytes(content)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(path)
+
+		_, err = LoadEnvVars(path)
+		if err == nil {
+			t.Fatal("expected error for UTF-16 BE BOM")
+		}
+		if !strings.Contains(err.Error(), "UTF-16 BE") {
+			t.Errorf("error = %v, want mention of UTF-16 BE", err)
+		}
+	})
+
+	t.Run("rejects UTF-16 LE BOM", func(t *testing.T) {
+		content := append([]byte{0xFF, 0xFE}, []byte("KEY=val\n")...)
+
+		path, err := createTempEnvFileBytes(content)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(path)
+
+		_, err = LoadEnvVars(path)
+		if err == nil {
+			t.Fatal("expected error for UTF-16 LE BOM")
+		}
+		if !strings.Contains(err.Error(), "UTF-16 LE") {
+			t.Errorf("error = %v, want mention of UTF-16 LE", err)
+		}
+	})
+
+	t.Run("rejects UTF-32 BE BOM", func(t *testing.T) {
+		content := append([]byte{0x00, 0x00, 0xFE, 0xFF}, []byte("KEY=val\n")...)
+
+		path, err := createTempEnvFileBytes(content)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(path)
+
+		_, err = LoadEnvVars(path)
+		if err == nil {
+			t.Fatal("expected error for UTF-32 BE BOM")
+		}
+		if !strings.Contains(err.Error(), "UTF-32 BE") {
+			t.Errorf("error = %v, want mention of UTF-32 BE", err)
+		}
+	})
+
+	t.Run("no BOM works unchanged", func(t *testing.T) {
+		path, err := createTempEnvFile("KEY=value\n")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(path)
+
+		result, err := LoadEnvVars(path)
+		if err != nil {
+			t.Fatalf("LoadEnvVars error: %v", err)
+		}
+		if result["KEY"] != "value" {
+			t.Errorf("KEY = %v, want value", result["KEY"])
+		}
+	})
+}
+
+func TestNonASCIIValues(t *testing.T) {
+	t.Run("preserves UTF-8 non-ASCII in values", func(t *testing.T) {
+		content := "NAME=José\nGREET=こんにちは\nEMOJI=🚀\n"
+		path, err := createTempEnvFile(content)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(path)
+
+		result, err := LoadEnvVars(path)
+		if err != nil {
+			t.Fatalf("LoadEnvVars error: %v", err)
+		}
+		if result["NAME"] != "José" {
+			t.Errorf("NAME = %v, want José", result["NAME"])
+		}
+		if result["GREET"] != "こんにちは" {
+			t.Errorf("GREET = %v, want こんにちは", result["GREET"])
+		}
+		if result["EMOJI"] != "🚀" {
+			t.Errorf("EMOJI = %v, want 🚀", result["EMOJI"])
+		}
+	})
+
+	t.Run("CRLF line endings parse correctly", func(t *testing.T) {
+		content := []byte("KEY1=val1\r\nKEY2=val2\r\n")
+		path, err := createTempEnvFileBytes(content)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(path)
+
+		result, err := LoadEnvVars(path)
+		if err != nil {
+			t.Fatalf("LoadEnvVars error: %v", err)
+		}
+		if result["KEY1"] != "val1" {
+			t.Errorf("KEY1 = %q, want val1", result["KEY1"])
+		}
+		if result["KEY2"] != "val2" {
+			t.Errorf("KEY2 = %q, want val2", result["KEY2"])
+		}
+	})
+
+	t.Run("UTF-8 BOM with non-ASCII values", func(t *testing.T) {
+		content := append([]byte{0xEF, 0xBB, 0xBF}, []byte("NAME=José\n")...)
+		path, err := createTempEnvFileBytes(content)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(path)
+
+		result, err := LoadEnvVars(path)
+		if err != nil {
+			t.Fatalf("LoadEnvVars error: %v", err)
+		}
+		if result["NAME"] != "José" {
+			t.Errorf("NAME = %v, want José", result["NAME"])
+		}
+	})
+}
+
 func setupVaultProject(t *testing.T, store *vault.Store) {
 	t.Helper()
 

--- a/pkg/userFlags/env_migrate.go
+++ b/pkg/userFlags/env_migrate.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/xaaha/hulak/pkg/envparser"
 	"github.com/xaaha/hulak/pkg/utils"
@@ -132,10 +133,20 @@ func mergeEnvFileIntoStore(filePath, envName string, store *vault.Store) error {
 	store.EnsureSection(envName)
 	existing := store.GetEnv(envName)
 
-	newKeys, skipped := 0, 0
+	newKeys, skipped, invalidUTF8 := 0, 0, 0
 	for key, val := range parsed {
 		if _, exists := existing[key]; exists {
 			skipped++
+			continue
+		}
+		// JSON requires valid UTF-8. Skip binary/corrupt values with a warning.
+		if str, ok := val.(string); ok && !utf8.ValidString(str) {
+			invalidUTF8++
+			utils.PrintWarningStderr(fmt.Sprintf(
+				"Skipped: key %q in %s contains invalid UTF-8 bytes. "+
+					"Store binary data as files and use {{getFile \"path\"}} instead.",
+				key, filepath.Base(filePath),
+			))
 			continue
 		}
 		store.SetKey(envName, key, val)
@@ -143,15 +154,17 @@ func mergeEnvFileIntoStore(filePath, envName string, store *vault.Store) error {
 	}
 
 	fileName := filepath.Base(filePath)
+	var parts []string
+	parts = append(parts, fmt.Sprintf("%d new", newKeys))
 	if skipped > 0 {
-		utils.PrintSuccessStderr(fmt.Sprintf(
-			"Migrated %s → store.age[%s] (%d new, %d skipped)", fileName, envName, newKeys, skipped,
-		))
-	} else {
-		utils.PrintSuccessStderr(fmt.Sprintf(
-			"Migrated %s → store.age[%s] (%d keys)", fileName, envName, newKeys,
-		))
+		parts = append(parts, fmt.Sprintf("%d skipped", skipped))
 	}
+	if invalidUTF8 > 0 {
+		parts = append(parts, fmt.Sprintf("%d invalid UTF-8", invalidUTF8))
+	}
+	utils.PrintSuccessStderr(fmt.Sprintf(
+		"Migrated %s → store.age[%s] (%s)", fileName, envName, strings.Join(parts, ", "),
+	))
 
 	return nil
 }

--- a/pkg/userFlags/env_migrate_test.go
+++ b/pkg/userFlags/env_migrate_test.go
@@ -208,6 +208,62 @@ func TestRunEnvMigrate(t *testing.T) {
 		}
 	})
 
+	t.Run("skips invalid UTF-8 values", func(t *testing.T) {
+		setupMigrateTest(t, map[string]string{
+			"global.env": "GOOD=hello\n",
+		}, nil)
+
+		// Write a second env file with raw invalid UTF-8 bytes.
+		cwd, _ := os.Getwd()
+		badContent := append([]byte("VALID=ok\nBAD="), []byte{0xFF, 0xFE, 0x80}...)
+		badContent = append(badContent, '\n')
+		if err := os.WriteFile(
+			filepath.Join(cwd, utils.EnvironmentFolder, "staging.env"),
+			badContent, utils.FilePer,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := runEnvMigrate(); err != nil {
+			t.Fatalf("runEnvMigrate error: %v", err)
+		}
+
+		identity, _ := vault.ResolveIdentity()
+		store, _ := vault.ReadStore(identity)
+
+		staging := store.GetEnv("staging")
+		if staging == nil {
+			t.Fatal("expected 'staging' section")
+		}
+		if staging["VALID"] != "ok" {
+			t.Errorf("VALID = %v, want ok", staging["VALID"])
+		}
+		if _, exists := staging["BAD"]; exists {
+			t.Error("BAD key should have been skipped (invalid UTF-8)")
+		}
+	})
+
+	t.Run("preserves valid non-ASCII in migration", func(t *testing.T) {
+		setupMigrateTest(t, map[string]string{
+			"global.env": "NAME=José\nGREET=こんにちは\n",
+		}, nil)
+
+		if err := runEnvMigrate(); err != nil {
+			t.Fatalf("runEnvMigrate error: %v", err)
+		}
+
+		identity, _ := vault.ResolveIdentity()
+		store, _ := vault.ReadStore(identity)
+
+		env := store.GetEnv("global")
+		if env["NAME"] != "José" {
+			t.Errorf("NAME = %v, want José", env["NAME"])
+		}
+		if env["GREET"] != "こんにちは" {
+			t.Errorf("GREET = %v, want こんにちは", env["GREET"])
+		}
+	})
+
 	t.Run("errors when env dir missing", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		tmpDir, _ = filepath.EvalSymlinks(tmpDir)

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -46,13 +46,22 @@ type Store struct {
 
 // MarshalJSON serializes the store as a flat object with `_version` alongside
 // the named environments: {"_version": 1, "global": {...}, "prod": {...}}.
+// Uses SetEscapeHTML(false) so characters like &, <, > in values (e.g. URLs)
+// are kept literal instead of being escaped to \u003c etc.
 func (s *Store) MarshalJSON() ([]byte, error) {
 	out := make(map[string]any, len(s.Envs)+1)
 	out[versionFieldName] = StoreVersion
 	for name, env := range s.Envs {
 		out[name] = env
 	}
-	return json.Marshal(out)
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(out); err != nil {
+		return nil, err
+	}
+	// Encode appends a trailing newline; trim it for MarshalJSON contract.
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
 }
 
 // UnmarshalJSON parses the flat object form, validates the version, and
@@ -224,11 +233,17 @@ func WriteStore(store *Store, recipients ...age.Recipient) error {
 		return err
 	}
 
-	// for edit command, we need to display readable json
-	plainText, err := json.MarshalIndent(store, "", "  ")
-	if err != nil {
+	// Encoder with SetEscapeHTML(false) keeps &, <, > literal in values
+	// (e.g. URLs with query params) instead of escaping to \u003c etc.
+	// Indented for readability in hulak env edit.
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(store); err != nil {
 		return fmt.Errorf("failed to marshal store: %w", err)
 	}
+	plainText := buf.Bytes()
 
 	cipherText, err := EncryptText(plainText, recipients...)
 	if err != nil {

--- a/pkg/vault/store_test.go
+++ b/pkg/vault/store_test.go
@@ -299,6 +299,74 @@ func TestReadStoreWriteStoreRoundTrip(t *testing.T) {
 	}
 }
 
+func TestRoundTripNonASCIIAndHTMLChars(t *testing.T) {
+	setupHulakProject(t)
+	id, _ := age.GenerateX25519Identity()
+
+	original := &Store{Envs: map[string]Env{
+		"global": {
+			"NAME":     "José",
+			"GREET":    "こんにちは",
+			"EMOJI":    "🚀",
+			"HTML_URL": "https://example.com/api?a=1&b=2",
+			"TAG":      "<script>alert('xss')</script>",
+		},
+	}}
+
+	if err := WriteStore(original, id.Recipient()); err != nil {
+		t.Fatalf("WriteStore error: %v", err)
+	}
+
+	got, err := ReadStore(id)
+	if err != nil {
+		t.Fatalf("ReadStore error: %v", err)
+	}
+
+	env := got.GetEnv("global")
+	cases := map[string]string{
+		"NAME":     "José",
+		"GREET":    "こんにちは",
+		"EMOJI":    "🚀",
+		"HTML_URL": "https://example.com/api?a=1&b=2",
+		"TAG":      "<script>alert('xss')</script>",
+	}
+	for key, want := range cases {
+		if env[key] != want {
+			t.Errorf("%s = %v, want %s", key, env[key], want)
+		}
+	}
+}
+
+func TestWriteStoreNoHTMLEscaping(t *testing.T) {
+	setupHulakProject(t)
+	id, _ := age.GenerateX25519Identity()
+
+	store := &Store{Envs: map[string]Env{
+		"global": {
+			"URL": "https://example.com?a=1&b=2",
+			"TAG": "<div>hi</div>",
+		},
+	}}
+
+	if err := WriteStore(store, id.Recipient()); err != nil {
+		t.Fatalf("WriteStore error: %v", err)
+	}
+
+	// Read back and verify HTML chars survived un-escaped.
+	got, err := ReadStore(id)
+	if err != nil {
+		t.Fatalf("ReadStore error: %v", err)
+	}
+
+	env := got.GetEnv("global")
+	if env["URL"] != "https://example.com?a=1&b=2" {
+		t.Errorf("URL = %v, want literal &", env["URL"])
+	}
+	if env["TAG"] != "<div>hi</div>" {
+		t.Errorf("TAG = %v, want literal < >", env["TAG"])
+	}
+}
+
 func TestReadStorePreservesNumberTypes(t *testing.T) {
 	setupHulakProject(t)
 	id, _ := age.GenerateX25519Identity()


### PR DESCRIPTION
## Summary
Closes #147

- **BOM handling** in `envparser`: strip UTF-8 BOM, reject non-UTF-8 BOMs (UTF-16 LE/BE, UTF-32 LE/BE) with clear error
- **UTF-8 validation** during `hulak env migrate`: skip invalid UTF-8 string values with warning, suggest `{{getFile}}` for binary data
- **JSON escaping**: use `SetEscapeHTML(false)` in store marshal/write so `&`, `<`, `>` stay literal (not `\u003c` etc.)

## Files changed
| File | Change |
|------|--------|
| `pkg/envparser/envparser.go` | `stripBOM` + `loadEnvVarsFromFile` reads bytes first |
| `pkg/userFlags/env_migrate.go` | `utf8.ValidString` check in merge loop |
| `pkg/vault/store.go` | `MarshalJSON` and `WriteStore` use encoder with `SetEscapeHTML(false)` |

## Test plan
- [x] UTF-8 BOM stripped, first key parsed correctly
- [x] UTF-16 BE/LE and UTF-32 BE BOMs rejected with encoding name in error
- [x] Non-ASCII values (José, こんにちは, 🚀) preserved through parse and encrypt/decrypt round-trip
- [x] CRLF line endings parse correctly (verified Go's `ScanLines` handles it)
- [x] Invalid UTF-8 bytes skipped during migration with warning
- [x] HTML chars (`&`, `<`, `>`) survive store write/read without escaping
- [x] `mise check` passes (0 lint issues, all tests green)