### PR TITLE
feat: hulak env backup/restore commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,10 +2,8 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/xaaha/hulak/pkg/envparser"
 	"github.com/xaaha/hulak/pkg/runner"
@@ -138,19 +136,17 @@ func ensureHulakProject() {
 	}
 
 	utils.PrintErrorStderr("environment resolution requires a Hulak project")
-	fmt.Fprint(os.Stderr, "Initialize one here? [y/N] ")
-
-	scanner := bufio.NewScanner(os.Stdin)
-	if scanner.Scan() {
-		answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
-		if answer == "y" || answer == "yes" {
-			fmt.Fprintln(os.Stderr)
-			if err := envparser.CreateDefaultEnvs(nil); err != nil {
-				utils.PanicRedAndExit("%v", err)
-			}
-			fmt.Fprintln(os.Stderr)
-			return
+	confirmed, err := utils.ConfirmAction("Initialize one here? [y/N] ")
+	if err != nil {
+		utils.PanicRedAndExit("failed to read input: %v", err)
+	}
+	if confirmed {
+		fmt.Fprintln(os.Stderr)
+		if err := envparser.CreateDefaultEnvs(nil); err != nil {
+			utils.PanicRedAndExit("%v", err)
 		}
+		fmt.Fprintln(os.Stderr)
+		return
 	}
 
 	fmt.Fprintln(os.Stderr, "\nTo set up manually, run: hulak init")

--- a/pkg/envparser/envparser.go
+++ b/pkg/envparser/envparser.go
@@ -49,13 +49,11 @@ func setEnvironment(envFromFlag string, isCli bool) (bool, error) {
 	if !slices.Contains(envFromFiles, envFromFlag) {
 		// Prompts go to stderr so they never leak into $() capture.
 		fmt.Fprintf(os.Stderr, "'%v.env' not found in the env directory\n", envFromFlag)
-		fmt.Fprintf(os.Stderr, "Create '%v.env'? (y/n) ", envFromFlag)
-		reader := bufio.NewReader(os.Stdin)
-		responses, err := reader.ReadString('\n')
-		if err != nil {
-			return fileCreationSkipped, utils.ColorError("failed to read responses: %v", err)
+		confirmed, confirmErr := utils.ConfirmAction(fmt.Sprintf("Create '%v.env'? [y/N] ", envFromFlag))
+		if confirmErr != nil {
+			return fileCreationSkipped, utils.ColorError("failed to read input: %v", confirmErr)
 		}
-		if strings.TrimSpace(responses) == "y" || strings.TrimSpace(responses) == "Y" {
+		if confirmed {
 			err := CreateDefaultEnvs(&envFromFlag)
 			if err != nil {
 				return fileCreationSkipped, utils.ColorError(

--- a/pkg/userFlags/env_backup.go
+++ b/pkg/userFlags/env_backup.go
@@ -155,9 +155,13 @@ func resolveBackupDest(outPath string, force bool) (string, error) {
 	ts := time.Now().Format(backupTimestampFormat)
 	base := filepath.Join(backupsDir, backupPrefix+ts)
 
-	// Same-second collision: append .1, .2, etc.
+	// Same-second collision: append .1, .2, etc. Cap at 999 to avoid unbounded spin.
 	dest := base
+	const maxCollisions = 999
 	for counter := 1; utils.FileExists(dest); counter++ {
+		if counter > maxCollisions {
+			return "", fmt.Errorf("too many backups with timestamp %s (max %d)", ts, maxCollisions)
+		}
 		dest = fmt.Sprintf("%s.%d", base, counter)
 	}
 

--- a/pkg/userFlags/env_backup.go
+++ b/pkg/userFlags/env_backup.go
@@ -1,0 +1,358 @@
+// Contains command factories and handlers for hulak env backup and hulak env restore.
+package userflags
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
+)
+
+// backupPrefix is the filename prefix for default backups.
+const backupPrefix = "store.age.bak."
+
+// backupTimestampFormat formats timestamps for backup filenames.
+// Uses dashes instead of colons so filenames are valid on all platforms.
+const (
+	backupTimestampFormat  = "2006-01-02T15-04-05"
+	displayTimestampFormat = "2006-01-02 15:04:05"
+)
+
+func newEnvBackupCmd() *command {
+	fs := flag.NewFlagSet("env backup", flag.ContinueOnError)
+	var outPath string
+	var force bool
+	fs.StringVar(&outPath, "out", "", "Custom output path for the backup file")
+	fs.StringVar(&outPath, "o", "", "Custom output path for the backup file")
+	fs.BoolVar(&force, "force", false, "Overwrite existing --out target")
+	fs.BoolVar(&force, "f", false, "Overwrite existing --out target")
+
+	return &command{
+		Name:  "backup",
+		Short: "Create a backup of the encrypted store",
+		Long: "Copy store.age to a timestamped backup file after validating decryptability.\n\n" +
+			"Default location: .hulak/backups/store.age.bak.<timestamp>\n" +
+			"Use --out/-o for a custom path. Use 'hulak env backup list' to see existing backups.",
+		Flags: fs,
+		Examples: []*utils.CommandHelp{
+			{
+				Command:     "hulak env backup",
+				Description: "Create a timestamped backup of encrypted store.age",
+			},
+			{
+				Command:     "hulak env backup -o ~/backups/my.age",
+				Description: "Backup to a custom path",
+			},
+			{Command: "hulak env backup list", Description: "List existing backups"},
+			{
+				Command:     "hulak env backup --out existing.age --force",
+				Description: "Overwrite an existing backup file",
+			},
+		},
+		SubCommands: []*command{newEnvBackupListCmd()},
+		Run: func(args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unexpected arguments: %v", args)
+			}
+			return runBackup(outPath, force)
+		},
+	}
+}
+
+func newEnvBackupListCmd() *command {
+	return &command{
+		Name:    "list",
+		Aliases: []string{"ls"},
+		Short:   "List existing backups",
+		Long:    "Show all backup files in .hulak/backups/ with timestamps.",
+		Examples: []*utils.CommandHelp{
+			{Command: "hulak env backup list", Description: "List all backups"},
+			{Command: "hulak env backup ls", Description: "Same as list (alias)"},
+		},
+		Run: func(args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unexpected arguments: %v", args)
+			}
+			return runBackupList()
+		},
+	}
+}
+
+// runBackup creates a backup of store.age.
+func runBackup(outPath string, force bool) error {
+	identity, err := vault.ResolveIdentity()
+	if err != nil {
+		return fmt.Errorf("failed to load identity: %w", err)
+	}
+
+	storePath, err := vault.StorePath()
+	if err != nil {
+		return err
+	}
+
+	cipherText, err := os.ReadFile(storePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("no store.age found — nothing to back up")
+		}
+		return fmt.Errorf("failed to read store: %w", err)
+	}
+
+	// Validate: decrypt to prove the store is healthy. Discard the data.
+	if _, err := vault.DecryptText(cipherText, identity); err != nil {
+		return fmt.Errorf(
+			"store.age cannot be decrypted with current identity — refusing to back up a corrupt or inaccessible store: %w",
+			err,
+		)
+	}
+
+	destPath, err := resolveBackupDest(outPath, force)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(destPath), utils.DirPer); err != nil {
+		return fmt.Errorf("failed to create backup directory: %w", err)
+	}
+
+	if err := os.WriteFile(destPath, cipherText, utils.SecretPer); err != nil {
+		return fmt.Errorf("failed to write backup: %w", err)
+	}
+
+	// Auto-add .hulak/backups/ to .gitignore on first default-path backup
+	if outPath == "" {
+		if err := ensureGitignoreEntry(utils.HiddenProjectName + "/backups/"); err != nil {
+			utils.PrintWarningStderr(fmt.Sprintf("could not update .gitignore: %v", err))
+		}
+	}
+
+	utils.PrintSuccessStderr(fmt.Sprintf("Backup created: %s", destPath))
+	return nil
+}
+
+// resolveBackupDest determines the backup destination path.
+// For --out: uses the provided path, checking for existing file.
+// For default: generates a timestamped path under .hulak/backups/ with collision handling.
+func resolveBackupDest(outPath string, force bool) (string, error) {
+	if outPath != "" {
+		if !force && utils.FileExists(outPath) {
+			return "", fmt.Errorf("file already exists: %s (use --force to overwrite)", outPath)
+		}
+		return outPath, nil
+	}
+
+	backupsDir, err := vault.BackupsDir()
+	if err != nil {
+		return "", err
+	}
+
+	ts := time.Now().Format(backupTimestampFormat)
+	base := filepath.Join(backupsDir, backupPrefix+ts)
+
+	// Same-second collision: append .1, .2, etc.
+	dest := base
+	for counter := 1; utils.FileExists(dest); counter++ {
+		dest = fmt.Sprintf("%s.%d", base, counter)
+	}
+
+	return dest, nil
+}
+
+// runBackupList prints existing backups from .hulak/backups/.
+func runBackupList() error {
+	backupsDir, err := vault.BackupsDir()
+	if err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(backupsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			utils.PrintInfoStderr("No backups found")
+			return nil
+		}
+		return fmt.Errorf("failed to read backups directory: %w", err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), backupPrefix) {
+			names = append(names, e.Name())
+		}
+	}
+
+	if len(names) == 0 {
+		utils.PrintInfoStderr("No backups found")
+		return nil
+	}
+
+	// Sort lexicographically (timestamps sort naturally), newest last
+	sort.Strings(names)
+
+	rows := make([][]string, len(names))
+	for i, name := range names {
+		tsStr := strings.TrimPrefix(name, backupPrefix)
+		// Strip collision suffix if present (e.g. ".1")
+		if idx := strings.LastIndex(tsStr, "."); idx > 0 {
+			if _, err := fmt.Sscanf(tsStr[idx+1:], "%d", new(int)); err == nil {
+				tsStr = tsStr[:idx]
+			}
+		}
+		parsed, err := time.Parse(backupTimestampFormat, tsStr)
+		if err != nil {
+			rows[i] = []string{name, "(unknown)"}
+			continue
+		}
+		rows[i] = []string{name, parsed.Format(displayTimestampFormat)}
+	}
+
+	return utils.PrintTable(
+		os.Stdout,
+		utils.StdoutHeaders([]string{"BACKUP", "CREATED"}),
+		rows,
+		0,
+	)
+}
+
+func newEnvRestoreCmd() *command {
+	fs := flag.NewFlagSet("env restore", flag.ContinueOnError)
+	var force bool
+	fs.BoolVar(&force, "force", false, "Skip confirmation prompt")
+	fs.BoolVar(&force, "f", false, "Skip confirmation prompt")
+
+	return &command{
+		Name:  "restore",
+		Short: "Restore the encrypted store from a backup",
+		Long: "Restore store.age from a backup file.\n\n" +
+			"With no arguments, restores the latest backup from .hulak/backups/.\n" +
+			"Pass a path to restore a specific backup. The backup is decrypted and\n" +
+			"re-encrypted to the current recipients.txt.",
+		Flags: fs,
+		Args: []argDef{
+			{Name: "path", Desc: "Path to backup file (default: latest from .hulak/backups/)"},
+		},
+		Examples: []*utils.CommandHelp{
+			{Command: "hulak env restore", Description: "Restore the latest backup"},
+			{
+				Command:     "hulak env restore .hulak/backups/store.age.bak.2026-05-01T14-30-00",
+				Description: "Restore a specific backup",
+			},
+			{
+				Command:     "hulak env restore ~/backups/my.age",
+				Description: "Restore from an external backup",
+			},
+			{Command: "hulak env restore --force", Description: "Skip confirmation prompt"},
+		},
+		Run: func(args []string) error {
+			if len(args) > 1 {
+				return fmt.Errorf(
+					"too many arguments: got %d, expected at most 1 (path)",
+					len(args),
+				)
+			}
+			var path string
+			if len(args) == 1 {
+				path = args[0]
+			}
+			return runRestore(path, force)
+		},
+	}
+}
+
+// runRestore restores store.age from a backup.
+func runRestore(backupPath string, force bool) error {
+	resolvedPath, err := resolveRestorePath(backupPath)
+	if err != nil {
+		return err
+	}
+
+	// Decrypt to validate identity + version + JSON structure.
+	// The age library handles format detection — non-age files
+	// produce a clear decrypt error without hardcoding the header.
+	identity, err := vault.ResolveIdentity()
+	if err != nil {
+		return fmt.Errorf("failed to load identity: %w", err)
+	}
+
+	store, err := vault.ReadStoreFrom(resolvedPath, identity)
+	if err != nil {
+		return err
+	}
+
+	// Confirmation prompt
+	if !force {
+		utils.PrintInfoStderr(fmt.Sprintf("Restoring from %s", filepath.Base(resolvedPath)))
+		confirmed, confirmErr := utils.ConfirmAction(
+			"This will overwrite your current store.age. Continue? [y/N] ",
+		)
+		if confirmErr != nil {
+			return fmt.Errorf("failed to read input: %w", confirmErr)
+		}
+		if !confirmed {
+			utils.PrintInfoStderr("Restore cancelled")
+			return nil
+		}
+	}
+
+	// Re-encrypt to current recipients and write atomically
+	return vault.WithStoreLock(func() error {
+		if err := vault.WriteStoreToRecipients(store); err != nil {
+			return fmt.Errorf("failed to write restored store: %w", err)
+		}
+		utils.PrintSuccessStderr("Store restored from backup")
+		return nil
+	})
+}
+
+// resolveRestorePath determines which backup to restore.
+// If backupPath is empty, finds the latest backup in .hulak/backups/.
+func resolveRestorePath(backupPath string) (string, error) {
+	if backupPath != "" {
+		if !utils.FileExists(backupPath) {
+			return "", fmt.Errorf("backup file not found: %s", backupPath)
+		}
+		return backupPath, nil
+	}
+
+	backupsDir, err := vault.BackupsDir()
+	if err != nil {
+		return "", err
+	}
+
+	entries, err := os.ReadDir(backupsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf(
+				"no backups found in %s/",
+				utils.HiddenProjectName+"/backups",
+			)
+		}
+		return "", fmt.Errorf("failed to read backups directory: %w", err)
+	}
+
+	var names []string
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasPrefix(entry.Name(), backupPrefix) {
+			names = append(names, entry.Name())
+		}
+	}
+
+	if len(names) == 0 {
+		return "", fmt.Errorf(
+			"no backups found in %s/",
+			utils.HiddenProjectName+"/backups",
+		)
+	}
+
+	// Lexicographic sort — timestamps sort naturally, pick the latest
+	sort.Strings(names)
+	latest := names[len(names)-1]
+
+	return filepath.Join(backupsDir, latest), nil
+}

--- a/pkg/userFlags/env_backup_test.go
+++ b/pkg/userFlags/env_backup_test.go
@@ -1,0 +1,380 @@
+package userflags
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
+)
+
+func TestRunBackup_DefaultPath(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	if err := runBackup("", false); err != nil {
+		t.Fatalf("runBackup: %v", err)
+	}
+
+	backupsDir, _ := vault.BackupsDir()
+	entries, err := os.ReadDir(backupsDir)
+	if err != nil {
+		t.Fatalf("read backups dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 backup, got %d", len(entries))
+	}
+
+	name := entries[0].Name()
+	if !strings.HasPrefix(name, backupPrefix) {
+		t.Errorf("backup name %q missing prefix %q", name, backupPrefix)
+	}
+
+	// Check permissions
+	info, _ := os.Stat(filepath.Join(backupsDir, name))
+	if perm := info.Mode().Perm(); perm != utils.SecretPer {
+		t.Errorf("backup permissions = %o, want %o", perm, utils.SecretPer)
+	}
+}
+
+func TestRunBackup_OutPath(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	outPath := filepath.Join(t.TempDir(), "custom-backup.age")
+	if err := runBackup(outPath, false); err != nil {
+		t.Fatalf("runBackup --out: %v", err)
+	}
+
+	if !utils.FileExists(outPath) {
+		t.Fatal("backup file not created at --out path")
+	}
+}
+
+func TestRunBackup_OutExistingNoForce(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	outPath := filepath.Join(t.TempDir(), "existing.age")
+	if err := os.WriteFile(outPath, []byte("old"), 0o600); err != nil {
+		t.Fatalf("create existing file: %v", err)
+	}
+
+	err := runBackup(outPath, false)
+	if err == nil {
+		t.Fatal("expected error for existing --out without --force")
+	}
+	if !strings.Contains(err.Error(), "file already exists") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunBackup_OutExistingForce(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	outPath := filepath.Join(t.TempDir(), "existing.age")
+	if err := os.WriteFile(outPath, []byte("old"), 0o600); err != nil {
+		t.Fatalf("create existing file: %v", err)
+	}
+
+	if err := runBackup(outPath, true); err != nil {
+		t.Fatalf("runBackup --out --force: %v", err)
+	}
+
+	data, _ := os.ReadFile(outPath)
+	if string(data) == "old" {
+		t.Error("file was not overwritten")
+	}
+}
+
+func TestRunBackup_SameSecondCollision(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	if err := runBackup("", false); err != nil {
+		t.Fatalf("first backup: %v", err)
+	}
+	if err := runBackup("", false); err != nil {
+		t.Fatalf("second backup: %v", err)
+	}
+
+	backupsDir, _ := vault.BackupsDir()
+	entries, _ := os.ReadDir(backupsDir)
+	if len(entries) < 2 {
+		t.Fatalf("expected at least 2 backups, got %d", len(entries))
+	}
+
+	found := false
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".1") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected collision suffix .1 on second backup")
+	}
+}
+
+func TestRunBackup_NoStore(t *testing.T) {
+	setupVaultProject(t)
+
+	err := runBackup("", false)
+	if err == nil {
+		t.Fatal("expected error when no store exists")
+	}
+	if !strings.Contains(err.Error(), "nothing to back up") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunBackupList_Empty(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runBackupList(); err != nil {
+		t.Fatalf("runBackupList: %v", err)
+	}
+}
+
+func TestRunBackupList_WithBackups(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	if err := runBackup("", false); err != nil {
+		t.Fatalf("runBackup: %v", err)
+	}
+
+	if err := runBackupList(); err != nil {
+		t.Fatalf("runBackupList: %v", err)
+	}
+}
+
+func TestRunBackup_GitignoreUpdated(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	if err := runBackup("", false); err != nil {
+		t.Fatalf("runBackup: %v", err)
+	}
+
+	gitignorePath, _ := utils.CreatePath(".gitignore")
+	data, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+
+	if !strings.Contains(string(data), ".hulak/backups/") {
+		t.Error(".gitignore does not contain .hulak/backups/ entry")
+	}
+}
+
+func TestRunRestore_LatestBackup(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runEnvSet([]string{"KEY", "original"}, "global", false); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	if err := runBackup("", false); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	if err := runEnvSet([]string{"KEY", "mutated"}, "global", false); err != nil {
+		t.Fatalf("mutate store: %v", err)
+	}
+	if got := readStoredValue(t, "global", "KEY"); got != "mutated" {
+		t.Fatalf("store not mutated: %v", got)
+	}
+
+	if err := runRestore("", true); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	if got := readStoredValue(t, "global", "KEY"); got != "original" {
+		t.Errorf("after restore: KEY = %v, want %q", got, "original")
+	}
+}
+
+func TestRunRestore_SpecificPath(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runEnvSet([]string{"KEY", "original"}, "global", false); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	outPath := filepath.Join(t.TempDir(), "specific.age")
+	if err := runBackup(outPath, false); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	if err := runEnvSet([]string{"KEY", "changed"}, "global", false); err != nil {
+		t.Fatalf("mutate: %v", err)
+	}
+
+	if err := runRestore(outPath, true); err != nil {
+		t.Fatalf("restore specific: %v", err)
+	}
+
+	if got := readStoredValue(t, "global", "KEY"); got != "original" {
+		t.Errorf("after restore: KEY = %v, want %q", got, "original")
+	}
+}
+
+func TestRunRestore_NoBackups(t *testing.T) {
+	setupVaultProject(t)
+
+	err := runRestore("", true)
+	if err == nil {
+		t.Fatal("expected error when no backups exist")
+	}
+	if !strings.Contains(err.Error(), "no backups found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunRestore_MissingFile(t *testing.T) {
+	setupVaultProject(t)
+
+	err := runRestore("/nonexistent/backup.age", true)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunRestore_PlaintextFile(t *testing.T) {
+	setupVaultProject(t)
+
+	plainPath := filepath.Join(t.TempDir(), "plain.txt")
+	if err := os.WriteFile(plainPath, []byte("KEY=VALUE\n"), 0o600); err != nil {
+		t.Fatalf("create plaintext file: %v", err)
+	}
+
+	err := runRestore(plainPath, true)
+	if err == nil {
+		t.Fatal("expected error for plaintext file")
+	}
+	if !strings.Contains(err.Error(), "decrypt") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunRestore_WrongIdentity(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	outPath := filepath.Join(t.TempDir(), "backup.age")
+	if err := runBackup(outPath, false); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	// Rotate to a new identity so the backup can't be decrypted
+	newKey, err := vault.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate new key: %v", err)
+	}
+	if err := vault.SetIdentity(newKey.Identity.String()); err != nil {
+		t.Fatalf("set new identity: %v", err)
+	}
+
+	err = runRestore(outPath, true)
+	if err == nil {
+		t.Fatal("expected error when decrypting with wrong identity")
+	}
+}
+
+func TestRunRestore_ReencryptsToCurrentRecipients(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	outPath := filepath.Join(t.TempDir(), "backup.age")
+	if err := runBackup(outPath, false); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	// Add a second recipient
+	newKey, _ := vault.GenerateKeyPair()
+	if err := runAddRecipient([]string{newKey.Recipient.String()}, "teammate", false); err != nil {
+		t.Fatalf("add recipient: %v", err)
+	}
+
+	// Restore the old backup (which was encrypted to 1 recipient)
+	if err := runRestore(outPath, true); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	// The restored store should be decryptable by the new recipient
+	store, err := vault.ReadStore(newKey.Identity)
+	if err != nil {
+		t.Fatalf("new recipient cannot decrypt restored store: %v", err)
+	}
+	if v := store.GetEnv("global")["KEY"]; v != "val" {
+		t.Errorf("restored value = %v, want %q", v, "val")
+	}
+}
+
+func TestRunRestore_CancelledPrompt(t *testing.T) {
+	setupVaultProject(t)
+
+	if err := runEnvSet([]string{"KEY", "original"}, "global", false); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	outPath := filepath.Join(t.TempDir(), "backup.age")
+	if err := runBackup(outPath, false); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	if err := runEnvSet([]string{"KEY", "mutated"}, "global", false); err != nil {
+		t.Fatalf("mutate: %v", err)
+	}
+
+	// Simulate "n" answer by piping to stdin
+	r, w, _ := os.Pipe()
+	if _, err := w.WriteString("n\n"); err != nil {
+		t.Fatalf("write to pipe: %v", err)
+	}
+	w.Close()
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = orig })
+
+	if err := runRestore(outPath, false); err != nil {
+		t.Fatalf("restore should not error on cancel: %v", err)
+	}
+
+	// Store should NOT be restored — still mutated
+	if got := readStoredValue(t, "global", "KEY"); got != "mutated" {
+		t.Errorf("store was restored despite cancel: KEY = %v", got)
+	}
+}

--- a/pkg/userFlags/init.go
+++ b/pkg/userFlags/init.go
@@ -238,10 +238,11 @@ func ensureGitignoreEntry(entry string) error {
 		}
 		defer file.Close()
 
+		bare := strings.TrimRight(entry, "/")
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
-			if line == entry {
+			if line == entry || line == bare {
 				return nil
 			}
 		}

--- a/pkg/userFlags/init.go
+++ b/pkg/userFlags/init.go
@@ -44,7 +44,8 @@ func InitClassicProject() error {
 		return err
 	}
 
-	if err := ensureGitignoreEntry(); err != nil {
+	// gitignored path suffix is "/"
+	if err := ensureGitignoreEntry(utils.EnvironmentFolder + "/"); err != nil {
 		utils.PrintWarningStderr(fmt.Sprintf("could not update .gitignore: %v", err))
 	}
 
@@ -223,15 +224,12 @@ func writeAPIOptionsExample() (bool, error) {
 	return true, nil
 }
 
-// ensureGitignoreEntry adds env/ to .gitignore if not already present.
-func ensureGitignoreEntry() error {
+// ensureGitignoreEntry adds entry to .gitignore if not already present.
+func ensureGitignoreEntry(entry string) error {
 	gitignorePath, err := utils.CreatePath(".gitignore")
 	if err != nil {
 		return fmt.Errorf("could not resolve .gitignore path: %w", err)
 	}
-
-	// .gitignored uses forward / for path
-	entry := utils.EnvironmentFolder + "/"
 
 	if utils.FileExists(gitignorePath) {
 		file, err := os.Open(gitignorePath)
@@ -243,7 +241,7 @@ func ensureGitignoreEntry() error {
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
-			if line == entry || line == utils.EnvironmentFolder {
+			if line == entry {
 				return nil
 			}
 		}

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -427,6 +427,8 @@ func newEnvCmd() *command {
 		newEnvSyncCmd(),
 		newEnvRotateKeyCmd(),
 		newEnvMigrateCmd(),
+		newEnvBackupCmd(),
+		newEnvRestoreCmd(),
 	}
 
 	return envCmd

--- a/pkg/utils/printing.go
+++ b/pkg/utils/printing.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -128,6 +129,19 @@ func WriteCommandHelp(commands []*CommandHelp) error {
 		}
 	}
 	return w.Flush()
+}
+
+// ConfirmAction prints prompt to stderr and reads a single line from stdin.
+// Returns true for "y" or "yes" (case-insensitive), false otherwise.
+// Returns false (not error) on EOF or non-interactive stdin.
+func ConfirmAction(prompt string) (bool, error) {
+	fmt.Fprint(os.Stderr, prompt)
+	scanner := bufio.NewScanner(os.Stdin)
+	if !scanner.Scan() {
+		return false, scanner.Err()
+	}
+	answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
+	return answer == "y" || answer == "yes", nil
 }
 
 // HelpfulError formats a multi-line error with a title, a section heading, and a

--- a/pkg/utils/printing_test.go
+++ b/pkg/utils/printing_test.go
@@ -5,47 +5,45 @@ import (
 	"testing"
 )
 
-func TestConfirmAction_Yes(t *testing.T) {
-	for _, input := range []string{"y\n", "yes\n", "Y\n", "YES\n", "Yes\n"} {
-		r, w, _ := os.Pipe()
-		if _, err := w.WriteString(input); err != nil {
-			t.Fatalf("input %q: failed to write to pipe: %v", input, err)
-		}
-		w.Close()
-
-		orig := os.Stdin
-		os.Stdin = r
-		t.Cleanup(func() { os.Stdin = orig })
-
-		got, err := ConfirmAction("Continue? [y/N] ")
-		if err != nil {
-			t.Fatalf("input %q: unexpected error: %v", input, err)
-		}
-		if !got {
-			t.Errorf("input %q: want true, got false", input)
-		}
+func TestConfirmAction(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		// Affirmative inputs
+		{"lowercase y", "y\n", true},
+		{"lowercase yes", "yes\n", true},
+		{"uppercase Y", "Y\n", true},
+		{"uppercase YES", "YES\n", true},
+		{"mixed case Yes", "Yes\n", true},
+		// Negative / other inputs
+		{"lowercase n", "n\n", false},
+		{"lowercase no", "no\n", false},
+		{"empty line", "\n", false},
+		{"arbitrary text", "anything\n", false},
 	}
-}
 
-func TestConfirmAction_No(t *testing.T) {
-	for _, input := range []string{"n\n", "no\n", "\n", "anything\n"} {
-		r, w, _ := os.Pipe()
-		if _, err := w.WriteString(input); err != nil {
-			t.Fatalf("input %q: failed to write to pipe: %v", input, err)
-		}
-		w.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			if _, err := w.WriteString(tt.input); err != nil {
+				t.Fatalf("failed to write to pipe: %v", err)
+			}
+			w.Close()
 
-		orig := os.Stdin
-		os.Stdin = r
-		t.Cleanup(func() { os.Stdin = orig })
+			orig := os.Stdin
+			os.Stdin = r
+			t.Cleanup(func() { os.Stdin = orig })
 
-		got, err := ConfirmAction("Continue? [y/N] ")
-		if err != nil {
-			t.Fatalf("input %q: unexpected error: %v", input, err)
-		}
-		if got {
-			t.Errorf("input %q: want false, got true", input)
-		}
+			got, err := ConfirmAction("Continue? [y/N] ")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ConfirmAction(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/utils/printing_test.go
+++ b/pkg/utils/printing_test.go
@@ -1,0 +1,67 @@
+package utils
+
+import (
+	"os"
+	"testing"
+)
+
+func TestConfirmAction_Yes(t *testing.T) {
+	for _, input := range []string{"y\n", "yes\n", "Y\n", "YES\n", "Yes\n"} {
+		r, w, _ := os.Pipe()
+		if _, err := w.WriteString(input); err != nil {
+			t.Fatalf("input %q: failed to write to pipe: %v", input, err)
+		}
+		w.Close()
+
+		orig := os.Stdin
+		os.Stdin = r
+		t.Cleanup(func() { os.Stdin = orig })
+
+		got, err := ConfirmAction("Continue? [y/N] ")
+		if err != nil {
+			t.Fatalf("input %q: unexpected error: %v", input, err)
+		}
+		if !got {
+			t.Errorf("input %q: want true, got false", input)
+		}
+	}
+}
+
+func TestConfirmAction_No(t *testing.T) {
+	for _, input := range []string{"n\n", "no\n", "\n", "anything\n"} {
+		r, w, _ := os.Pipe()
+		if _, err := w.WriteString(input); err != nil {
+			t.Fatalf("input %q: failed to write to pipe: %v", input, err)
+		}
+		w.Close()
+
+		orig := os.Stdin
+		os.Stdin = r
+		t.Cleanup(func() { os.Stdin = orig })
+
+		got, err := ConfirmAction("Continue? [y/N] ")
+		if err != nil {
+			t.Fatalf("input %q: unexpected error: %v", input, err)
+		}
+		if got {
+			t.Errorf("input %q: want false, got true", input)
+		}
+	}
+}
+
+func TestConfirmAction_EOF(t *testing.T) {
+	r, w, _ := os.Pipe()
+	w.Close()
+
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = orig })
+
+	got, err := ConfirmAction("Continue? [y/N] ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Error("EOF stdin should return false")
+	}
+}

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -170,8 +170,8 @@ func (s *Store) DeleteKey(envName, key string) {
 	delete(env, key)
 }
 
-// storePath returns the absolute path to .hulak/store.age in the project root.
-func storePath() (string, error) {
+// StorePath returns the absolute path to .hulak/store.age in the project root.
+func StorePath() (string, error) {
 	markerPath, err := utils.GetProjectMarker()
 	if err != nil {
 		return "", err
@@ -179,10 +179,19 @@ func storePath() (string, error) {
 	return filepath.Join(markerPath, utils.StoreFile), nil
 }
 
+// BackupsDir returns the absolute path to .hulak/backups/ in the project root.
+func BackupsDir() (string, error) {
+	markerPath, err := utils.GetProjectMarker()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(markerPath, "backups"), nil
+}
+
 // ReadStore decrypts store.age and returns the Store.
 // Uses json.Decoder.UseNumber() to preserve int/float distinction.
 func ReadStore(identity age.Identity) (*Store, error) {
-	path, err := storePath()
+	path, err := StorePath()
 	if err != nil {
 		return nil, err
 	}
@@ -210,6 +219,26 @@ func ReadStore(identity age.Identity) (*Store, error) {
 	return store, nil
 }
 
+// ReadStoreFrom decrypts an age-encrypted store file at the given path.
+// Unlike ReadStore, a missing file is an error (not an empty store).
+func ReadStoreFrom(path string, identity age.Identity) (*Store, error) {
+	cipherText, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read backup: %w", err)
+	}
+
+	plainText, err := DecryptText(cipherText, identity)
+	if err != nil {
+		return nil, WrapDecryptError(fmt.Errorf("failed to decrypt backup: %w", err))
+	}
+
+	store := &Store{}
+	if err := json.Unmarshal(plainText, store); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
 // maybeWarnStoreSize prints a one-time stderr warning if the decrypted store
 // exceeds MaxStoreSizeWarnBytes. Stderr (not stdout) so callers like
 // `hulak env get` captured via $(...) stay clean.
@@ -228,7 +257,7 @@ func maybeWarnStoreSize(size int) {
 // WriteStore marshals the store to JSON, encrypts it, and writes to store.age.
 // Uses atomic write: writes to .tmp first, then renames to prevent corruption.
 func WriteStore(store *Store, recipients ...age.Recipient) error {
-	path, err := storePath()
+	path, err := StorePath()
 	if err != nil {
 		return err
 	}
@@ -275,7 +304,7 @@ const (
 // DetectStore checks which storage backend is available.
 // .hulak/store.age takes priority over env/ if both exist.
 func DetectStore() StoreType {
-	if path, err := storePath(); err == nil && utils.FileExists(path) {
+	if path, err := StorePath(); err == nil && utils.FileExists(path) {
 		return StoreAge
 	}
 

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -232,8 +232,12 @@ func ReadStoreFrom(path string, identity age.Identity) (*Store, error) {
 		return nil, WrapDecryptError(fmt.Errorf("failed to decrypt backup: %w", err))
 	}
 
+	maybeWarnStoreSize(len(plainText))
+
+	dec := json.NewDecoder(bytes.NewReader(plainText))
+	dec.UseNumber()
 	store := &Store{}
-	if err := json.Unmarshal(plainText, store); err != nil {
+	if err := dec.Decode(store); err != nil {
 		return nil, err
 	}
 	return store, nil

--- a/pkg/vault/store_test.go
+++ b/pkg/vault/store_test.go
@@ -733,3 +733,62 @@ func TestWriteStoreAtomicCleanup(t *testing.T) {
 		t.Error("WriteStore() left behind .tmp file")
 	}
 }
+
+func TestReadStoreFrom(t *testing.T) {
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+
+	store := &Store{Envs: map[string]Env{
+		"global": {"SECRET": "hello"},
+	}}
+	jsonData, err := json.Marshal(store)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	cipher, err := EncryptText(jsonData, id.Recipient())
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	backupPath := filepath.Join(t.TempDir(), "backup.age")
+	if err := os.WriteFile(backupPath, cipher, 0o600); err != nil {
+		t.Fatalf("write backup: %v", err)
+	}
+
+	got, err := ReadStoreFrom(backupPath, id)
+	if err != nil {
+		t.Fatalf("ReadStoreFrom: %v", err)
+	}
+	if v, ok := got.GetEnv("global")["SECRET"].(string); !ok || v != "hello" {
+		t.Errorf("got SECRET=%v, want %q", got.GetEnv("global")["SECRET"], "hello")
+	}
+}
+
+func TestReadStoreFrom_MissingFile(t *testing.T) {
+	id, _ := age.GenerateX25519Identity()
+	_, err := ReadStoreFrom("/nonexistent/path.age", id)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestReadStoreFrom_WrongIdentity(t *testing.T) {
+	id1, _ := age.GenerateX25519Identity()
+	id2, _ := age.GenerateX25519Identity()
+
+	store := &Store{Envs: map[string]Env{"global": {"K": "V"}}}
+	jsonData, _ := json.Marshal(store)
+	cipher, _ := EncryptText(jsonData, id1.Recipient())
+
+	path := filepath.Join(t.TempDir(), "backup.age")
+	if err := os.WriteFile(path, cipher, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := ReadStoreFrom(path, id2)
+	if err == nil {
+		t.Fatal("expected error when decrypting with wrong identity")
+	}
+}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -72,7 +72,7 @@ func EnsureKeypair() (AgeKey, error) {
 
 	// Identity missing. Refuse if a store already exists — the new identity
 	// wouldn't match the recipient store.age was encrypted to.
-	if existingStore, err := storePath(); err == nil && utils.FileExists(existingStore) {
+	if existingStore, err := StorePath(); err == nil && utils.FileExists(existingStore) {
 		return AgeKey{}, utils.HelpfulError(
 			fmt.Sprintf(
 				"identity not found at %s but %s exists. Refusing to generate a new identity that would not match the existing store",


### PR DESCRIPTION
## Summary

Closes #145

- Add `hulak env backup` — validates store decryptability, copies ciphertext to `.hulak/backups/` with timestamped filename
- Add `hulak env backup list` (alias `ls`) — shows existing backups with timestamps
- Add `hulak env restore` — decrypts backup, re-encrypts to current `recipients.txt`, atomic write
- Restore with no args auto-picks latest backup from `.hulak/backups/`
- `--out` / `-o` for custom backup path, `--force` / `-f` for overwrite/skip-confirm
- Same-second collision handling (`.1`, `.2` suffix)
- Auto-adds `.hulak/backups/` to `.gitignore` on first backup
- Extract `ConfirmAction` helper to `pkg/utils/printing.go`, refactor `main.go` and `envparser.go`
- Export `vault.StorePath()`, add `vault.BackupsDir()` and `vault.ReadStoreFrom()`
- Generalize `ensureGitignoreEntry` to accept arbitrary entry

## Test plan

- [ ] `go vet ./... && go test ./...` — all pass
- [ ] Backup creates timestamped file with 0600 perms
- [ ] Backup `--out` writes to custom path, errors on existing without `--force`
- [ ] Same-second collision appends counter suffix
- [ ] `backup list` shows backups table
- [ ] Restore round-trip: backup → mutate → restore → verify original
- [ ] Restore re-encrypts to current recipients (new recipient can decrypt after restore)
- [ ] Restore cancelled on `n` prompt leaves store unchanged
- [ ] Plaintext/wrong-identity file gives clear error on restore
- [ ] `.gitignore` updated on first backup