### PR TITLE
fix: v0.3 response handling bugs

### DIFF
--- a/pkg/apiCalls/apicalls.go
+++ b/pkg/apiCalls/apicalls.go
@@ -137,5 +137,5 @@ func PrintAndSaveFinalResp(resp CustomResponse, path string) error {
 		fmt.Println(strBody)
 	}
 
-	return evalAndWriteRes(strBody, path)
+	return evalAndWriteRes(strBody, resp.contentType, path)
 }

--- a/pkg/apiCalls/apicalls.go
+++ b/pkg/apiCalls/apicalls.go
@@ -109,16 +109,19 @@ func SendAndSaveAPIRequest(secretsMap map[string]any, path string, debug bool) (
 		return "", err
 	}
 
-	PrintAndSaveFinalResp(resp, path)
+	saveErr := PrintAndSaveFinalResp(resp, path)
 	status := ""
 	if resp.Response != nil {
 		status = resp.Response.Status
 	}
-	return status, nil
+	return status, saveErr
 }
 
-// PrintAndSaveFinalResp prints and saves the CustomResponse
-func PrintAndSaveFinalResp(resp CustomResponse, path string) {
+// PrintAndSaveFinalResp prints the CustomResponse to stdout and saves it to
+// disk next to the request file. Returns an error if the disk write fails so
+// the caller can fail the task — a successful HTTP request with a missing
+// response file should not look like a success to the user.
+func PrintAndSaveFinalResp(resp CustomResponse, path string) error {
 	jsonData, err := json.MarshalIndent(resp, "", "  ")
 
 	var strBody string
@@ -134,7 +137,5 @@ func PrintAndSaveFinalResp(resp CustomResponse, path string) {
 		fmt.Println(strBody)
 	}
 
-	if err := evalAndWriteRes(strBody, path); err != nil {
-		utils.PrintErrorStderr("saving response: " + err.Error())
-	}
+	return evalAndWriteRes(strBody, path)
 }

--- a/pkg/apiCalls/apicalls.go
+++ b/pkg/apiCalls/apicalls.go
@@ -80,7 +80,7 @@ func StandardCallWithClient(
 
 	duration := end.Sub(start)
 
-	return processResponse(req, response, duration, debug, reqBodyForDebug), nil
+	return processResponse(req, response, duration, debug, reqBodyForDebug)
 }
 
 // SendAndSaveAPIRequest calls the PrepareStruct using the provided envMap

--- a/pkg/apiCalls/apicalls_test.go
+++ b/pkg/apiCalls/apicalls_test.go
@@ -182,6 +182,45 @@ func TestStandardCallWithClient_NetworkError(t *testing.T) {
 	}
 }
 
+// TestStandardCallWithClient_BodyReadError simulates a transport error mid-stream
+// (e.g., TCP reset, connection drop while reading the response body). Regression
+// for #204 — previously this triggered log.Fatalf and killed the entire process,
+// abandoning sibling requests in the worker pool.
+func TestStandardCallWithClient_BodyReadError(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Status:     "200 OK",
+				Body:       &erroringReadCloser{err: ErrMockNetwork},
+				Header:     make(http.Header),
+			}, nil
+		},
+	}
+
+	apiInfo := yamlparser.APIInfo{
+		Method:  "GET",
+		URL:     "http://example.com/api/test",
+		Headers: map[string]string{},
+	}
+
+	_, err := StandardCallWithClient(apiInfo, false, mockClient)
+	if err == nil {
+		t.Fatal("expected error from body read failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "reading response body") {
+		t.Errorf("expected error to wrap with 'reading response body', got %v", err)
+	}
+}
+
+// erroringReadCloser returns err on every Read, simulating a broken stream.
+type erroringReadCloser struct {
+	err error
+}
+
+func (e *erroringReadCloser) Read(_ []byte) (int, error) { return 0, e.err }
+func (e *erroringReadCloser) Close() error               { return nil }
+
 func TestStandardCallWithClient_URLParams(t *testing.T) {
 	var capturedURL string
 

--- a/pkg/apiCalls/prepare.go
+++ b/pkg/apiCalls/prepare.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -40,13 +39,13 @@ func processResponse(
 	duration time.Duration,
 	debug bool,
 	reqBody []byte,
-) CustomResponse {
+) (CustomResponse, error) {
 	respBody, err := io.ReadAll(resp.Body)
 	if closeErr := resp.Body.Close(); closeErr != nil {
-		log.Printf("prepare.go: Error while closing response body: %v", closeErr)
+		utils.PrintWarningStderr("closing response body: " + closeErr.Error())
 	}
 	if err != nil {
-		log.Fatalf("prepare.go: Error while reading response: %v", err)
+		return CustomResponse{}, fmt.Errorf("reading response body: %w", err)
 	}
 
 	// Formatting the duration to two decimal points
@@ -69,7 +68,7 @@ func processResponse(
 				Body:       responseBody,
 			},
 			Duration: durationFormatted,
-		}
+		}, nil
 	}
 
 	// Reading Response Headers
@@ -123,7 +122,7 @@ func processResponse(
 		},
 		HTTPInfo: &tlsInfo,
 		Duration: durationFormatted,
-	}
+	}, nil
 }
 
 // when the flag is -dir run all the requests concurrently this is the current behavior.

--- a/pkg/apiCalls/prepare.go
+++ b/pkg/apiCalls/prepare.go
@@ -59,6 +59,8 @@ func processResponse(
 		responseBody = string(respBody)
 	}
 
+	contentType := resp.Header.Get("Content-Type")
+
 	if !debug {
 		// Return minimal set of data
 		return CustomResponse{
@@ -67,7 +69,8 @@ func processResponse(
 				Status:     resp.Status,
 				Body:       responseBody,
 			},
-			Duration: durationFormatted,
+			Duration:    durationFormatted,
+			contentType: contentType,
 		}, nil
 	}
 
@@ -120,8 +123,9 @@ func processResponse(
 			Headers:    responseHeaders,
 			Body:       responseBody,
 		},
-		HTTPInfo: &tlsInfo,
-		Duration: durationFormatted,
+		HTTPInfo:    &tlsInfo,
+		Duration:    durationFormatted,
+		contentType: contentType,
 	}, nil
 }
 

--- a/pkg/apiCalls/types.go
+++ b/pkg/apiCalls/types.go
@@ -7,6 +7,11 @@ type CustomResponse struct {
 	Response *ResponseInfo `json:"response,omitempty"`
 	HTTPInfo *HTTPInfo     `json:"http_info,omitempty"`
 	Duration string        `json:"duration,omitempty"`
+
+	// contentType captures the response Content-Type header so the saved
+	// file can use the right extension (#208). Unexported so it doesn't
+	// leak into the JSON output users see — encoding/json skips it.
+	contentType string
 }
 
 // RequestInfo has all the information about the  request body

--- a/pkg/apiCalls/writeResponse.go
+++ b/pkg/apiCalls/writeResponse.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"mime"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,19 +14,110 @@ import (
 	"golang.org/x/net/html"
 )
 
-func IsJSON(str string) bool {
-	var jsBfr json.RawMessage
-	return json.Unmarshal([]byte(str), &jsBfr) == nil
+// IsJSON reports whether s is a syntactically valid JSON document.
+// Uses encoding/json's state-machine validator so truncated payloads like
+// `{"key":"unclosed` are rejected (regression for #208).
+func IsJSON(s string) bool {
+	return json.Valid([]byte(s))
 }
 
+// IsXML reports whether s parses as XML.
 func IsXML(str string) bool {
 	var v any
 	return xml.Unmarshal([]byte(str), &v) == nil
 }
 
-func IsHTML(str string) bool {
-	doc, err := html.Parse(strings.NewReader(str))
-	return err == nil && strings.Contains(str, "</html>") && doc != nil
+// IsHTML reports whether s starts with a recognizable HTML structural marker.
+//
+// We require either `<!DOCTYPE` or a `<html` opening tag (case-insensitive,
+// after leading whitespace) instead of substring-matching `</html>` anywhere
+// in the body — the old check classified JSON error messages mentioning HTML
+// (e.g. `{"error":"... </html> ..."}`) as HTML and saved them with the wrong
+// extension (#208).
+func IsHTML(s string) bool {
+	trimmed := strings.TrimLeft(s, " \t\r\n")
+	lower := strings.ToLower(trimmed)
+	if strings.HasPrefix(lower, "<!doctype html") {
+		return true
+	}
+	if !strings.HasPrefix(lower, "<html") {
+		return false
+	}
+	// Final cheap sanity check: parse succeeds. html.Parse is permissive
+	// but it does reject truly broken inputs.
+	_, err := html.Parse(strings.NewReader(s))
+	return err == nil
+}
+
+// extensionFor picks the response-file extension. Content-Type header is the
+// primary signal; body sniffing is the fallback for servers that send no
+// header or a generic one (application/octet-stream, */*).
+//
+// Header parsing uses mime.ParseMediaType so parameters like "; charset=utf-8"
+// are stripped, and structured-suffix subtypes like "application/vnd.api+json"
+// resolve to the right extension via the "+suffix" convention (RFC 6839).
+func extensionFor(contentType, body string) string {
+	media, _, err := mime.ParseMediaType(contentType)
+	if err == nil && media != "" && !isGenericMediaType(media) {
+		if ext, ok := extensionForMediaType(media); ok {
+			return ext
+		}
+	}
+
+	// Fall back to body sniffing — order matters: HTML check is now strict
+	// enough that JSON containing markup-like substrings won't trip it.
+	switch {
+	case IsJSON(body):
+		return ".json"
+	case IsHTML(body):
+		return ".html"
+	case IsXML(body):
+		return ".xml"
+	default:
+		return ".txt"
+	}
+}
+
+// isGenericMediaType identifies media types that carry no useful classification
+// signal, so callers should fall through to body sniffing instead.
+func isGenericMediaType(media string) bool {
+	switch media {
+	case "application/octet-stream", "*/*":
+		return true
+	}
+	return false
+}
+
+// extensionForMediaType maps a parsed media type (no parameters) to a file
+// extension. Returns ok=false for unknown types so the caller can fall back.
+func extensionForMediaType(media string) (string, bool) {
+	// Structured-suffix subtypes per RFC 6839: "application/vnd.api+json"
+	// → ".json", "image/svg+xml" → ".xml", etc. Check before exact-match
+	// lookup so vendored types resolve correctly.
+	if idx := strings.LastIndex(media, "+"); idx > 0 {
+		switch media[idx+1:] {
+		case "json":
+			return ".json", true
+		case "xml":
+			return ".xml", true
+		}
+	}
+
+	switch media {
+	case "application/json", "text/json":
+		return ".json", true
+	case "text/html":
+		return ".html", true
+	case "application/xml", "text/xml":
+		return ".xml", true
+	case "text/plain":
+		return ".txt", true
+	case "text/csv":
+		return ".csv", true
+	case "application/pdf":
+		return ".pdf", true
+	}
+	return "", false
 }
 
 // Write the content to the specified path with the appropriate file extension.
@@ -41,20 +133,11 @@ func writeFile(path, suffixType, contentBody string) error {
 	return nil
 }
 
-// checks the content type of resBody and writes to the corresponding file format
-func evalAndWriteRes(resBody, path string) error {
+// evalAndWriteRes picks the file extension via Content-Type (with body-sniff
+// fallback) and writes resBody next to path.
+func evalAndWriteRes(resBody, contentType, path string) error {
 	if resBody == "" || path == "" {
 		return utils.ColorError("Invalid input: file path and resBody cannot be empty")
 	}
-
-	switch {
-	case IsJSON(resBody):
-		return writeFile(path, ".json", resBody)
-	case IsXML(resBody):
-		return writeFile(path, ".xml", resBody)
-	case IsHTML(resBody):
-		return writeFile(path, ".html", resBody)
-	default:
-		return writeFile(path, ".txt", resBody)
-	}
+	return writeFile(path, extensionFor(contentType, resBody), resBody)
 }

--- a/pkg/apiCalls/writeResponse.go
+++ b/pkg/apiCalls/writeResponse.go
@@ -4,6 +4,7 @@ package apicalls
 import (
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,15 +28,17 @@ func IsHTML(str string) bool {
 	return err == nil && strings.Contains(str, "</html>") && doc != nil
 }
 
-// Write the content to the specified path with the appropriate file extension
-func writeFile(path, suffixType, contentBody string) {
+// Write the content to the specified path with the appropriate file extension.
+// Returns an error if the disk write fails so the caller can fail the task
+// instead of silently losing the response file.
+func writeFile(path, suffixType, contentBody string) error {
 	fileName := utils.FileNameWithoutExtension(path) + utils.ResponseBase
 	dir := filepath.Dir(path)
 	fullFilePath := filepath.Join(dir, fileName+suffixType)
 	if err := os.WriteFile(fullFilePath, []byte(contentBody), 0o600); err != nil {
-		utils.PrintErrorStderr("saving response file: " + err.Error())
-		return
+		return fmt.Errorf("saving response %s: %w", fullFilePath, err)
 	}
+	return nil
 }
 
 // checks the content type of resBody and writes to the corresponding file format
@@ -46,13 +49,12 @@ func evalAndWriteRes(resBody, path string) error {
 
 	switch {
 	case IsJSON(resBody):
-		writeFile(path, ".json", resBody)
+		return writeFile(path, ".json", resBody)
 	case IsXML(resBody):
-		writeFile(path, ".xml", resBody)
+		return writeFile(path, ".xml", resBody)
 	case IsHTML(resBody):
-		writeFile(path, ".html", resBody)
+		return writeFile(path, ".html", resBody)
 	default:
-		writeFile(path, ".txt", resBody)
+		return writeFile(path, ".txt", resBody)
 	}
-	return nil
 }

--- a/pkg/apiCalls/writeResponse_test.go
+++ b/pkg/apiCalls/writeResponse_test.go
@@ -3,6 +3,8 @@ package apicalls
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -46,7 +48,9 @@ func TestEvalAndWriteRes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			filePath := filepath.Join(tempDir, "test")
 
-			_ = evalAndWriteRes(tc.resBody, filePath)
+			if err := evalAndWriteRes(tc.resBody, filePath); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
 			expectedFileName := "test_response" + tc.expectedExt
 			expectedPath := filepath.Join(tempDir, expectedFileName)
@@ -64,4 +68,31 @@ func TestEvalAndWriteRes(t *testing.T) {
 			t.Fatal("Expected Error but did not get it")
 		}
 	})
+}
+
+// TestEvalAndWriteRes_ReadOnlyDir is a regression for #205 — write failures
+// used to be silently swallowed, leaving the user with a "success" outcome
+// and no response file on disk. Skipped on Windows because chmod 0o555 on a
+// directory does not block writes there the way it does on POSIX.
+func TestEvalAndWriteRes_ReadOnlyDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("read-only dir semantics differ on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses dir mode bits")
+	}
+
+	tempDir := t.TempDir()
+	if err := os.Chmod(tempDir, 0o555); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(tempDir, 0o755) })
+
+	err := evalAndWriteRes(`{"ok":true}`, filepath.Join(tempDir, "req"))
+	if err == nil {
+		t.Fatal("expected error writing to read-only dir, got nil")
+	}
+	if !strings.Contains(err.Error(), "saving response") {
+		t.Errorf("expected error to wrap with 'saving response', got %v", err)
+	}
 }

--- a/pkg/apiCalls/writeResponse_test.go
+++ b/pkg/apiCalls/writeResponse_test.go
@@ -14,31 +14,35 @@ func TestEvalAndWriteRes(t *testing.T) {
 	tests := []struct {
 		name         string
 		resBody      string
+		contentType  string
 		expectedFile string
 		expectedExt  string
 	}{
 		{
 			name:         "JSON file creation",
 			resBody:      `{"key": "value"}`,
+			contentType:  "application/json",
 			expectedFile: "test.json",
 			expectedExt:  ".json",
 		},
 		{
 			name:         "XML file creation",
 			resBody:      `<root><key>value</key></root>`,
+			contentType:  "application/xml",
 			expectedFile: "test.xml",
 			expectedExt:  ".xml",
 		},
-		// not sure about html parser and test
-		// {
-		// 	name:         "HTML file creation",
-		// 	resBody:      `<html><body>Hello</body></html>`,
-		// 	expectedFile: "test.html",
-		// 	expectedExt:  ".html",
-		// },
+		{
+			name:         "HTML file creation",
+			resBody:      `<!DOCTYPE html><html><body>Hello</body></html>`,
+			contentType:  "text/html",
+			expectedFile: "test.html",
+			expectedExt:  ".html",
+		},
 		{
 			name:         "Plain text file creation",
 			resBody:      "This is plain text",
+			contentType:  "text/plain",
 			expectedFile: "test.txt",
 			expectedExt:  ".txt",
 		},
@@ -48,7 +52,7 @@ func TestEvalAndWriteRes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			filePath := filepath.Join(tempDir, "test")
 
-			if err := evalAndWriteRes(tc.resBody, filePath); err != nil {
+			if err := evalAndWriteRes(tc.resBody, tc.contentType, filePath); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
@@ -63,7 +67,7 @@ func TestEvalAndWriteRes(t *testing.T) {
 	}
 
 	t.Run("Invalid inputs should not create files", func(t *testing.T) {
-		err := evalAndWriteRes("", "")
+		err := evalAndWriteRes("", "", "")
 		if err == nil {
 			t.Fatal("Expected Error but did not get it")
 		}
@@ -88,11 +92,214 @@ func TestEvalAndWriteRes_ReadOnlyDir(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(tempDir, 0o755) })
 
-	err := evalAndWriteRes(`{"ok":true}`, filepath.Join(tempDir, "req"))
+	err := evalAndWriteRes(`{"ok":true}`, "application/json", filepath.Join(tempDir, "req"))
 	if err == nil {
 		t.Fatal("expected error writing to read-only dir, got nil")
 	}
 	if !strings.Contains(err.Error(), "saving response") {
 		t.Errorf("expected error to wrap with 'saving response', got %v", err)
+	}
+}
+
+// TestExtensionFor covers Content-Type → extension resolution and the body-sniff
+// fallback for missing/generic headers. Regression for #208 — the previous
+// implementation classified by body sniffing alone and produced wrong
+// extensions for truncated JSON, JSON containing the literal `</html>`, and
+// vendored JSON subtypes.
+func TestExtensionFor(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		want        string
+	}{
+		// --- Header-based resolution ---
+		{
+			name:        "application/json",
+			contentType: "application/json",
+			body:        `{"ok":true}`,
+			want:        ".json",
+		},
+		{
+			name:        "json with charset parameter",
+			contentType: "application/json; charset=utf-8",
+			body:        `{"ok":true}`,
+			want:        ".json",
+		},
+		{
+			name:        "vendored json subtype",
+			contentType: "application/vnd.api+json",
+			body:        `{"ok":true}`,
+			want:        ".json",
+		},
+		{
+			name:        "text/json",
+			contentType: "text/json",
+			body:        `{"ok":true}`,
+			want:        ".json",
+		},
+		{
+			name:        "text/html",
+			contentType: "text/html; charset=utf-8",
+			body:        "<!DOCTYPE html><html></html>",
+			want:        ".html",
+		},
+		{
+			name:        "application/xml",
+			contentType: "application/xml",
+			body:        "<r/>",
+			want:        ".xml",
+		},
+		{
+			name:        "vendored xml subtype",
+			contentType: "image/svg+xml",
+			body:        "<svg/>",
+			want:        ".xml",
+		},
+		{
+			name:        "text/plain",
+			contentType: "text/plain",
+			body:        "hello",
+			want:        ".txt",
+		},
+		{
+			name:        "text/csv",
+			contentType: "text/csv",
+			body:        "a,b\n1,2",
+			want:        ".csv",
+		},
+		{
+			name:        "application/pdf",
+			contentType: "application/pdf",
+			body:        "%PDF-1.4...",
+			want:        ".pdf",
+		},
+
+		// --- Generic / missing header → body sniff ---
+		{
+			name:        "missing content-type, JSON body",
+			contentType: "",
+			body:        `{"ok":true}`,
+			want:        ".json",
+		},
+		{
+			name:        "octet-stream falls back to sniff",
+			contentType: "application/octet-stream",
+			body:        `{"ok":true}`,
+			want:        ".json",
+		},
+		{
+			name:        "*/* falls back to sniff",
+			contentType: "*/*",
+			body:        `{"ok":true}`,
+			want:        ".json",
+		},
+		{
+			name:        "unknown content-type, plain body",
+			contentType: "application/x-some-unknown",
+			body:        "hello world",
+			want:        ".txt",
+		},
+
+		// --- #208 regression cases ---
+		{
+			name:        "json error mentioning </html> stays json",
+			contentType: "application/json",
+			body:        `{"error":"got </html> in input"}`,
+			want:        ".json",
+		},
+		{
+			name:        "no header, json body containing </html>",
+			contentType: "",
+			body:        `{"error":"got </html> in input"}`,
+			want:        ".json",
+		},
+		{
+			name:        "truncated json with no header is text",
+			contentType: "",
+			body:        `{"key":"unclosed`,
+			want:        ".txt",
+		},
+		{
+			name:        "plain text containing <html> is text",
+			contentType: "",
+			body:        "log line: <html> appeared in input",
+			want:        ".txt",
+		},
+		{
+			name:        "html starting with doctype",
+			contentType: "",
+			body:        "<!DOCTYPE html><html><body>x</body></html>",
+			want:        ".html",
+		},
+		{
+			name:        "html with leading whitespace",
+			contentType: "",
+			body:        "\n  <html><body>x</body></html>",
+			want:        ".html",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extensionFor(tc.contentType, tc.body); got != tc.want {
+				t.Errorf("extensionFor(%q, %q) = %q, want %q",
+					tc.contentType, tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsJSON_StrictValidation verifies the tightened IsJSON catches truncated
+// payloads (#208). The previous json.Unmarshal-into-RawMessage check accepted
+// some malformed inputs.
+func TestIsJSON_StrictValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"valid object", `{"a":1}`, true},
+		{"valid array", `[1,2,3]`, true},
+		{"valid string", `"hello"`, true},
+		{"truncated object", `{"key":"unclosed`, false},
+		{"truncated array", `[1,2,`, false},
+		{"trailing garbage", `{"a":1}garbage`, false},
+		{"empty", ``, false},
+		{"plain text", `hello`, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsJSON(tc.in); got != tc.want {
+				t.Errorf("IsJSON(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsHTML_StrictPrefix verifies IsHTML no longer matches arbitrary
+// substrings — only inputs that actually start with HTML structural markers
+// (regression for #208).
+func TestIsHTML_StrictPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"doctype html", "<!DOCTYPE html><html></html>", true},
+		{"html tag", "<html><body>x</body></html>", true},
+		{"html with leading whitespace", "  \n<html></html>", true},
+		{"uppercase HTML tag", "<HTML></HTML>", true},
+		{"json containing </html>", `{"e":"</html>"}`, false},
+		{"plain text mentioning <html>", "see <html> in logs", false},
+		{"empty string", "", false},
+		{"xml document", "<?xml version=\"1.0\"?><root/>", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsHTML(tc.in); got != tc.want {
+				t.Errorf("IsHTML(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/pkg/features/auth20.go
+++ b/pkg/features/auth20.go
@@ -136,8 +136,7 @@ func SendAPIRequestForAuth2(secretsMap map[string]any, filePath string, debug bo
 	if err != nil {
 		return err
 	}
-	apicalls.PrintAndSaveFinalResp(resp, filePath)
-	return nil
+	return apicalls.PrintAndSaveFinalResp(resp, filePath)
 }
 
 // isWSL checks if the Go program is running inside Windows Subsystem for Linux

--- a/pkg/tui/envselect/envselect.go
+++ b/pkg/tui/envselect/envselect.go
@@ -47,19 +47,22 @@ func noEnvFilesError() error {
 
 // envItems returns available environment names.
 // Reads from encrypted store when available, otherwise from env/ directory.
-func envItems() []string {
+//
+// Returns a non-nil error only when the vault is broken (missing identity,
+// decrypt failure, recipient drift). An empty-but-healthy vault and a missing
+// env/ directory both return (nil, nil) so the caller falls through to the
+// "no envs configured" prompt instead of an alarming error.
+func envItems() ([]string, error) {
 	if vault.DetectStore() == vault.StoreAge {
 		identity, err := vault.ResolveIdentity()
 		if err != nil {
-			utils.PrintErrorStderr(fmt.Sprintf("vault: %v", err))
-			return nil
+			return nil, fmt.Errorf("vault: %w", err)
 		}
 		store, err := vault.ReadStore(identity)
 		if err != nil {
-			utils.PrintErrorStderr(fmt.Sprintf("vault: failed to read store: %v", err))
-			return nil
+			return nil, fmt.Errorf("vault: reading store: %w", err)
 		}
-		return store.ListEnvs()
+		return store.ListEnvs(), nil
 	}
 
 	var items []string
@@ -70,10 +73,16 @@ func envItems() []string {
 			}
 		}
 	}
-	return items
+	return items, nil
 }
 
 // RunEnvSelector runs the environment selector and returns the selected environment.
+// Surfaces vault-layer errors verbatim so the user sees the actual problem
+// (e.g. "identity file is corrupt") instead of an empty selector.
 func RunEnvSelector() (string, error) {
-	return tui.RunSelector(envItems(), "Select Environment: ", noEnvFilesError())
+	items, err := envItems()
+	if err != nil {
+		return "", err
+	}
+	return tui.RunSelector(items, "Select Environment: ", noEnvFilesError())
 }

--- a/pkg/tui/envselect/envselect_test.go
+++ b/pkg/tui/envselect/envselect_test.go
@@ -45,7 +45,10 @@ func TestEnvItemsWithEnvFiles(t *testing.T) {
 	cleanup := setupTestEnvDir(t, []string{"dev.env", "prod.env", "staging.env"})
 	defer cleanup()
 
-	items := envItems()
+	items, err := envItems()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(items) != 3 {
 		t.Errorf("expected 3 items, got %d", len(items))
@@ -63,7 +66,10 @@ func TestEnvItemsWithNoEnvFiles(t *testing.T) {
 	cleanup := setupTestEnvDir(t, []string{})
 	defer cleanup()
 
-	items := envItems()
+	items, err := envItems()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(items) != 0 {
 		t.Errorf("expected 0 items, got %d", len(items))
@@ -74,7 +80,10 @@ func TestEnvItemsIgnoresNonEnvFiles(t *testing.T) {
 	cleanup := setupTestEnvDir(t, []string{"dev.env", "readme.txt", "config.yaml"})
 	defer cleanup()
 
-	items := envItems()
+	items, err := envItems()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(items) != 1 {
 		t.Errorf("expected 1 item, got %d", len(items))
@@ -138,7 +147,10 @@ func TestEnvItemsFromVault(t *testing.T) {
 		t.Fatalf("WriteStore() error: %v", err)
 	}
 
-	items := envItems()
+	items, err := envItems()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(items) != 3 {
 		t.Fatalf("EnvItems() len = %d, want 3", len(items))
@@ -203,4 +215,98 @@ func TestNoEnvFilesErrorVaultMode(t *testing.T) {
 	if strings.Contains(errStr, "hulak init") {
 		t.Errorf("vault error should not mention 'hulak init', got: %s", errStr)
 	}
+}
+
+// setupVaultProject prepares a working dir with a .hulak/ marker and an
+// isolated XDG_CONFIG_HOME pointing at a temp dir. Returns the project dir.
+// Used by the broken-vault regressions for #209.
+func setupVaultProject(t *testing.T) string {
+	t.Helper()
+
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Errorf("chdir back: %v", err)
+		}
+	})
+
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	hulakDir := filepath.Join(tmpDir, utils.HiddenProjectName)
+	if err := os.Mkdir(hulakDir, utils.DirPer); err != nil {
+		t.Fatal(err)
+	}
+
+	configTmp := t.TempDir()
+	configTmp, _ = filepath.EvalSymlinks(configTmp)
+	t.Setenv("XDG_CONFIG_HOME", configTmp)
+	t.Setenv(utils.MasterKey, "") // ensure no env-var identity bleeds in
+
+	configDir, err := utils.UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir: %v", err)
+	}
+	if err := os.MkdirAll(configDir, utils.DirPer); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	return tmpDir
+}
+
+// TestEnvItems_VaultErrors regression for #209 — vault read failures used to
+// be swallowed and shown to the user as "no envs found", masking the real
+// problem. Each subtest sets up a broken vault and asserts envItems surfaces
+// the error instead of returning a silent empty list.
+func TestEnvItems_VaultErrors(t *testing.T) {
+	t.Run("missing identity", func(t *testing.T) {
+		tmpDir := setupVaultProject(t)
+		// Write a store file but no identity. ResolveIdentity must fail.
+		storePath := filepath.Join(tmpDir, utils.HiddenProjectName, utils.StoreFile)
+		if err := os.WriteFile(storePath, []byte("encrypted"), utils.SecretPer); err != nil {
+			t.Fatal(err)
+		}
+
+		items, err := envItems()
+		if err == nil {
+			t.Fatalf("expected error, got items=%v", items)
+		}
+		if items != nil {
+			t.Errorf("expected nil items on error, got %v", items)
+		}
+		if !strings.Contains(err.Error(), "vault") {
+			t.Errorf("expected error to wrap with 'vault', got %v", err)
+		}
+	})
+
+	t.Run("corrupted store", func(t *testing.T) {
+		tmpDir := setupVaultProject(t)
+
+		id, err := age.GenerateX25519Identity()
+		if err != nil {
+			t.Fatalf("GenerateX25519Identity: %v", err)
+		}
+		if err := vault.SetIdentity(id.String()); err != nil {
+			t.Fatalf("SetIdentity: %v", err)
+		}
+		// Write garbage where the encrypted store should be — ReadStore will
+		// fail to decrypt.
+		storePath := filepath.Join(tmpDir, utils.HiddenProjectName, utils.StoreFile)
+		if err := os.WriteFile(storePath, []byte("not a valid age ciphertext"), utils.SecretPer); err != nil {
+			t.Fatal(err)
+		}
+
+		items, err := envItems()
+		if err == nil {
+			t.Fatalf("expected error, got items=%v", items)
+		}
+		if !strings.Contains(err.Error(), "vault") {
+			t.Errorf("expected error to wrap with 'vault', got %v", err)
+		}
+	})
 }


### PR DESCRIPTION
## Completed

- [x] Closes #204 — `log.Fatalf` in response body read crashes whole process on flaky network
- [x] Closes #205 — response file write failures are silently swallowed
- [x] Closes #208 — response file extension uses fragile body-sniffing instead of `Content-Type` header
- [x] Closes #209 — vault read failures show as "no envs found" instead of actionable error