### PR TITLE
feat: configurable request timeout (closes #206)

### DIFF
--- a/assets/schema.json
+++ b/assets/schema.json
@@ -10,6 +10,12 @@
       "description": "Request type that determines the flow to follow.",
       "enum": ["API", "Auth", "GraphQL", "graphql", "api", "auth"]
     },
+    "timeout": {
+      "title": "requestTimeout",
+      "type": "string",
+      "description": "Per-request timeout as a Go duration string (e.g. 30s, 5m, 1h30m). Overrides --timeout and $HULAK_TIMEOUT for this file. Default 60s.",
+      "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+    },
     "method": {
       "title": "httpMethod",
       "type": "string",

--- a/docs/body.md
+++ b/docs/body.md
@@ -39,6 +39,67 @@ urlparams:
   check: true
 ```
 
+### Timeout
+
+Optional per-request timeout. When unset, Hulak falls back to the `--timeout` flag, then `$HULAK_TIMEOUT`, then a 60-second default.
+
+```yaml
+method: GET
+url: "https://slow.example.com/big-export"
+timeout: 5m
+```
+
+Accepts any [Go duration string](https://pkg.go.dev/time#ParseDuration): `30s`, `90s`, `5m`, `2m30s`, `1h`. Bare numbers (`60`) are rejected — always include the unit.
+
+#### Precedence
+
+When more than one source could time-out a request, Hulak picks the highest-precedence source that is set:
+
+1. **YAML `timeout:` field** — wins over everything else for this file.
+2. **`--timeout <duration>` flag** — fallback for files with no YAML override. Works on `hulak run`, `hulak -fp`, and `hulak -dir`.
+3. **`HULAK_TIMEOUT` env var** — same scope as the flag, scoped to the shell session. Useful for slow VPNs or one-off runs without retyping.
+4. **60-second default** — when nothing above is set.
+
+A non-zero value at any layer overrides every layer below it; an unset / zero layer falls through to the next.
+
+#### Single-file runs
+
+```bash
+hulak run requests/big-export.hk.yaml                    # uses YAML timeout if set, else 60s
+hulak run requests/big-export.hk.yaml --timeout 10m      # 10m unless the YAML overrides it
+HULAK_TIMEOUT=2m hulak run requests/big-export.hk.yaml   # 2m unless YAML or --timeout overrides
+hulak -fp requests/big-export.hk.yaml --timeout 10m      # same precedence on the root-flag form
+```
+
+If the YAML has `timeout: 30s`, the file takes 30s no matter what `--timeout` or `HULAK_TIMEOUT` say.
+
+#### Directory / bulk runs
+
+Each file's YAML wins for that file. `--timeout` and `HULAK_TIMEOUT` act as the per-file fallback for files with no `timeout:` field. Resolution is per-file: in a directory of ten files where two set `timeout: 5m` in YAML, those two get 5 minutes and the other eight get the resolved fallback.
+
+```bash
+hulak run requests/ --timeout 90s          # 90s for files without YAML timeout, YAML still wins per-file
+hulak run requests/ --sequential --timeout 90s
+hulak -dir ./requests --timeout 90s        # root-flag form, concurrent
+hulak -dirseq ./requests --timeout 90s     # root-flag form, sequential
+```
+
+Files in concurrent mode (`-dir` / `hulak run <dir>`) each get their own resolved timeout independently — one slow file does not steal the budget from the next. Sequential mode (`-dirseq` / `--sequential`) applies the same per-file resolution one file at a time.
+
+#### Errors
+
+Hulak validates timeouts up front so a typo cannot silently fall back to the default:
+
+- A YAML `timeout:` value that is not a valid positive Go duration fails that file with `in <path>: invalid timeout "<value>": ...` before any request goes out. Other files in the run are unaffected.
+- An invalid `HULAK_TIMEOUT` aborts the whole run before any request work begins.
+- An invalid `--timeout` is rejected by Go's `flag` package the same way as any other duration flag.
+
+> [!Note]
+>
+> 1. `timeout: 0s` and negative durations are rejected — there is no "no timeout" mode. Set a value high enough for the slowest request you expect.
+> 2. The timeout covers the whole request (connect + send + read). It is not a connect-only or read-only timeout.
+> 3. Each retry attempt uses the same timeout independently; the value is per-attempt, not a total budget across retries.
+
 ### Body
 
 Represents the body of an HTTP request. Only one body type is allowed per request.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -89,11 +89,12 @@ hulak run path/to/dir/ --sequential
 
 Supported flags:
 
-| Flag                     | Meaning                                  |
-| ------------------------ | ---------------------------------------- |
-| `--env`, `--environment` | Use a specific environment               |
-| `--debug`                | Print request and response debug details |
-| `--sequential`, `--seq`  | Run directory files one at a time        |
+| Flag                     | Meaning                                                                                                                               |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `--env`, `--environment` | Use a specific environment                                                                                                            |
+| `--debug`                | Print request and response debug details                                                                                              |
+| `--sequential`, `--seq`  | Run directory files one at a time                                                                                                     |
+| `--timeout`              | Per-request timeout, e.g. `5m` or `90s`. Overrides `$HULAK_TIMEOUT`; YAML `timeout:` wins per file. See [body.md](./body.md#timeout). |
 
 Notes:
 
@@ -212,15 +213,16 @@ hulak <command> --help
 
 These are still supported. They are useful when you want the older root-flag style or need file-name search behavior.
 
-| Flag                    | Meaning                                                    | Example                                         |
-| ----------------------- | ---------------------------------------------------------- | ----------------------------------------------- |
-| `-env`, `--environment` | Select an environment for root-flag execution              | `hulak -env prod -fp requests/get-user.hk.yaml` |
-| `-fp`, `--file-path`    | Run one exact file path                                    | `hulak -fp requests/get-user.hk.yaml`           |
-| `-f`, `--file`          | Search for matching file names recursively and run matches | `hulak -f getUser`                              |
-| `-dir`                  | Run a directory concurrently                               | `hulak -dir ./requests/`                        |
-| `-dirseq`               | Run a directory sequentially                               | `hulak -dirseq ./requests/`                     |
-| `-debug`                | Enable debug output                                        | `hulak -fp requests/get-user.hk.yaml -debug`    |
-| `-v`, `--version`       | Print version                                              | `hulak --version`                               |
-| `-h`, `--help`          | Print help                                                 | `hulak --help`                                  |
+| Flag                    | Meaning                                                    | Example                                           |
+| ----------------------- | ---------------------------------------------------------- | ------------------------------------------------- |
+| `-env`, `--environment` | Select an environment for root-flag execution              | `hulak -env prod -fp requests/get-user.hk.yaml`   |
+| `-fp`, `--file-path`    | Run one exact file path                                    | `hulak -fp requests/get-user.hk.yaml`             |
+| `-f`, `--file`          | Search for matching file names recursively and run matches | `hulak -f getUser`                                |
+| `-dir`                  | Run a directory concurrently                               | `hulak -dir ./requests/`                          |
+| `-dirseq`               | Run a directory sequentially                               | `hulak -dirseq ./requests/`                       |
+| `-debug`                | Enable debug output                                        | `hulak -fp requests/get-user.hk.yaml -debug`      |
+| `-timeout`              | Per-request timeout, e.g. `5m` or `90s`                    | `hulak -fp requests/get-user.hk.yaml -timeout 2m` |
+| `-v`, `--version`       | Print version                                              | `hulak --version`                                 |
+| `-h`, `--help`          | Print help                                                 | `hulak --help`                                    |
 
 Use the shorthand form when it fits your workflow, but prefer `hulak run ...` in examples and onboarding material.

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 		}
 	}
 
-	if err := runner.ExecuteSingleFile(envMap, flags.Debug, filePath); err != nil {
+	if err := runner.ExecuteSingleFile(envMap, flags.Debug, filePath, flags.Timeout); err != nil {
 		// Same suppression as above: runner.IsRunFailure means printOutcome
 		// already explained the failure on stderr; just flip the exit code.
 		// The non-IsRunFailure branch is defensive — handleAPIRequests is

--- a/pkg/apiCalls/apicalls.go
+++ b/pkg/apiCalls/apicalls.go
@@ -3,6 +3,7 @@ package apicalls
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -23,13 +24,14 @@ var DefaultClient HTTPClient = &http.Client{}
 
 // StandardCall calls the api and returns the json body string
 // Uses the DefaultClient for HTTP calls
-func StandardCall(apiInfo yamlparser.APIInfo, debug bool) (CustomResponse, error) {
-	return StandardCallWithClient(apiInfo, debug, DefaultClient)
+func StandardCall(ctx context.Context, apiInfo yamlparser.APIInfo, debug bool) (CustomResponse, error) {
+	return StandardCallWithClient(ctx, apiInfo, debug, DefaultClient)
 }
 
 // StandardCallWithClient calls the api with a custom HTTP client and returns the json body string
 // This function allows dependency injection for testing purposes
 func StandardCallWithClient(
+	ctx context.Context,
 	apiInfo yamlparser.APIInfo,
 	debug bool,
 	client HTTPClient,
@@ -59,7 +61,7 @@ func StandardCallWithClient(
 	reqBodyForDebug := make([]byte, len(bodyBytes))
 	copy(reqBodyForDebug, bodyBytes)
 
-	req, err := http.NewRequest(method, preparedURL, newBodyReader)
+	req, err := http.NewRequestWithContext(ctx, method, preparedURL, newBodyReader)
 	if err != nil {
 		return CustomResponse{}, fmt.Errorf("error occurred on '%s': %v", method, err)
 	}
@@ -90,7 +92,7 @@ func StandardCallWithClient(
 // a per-file outcome line. On pre-flight failures (config parse, request
 // build) the status is empty. On transport failures (network down, DNS) the
 // status is also empty — the err carries the detail.
-func SendAndSaveAPIRequest(secretsMap map[string]any, path string, debug bool) (string, error) {
+func SendAndSaveAPIRequest(ctx context.Context, secretsMap map[string]any, path string, debug bool) (string, error) {
 	apiConfig, _, err := yamlparser.FinalStructForAPI(
 		path,
 		secretsMap,
@@ -104,7 +106,7 @@ func SendAndSaveAPIRequest(secretsMap map[string]any, path string, debug bool) (
 		return "", err
 	}
 
-	resp, err := StandardCall(apiInfo, debug)
+	resp, err := StandardCall(ctx, apiInfo, debug)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/apiCalls/apicalls_test.go
+++ b/pkg/apiCalls/apicalls_test.go
@@ -2,6 +2,7 @@ package apicalls
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -70,7 +71,7 @@ func TestStandardCallWithClient_Success(t *testing.T) {
 				Headers: map[string]string{},
 			}
 
-			resp, err := StandardCallWithClient(apiInfo, false, mockClient)
+			resp, err := StandardCallWithClient(context.Background(), apiInfo, false, mockClient)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -102,7 +103,7 @@ func TestStandardCallWithClient_Headers(t *testing.T) {
 		},
 	}
 
-	_, err := StandardCallWithClient(apiInfo, false, mockClient)
+	_, err := StandardCallWithClient(context.Background(), apiInfo, false, mockClient)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -141,7 +142,7 @@ func TestStandardCallWithClient_PostWithBody(t *testing.T) {
 		Body:    bytes.NewReader([]byte(requestBody)),
 	}
 
-	resp, err := StandardCallWithClient(apiInfo, false, mockClient)
+	resp, err := StandardCallWithClient(context.Background(), apiInfo, false, mockClient)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -172,7 +173,7 @@ func TestStandardCallWithClient_NetworkError(t *testing.T) {
 		Headers: map[string]string{},
 	}
 
-	_, err := StandardCallWithClient(apiInfo, false, mockClient)
+	_, err := StandardCallWithClient(context.Background(), apiInfo, false, mockClient)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -204,7 +205,7 @@ func TestStandardCallWithClient_BodyReadError(t *testing.T) {
 		Headers: map[string]string{},
 	}
 
-	_, err := StandardCallWithClient(apiInfo, false, mockClient)
+	_, err := StandardCallWithClient(context.Background(), apiInfo, false, mockClient)
 	if err == nil {
 		t.Fatal("expected error from body read failure, got nil")
 	}
@@ -241,7 +242,7 @@ func TestStandardCallWithClient_URLParams(t *testing.T) {
 		},
 	}
 
-	_, err := StandardCallWithClient(apiInfo, false, mockClient)
+	_, err := StandardCallWithClient(context.Background(), apiInfo, false, mockClient)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -272,7 +273,7 @@ func TestStandardCallWithClient_DebugMode(t *testing.T) {
 	}
 
 	// Test with debug=true
-	resp, err := StandardCallWithClient(apiInfo, true, mockClient)
+	resp, err := StandardCallWithClient(context.Background(), apiInfo, true, mockClient)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -308,7 +309,7 @@ func TestStandardCallWithClient_NonDebugMode(t *testing.T) {
 	}
 
 	// Test with debug=false
-	resp, err := StandardCallWithClient(apiInfo, false, mockClient)
+	resp, err := StandardCallWithClient(context.Background(), apiInfo, false, mockClient)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -339,7 +340,7 @@ func TestStandardCallWithClient_JSONResponse(t *testing.T) {
 		Headers: map[string]string{},
 	}
 
-	resp, err := StandardCallWithClient(apiInfo, false, mockClient)
+	resp, err := StandardCallWithClient(context.Background(), apiInfo, false, mockClient)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -374,7 +375,7 @@ func TestStandardCallWithClient_PlainTextResponse(t *testing.T) {
 		Headers: map[string]string{},
 	}
 
-	resp, err := StandardCallWithClient(apiInfo, false, mockClient)
+	resp, err := StandardCallWithClient(context.Background(), apiInfo, false, mockClient)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -404,7 +405,7 @@ func TestStandardCallWithClient_NilHeaders(t *testing.T) {
 		Headers: nil, // explicitly nil
 	}
 
-	_, err := StandardCallWithClient(apiInfo, false, mockClient)
+	_, err := StandardCallWithClient(context.Background(), apiInfo, false, mockClient)
 	if err != nil {
 		t.Fatalf("unexpected error with nil headers: %v", err)
 	}
@@ -423,7 +424,7 @@ func TestStandardCallWithClient_Duration(t *testing.T) {
 		Headers: map[string]string{},
 	}
 
-	resp, err := StandardCallWithClient(apiInfo, false, mockClient)
+	resp, err := StandardCallWithClient(context.Background(), apiInfo, false, mockClient)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -450,7 +451,7 @@ func TestStandardCall_UsesDefaultClient(t *testing.T) {
 		Headers: map[string]string{},
 	}
 
-	resp, err := StandardCall(apiInfo, false)
+	resp, err := StandardCall(context.Background(), apiInfo, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/features/auth20.go
+++ b/pkg/features/auth20.go
@@ -2,6 +2,7 @@
 package features
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -117,7 +118,7 @@ func openBrowserAndGetCode(filePath string, secretsMap map[string]any) (string, 
 
 // SendAPIRequestForAuth2  calls the PrepareStruct using the provided envMap
 // and makes the Api Call with StandardCall and prints the response in console
-func SendAPIRequestForAuth2(secretsMap map[string]any, filePath string, debug bool) error {
+func SendAPIRequestForAuth2(ctx context.Context, secretsMap map[string]any, filePath string, debug bool) error {
 	code, err := openBrowserAndGetCode(filePath, secretsMap)
 	if err != nil {
 		return err
@@ -132,7 +133,7 @@ func SendAPIRequestForAuth2(secretsMap map[string]any, filePath string, debug bo
 	if err != nil {
 		return err
 	}
-	resp, err := apicalls.StandardCall(apiInfo, debug)
+	resp, err := apicalls.StandardCall(ctx, apiInfo, debug)
 	if err != nil {
 		return err
 	}

--- a/pkg/features/graphql/graphql.go
+++ b/pkg/features/graphql/graphql.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -26,7 +27,7 @@ func FetchAndParseSchema(apiInfo yamlparser.APIInfo) (Schema, error) {
 	apiInfo.Body = bytes.NewReader(jsonData)
 
 	// Make the HTTP call
-	resp, err := apicalls.StandardCall(apiInfo, false)
+	resp, err := apicalls.StandardCall(context.Background(), apiInfo, false)
 	if err != nil {
 		return Schema{}, fmt.Errorf("introspection request failed: %w", err)
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -36,13 +36,32 @@ type Flags struct {
 	Debug    bool
 	Dir      string
 	Dirseq   string
+	// Timeout overrides the default 60s per-request timeout. Zero means
+	// "fall back to HULAK_TIMEOUT, then the 60s default". A YAML `timeout:`
+	// field on the request file wins over this flag.
+	Timeout time.Duration
 }
+
+// DefaultTimeout is the per-request timeout used when no override is set
+// (no YAML `timeout:` field, no --timeout flag, no HULAK_TIMEOUT env var).
+const DefaultTimeout = 60 * time.Second
+
+// HulakTimeoutEnv is the env var users set to override the default timeout
+// for a session without editing request files or passing --timeout.
+const HulakTimeoutEnv = "HULAK_TIMEOUT"
 
 // Execute runs the full pipeline: discover files, resolve env, execute requests.
 // Returns an error if any request file failed — callers should propagate it
 // so the top-level exit code is non-zero on partial success. A nil error means
 // every dispatched request succeeded.
 func Execute(f *Flags) error {
+	// Resolve the flag/env layer of the timeout chain up front so a malformed
+	// HULAK_TIMEOUT fails fast before any request work begins.
+	baseTimeout, err := resolveBaseTimeout(f.Timeout)
+	if err != nil {
+		return err
+	}
+
 	fileList, concurrentDir, sequentialDir, err := discoverFilePaths(
 		f.File,
 		f.FilePath,
@@ -84,13 +103,65 @@ func Execute(f *Flags) error {
 		append(fileList, concurrentDir...),
 		sequentialDir,
 		f.FilePath,
+		baseTimeout,
 	)
 }
 
 // ExecuteSingleFile runs a single file through the pipeline.
 // Used by interactive mode where the file is already known.
-func ExecuteSingleFile(envMap map[string]any, debug bool, filePath string) error {
-	return handleAPIRequests(envMap, debug, []string{filePath}, nil, filePath)
+//
+// flagTimeout is the value of --timeout (zero if unset). HULAK_TIMEOUT and
+// the default 60s still apply through resolveBaseTimeout.
+func ExecuteSingleFile(
+	envMap map[string]any,
+	debug bool,
+	filePath string,
+	flagTimeout time.Duration,
+) error {
+	baseTimeout, err := resolveBaseTimeout(flagTimeout)
+	if err != nil {
+		return err
+	}
+	return handleAPIRequests(envMap, debug, []string{filePath}, nil, filePath, baseTimeout)
+}
+
+// resolveFileTimeout returns the per-file timeout, preferring a valid YAML
+// `timeout:` field over base. A peek failure (file unreadable, decode error,
+// malformed timeout) returns base — processTask runs ParseConfig again and
+// surfaces the same error as a config error in the outcome.
+func resolveFileTimeout(path string, secretsMap map[string]any, base time.Duration) time.Duration {
+	cfg, err := yamlparser.ParseConfig(path, secretsMap)
+	if err != nil {
+		return base
+	}
+	d, err := cfg.ParsedTimeout()
+	if err != nil || d <= 0 {
+		return base
+	}
+	return d
+}
+
+// resolveBaseTimeout combines the --timeout flag and HULAK_TIMEOUT env var
+// into a single duration the runner uses when no per-file YAML override is
+// set. Precedence: flag > env > DefaultTimeout. A non-empty but invalid env
+// var returns an error so the user sees the typo instead of getting a silent
+// fallback.
+func resolveBaseTimeout(flagT time.Duration) (time.Duration, error) {
+	if flagT > 0 {
+		return flagT, nil
+	}
+	raw := os.Getenv(HulakTimeoutEnv)
+	if raw == "" {
+		return DefaultTimeout, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: %w", HulakTimeoutEnv, raw, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("%s must be positive, got %q", HulakTimeoutEnv, raw)
+	}
+	return d, nil
 }
 
 // containsTemplateVars returns true if any file in the list uses template vars.
@@ -166,12 +237,16 @@ type outcome struct {
 // handleAPIRequests processes API requests from pre-discovered file lists.
 // Returns nil if every dispatched request succeeded; otherwise an error
 // summarizing the failures so the call site can propagate a non-zero exit.
+//
+// baseTimeout is the resolved flag/env timeout (or DefaultTimeout). It is
+// the floor used for each request unless the file's YAML overrides it.
 func handleAPIRequests(
 	secrets map[string]any,
 	debug bool,
 	concurrentFiles []string,
 	sequentialFiles []string,
 	fp string,
+	baseTimeout time.Duration,
 ) error {
 	totalFiles := len(concurrentFiles) + len(sequentialFiles)
 	// Per-file outcome lines only help when multiple files are running — they
@@ -188,7 +263,9 @@ func handleAPIRequests(
 				fmt.Sprintf("Processing %d files concurrently...", len(concurrentFiles)),
 			)
 		}
-		outcomes = append(outcomes, runTasks(concurrentFiles, secrets, debug, fp, multiFile)...)
+		outcomes = append(
+			outcomes,
+			runTasks(concurrentFiles, secrets, debug, fp, multiFile, baseTimeout)...)
 	}
 	if len(sequentialFiles) > 0 {
 		utils.PrintInfoStderr(
@@ -369,16 +446,21 @@ var ansiInOutcome = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 // runTasks manages the go tasks with a limited worker pool. Returns one
 // outcome per file in the order they finished. multiFile gates whether the
 // per-file outcome line is printed (skipped for single-file runs).
+//
+// baseTimeout is the per-request timeout when a file has no YAML `timeout:`
+// override. The peek that resolves the YAML override happens inside the
+// worker so failures (unreadable file, malformed timeout) become outcomes
+// instead of crashing the dispatcher.
 func runTasks(
 	filePathList []string,
 	secretsMap map[string]any,
 	debug bool,
 	fp string,
 	multiFile bool,
+	baseTimeout time.Duration,
 ) []outcome {
 	maxWorkers := utils.GetWorkers(nil)
 	maxRetries := 3
-	timeout := 60 * time.Second
 
 	if fp != "" {
 		maxRetries = 1
@@ -400,6 +482,11 @@ func runTasks(
 
 			for path := range taskChan {
 				var final outcome
+
+				// Resolve per-file timeout once per task. YAML override wins;
+				// peek failures fall back to baseTimeout — processTask runs
+				// ParseConfig again and surfaces the real error in the outcome.
+				timeout := resolveFileTimeout(path, secretsMap, baseTimeout)
 
 				for attempt := 0; attempt < maxRetries; attempt++ {
 					if attempt > 0 {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -129,13 +129,20 @@ func ExecuteSingleFile(
 // `timeout:` field over base. A peek failure (file unreadable, decode error,
 // malformed timeout) returns base — processTask runs ParseConfig again and
 // surfaces the same error as a config error in the outcome.
+//
+// secretsMap is copied before being passed into ParseConfig because workers
+// share a single secretsMap and ParseConfig's template substitution path
+// reads through it; matching the CopyEnvMap discipline used by processTask
+// keeps the peek race-free without auditing every action's caching behavior.
 func resolveFileTimeout(path string, secretsMap map[string]any, base time.Duration) time.Duration {
-	cfg, err := yamlparser.ParseConfig(path, secretsMap)
+	cfg, err := yamlparser.ParseConfig(path, utils.CopyEnvMap(secretsMap))
 	if err != nil {
 		return base
 	}
-	d, err := cfg.ParsedTimeout()
-	if err != nil || d <= 0 {
+	// ParseConfig already validated Timeout via ParsedTimeout, so the parse
+	// here cannot fail — only an unset value (d == 0) reaches base.
+	d, _ := cfg.ParsedTimeout()
+	if d <= 0 {
 		return base
 	}
 	return d
@@ -273,7 +280,7 @@ func handleAPIRequests(
 		)
 		outcomes = append(
 			outcomes,
-			processFilesSequentially(sequentialFiles, secrets, debug, multiFile)...)
+			processFilesSequentially(sequentialFiles, secrets, debug, multiFile, baseTimeout)...)
 	}
 
 	if totalFiles == 0 {
@@ -597,16 +604,41 @@ func processTask(path string, secretsMap map[string]any, debug bool) outcome {
 // execution order. multiFile gates the per-file outcome line — single-file
 // mode keeps stderr quiet on success since the response body already prints
 // to stdout; failures always surface so a silent error isn't mistaken for OK.
+//
+// baseTimeout is the per-request timeout when a file has no YAML override.
+// Mirrors the runTasks pattern so `-dirseq` honors --timeout / HULAK_TIMEOUT
+// the same way concurrent runs do; sequential mode has no retry loop, so a
+// timeout becomes the final outcome for that file and the run continues.
 func processFilesSequentially(
 	filePaths []string,
 	secretsMap map[string]any,
 	debug bool,
 	multiFile bool,
+	baseTimeout time.Duration,
 ) []outcome {
 	outcomes := make([]outcome, 0, len(filePaths))
 	for _, path := range filePaths {
-		fileEnv := utils.CopyEnvMap(secretsMap)
-		o := processTask(path, fileEnv, debug)
+		timeout := resolveFileTimeout(path, secretsMap, baseTimeout)
+
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		resCh := make(chan outcome, 1)
+		go func() {
+			resCh <- processTask(path, utils.CopyEnvMap(secretsMap), debug)
+		}()
+
+		var o outcome
+		select {
+		case res := <-resCh:
+			o = res
+		case <-ctx.Done():
+			o = outcome{
+				path: path,
+				ok:   false,
+				err:  fmt.Errorf("timeout after %v", timeout),
+			}
+		}
+		cancel()
+
 		if multiFile || !o.ok {
 			printOutcome(o)
 		}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -125,29 +125,6 @@ func ExecuteSingleFile(
 	return handleAPIRequests(envMap, debug, []string{filePath}, nil, filePath, baseTimeout)
 }
 
-// resolveFileTimeout returns the per-file timeout, preferring a valid YAML
-// `timeout:` field over base. A peek failure (file unreadable, decode error,
-// malformed timeout) returns base — processTask runs ParseConfig again and
-// surfaces the same error as a config error in the outcome.
-//
-// secretsMap is copied before being passed into ParseConfig because workers
-// share a single secretsMap and ParseConfig's template substitution path
-// reads through it; matching the CopyEnvMap discipline used by processTask
-// keeps the peek race-free without auditing every action's caching behavior.
-func resolveFileTimeout(path string, secretsMap map[string]any, base time.Duration) time.Duration {
-	cfg, err := yamlparser.ParseConfig(path, utils.CopyEnvMap(secretsMap))
-	if err != nil {
-		return base
-	}
-	// ParseConfig already validated Timeout via ParsedTimeout, so the parse
-	// here cannot fail — only an unset value (d == 0) reaches base.
-	d, _ := cfg.ParsedTimeout()
-	if d <= 0 {
-		return base
-	}
-	return d
-}
-
 // resolveBaseTimeout combines the --timeout flag and HULAK_TIMEOUT env var
 // into a single duration the runner uses when no per-file YAML override is
 // set. Precedence: flag > env > DefaultTimeout. A non-empty but invalid env
@@ -455,9 +432,9 @@ var ansiInOutcome = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 // per-file outcome line is printed (skipped for single-file runs).
 //
 // baseTimeout is the per-request timeout when a file has no YAML `timeout:`
-// override. The peek that resolves the YAML override happens inside the
-// worker so failures (unreadable file, malformed timeout) become outcomes
-// instead of crashing the dispatcher.
+// override. processTask resolves the YAML override internally (single
+// ParseConfig call) and threads the resulting context into the HTTP client
+// for real cancellation — no leaked goroutines on timeout.
 func runTasks(
 	filePathList []string,
 	secretsMap map[string]any,
@@ -490,11 +467,6 @@ func runTasks(
 			for path := range taskChan {
 				var final outcome
 
-				// Resolve per-file timeout once per task. YAML override wins;
-				// peek failures fall back to baseTimeout — processTask runs
-				// ParseConfig again and surfaces the real error in the outcome.
-				timeout := resolveFileTimeout(path, secretsMap, baseTimeout)
-
 				for attempt := 0; attempt < maxRetries; attempt++ {
 					if attempt > 0 {
 						backoffDuration := time.Duration(1<<(attempt-1)) * time.Second
@@ -503,24 +475,7 @@ func runTasks(
 						time.Sleep(backoffDuration)
 					}
 
-					ctx, cancel := context.WithTimeout(context.Background(), timeout)
-
-					resCh := make(chan outcome, 1)
-					go func() {
-						resCh <- processTask(path, utils.CopyEnvMap(secretsMap), debug)
-					}()
-
-					select {
-					case res := <-resCh:
-						final = res
-					case <-ctx.Done():
-						final = outcome{
-							path: path,
-							ok:   false,
-							err:  fmt.Errorf("timeout after %v", timeout),
-						}
-					}
-					cancel()
+					final = processTask(path, utils.CopyEnvMap(secretsMap), debug, baseTimeout)
 
 					if final.ok || !isRetryable(final.err) {
 						break
@@ -570,19 +525,32 @@ func isRetryable(err error) bool {
 // processTask handles a single task and returns a structured outcome.
 // Wall-clock duration is measured around the dispatched call so it reflects
 // the actual API latency (plus YAML parse time, which is small).
-func processTask(path string, secretsMap map[string]any, debug bool) outcome {
+//
+// baseTimeout is the resolved flag/env timeout. The YAML `timeout:` field
+// on the parsed config wins over base. The context created here flows into
+// the HTTP client so the request is truly cancelled on deadline — no leaked
+// goroutines.
+func processTask(path string, secretsMap map[string]any, debug bool, baseTimeout time.Duration) outcome {
 	start := time.Now()
 	config, err := yamlparser.ParseConfig(path, secretsMap)
 	if err != nil {
 		return outcome{path: path, ok: false, duration: time.Since(start), err: &configError{err}}
 	}
 
+	// Resolve per-file timeout: YAML wins over base.
+	timeout := baseTimeout
+	if d, _ := config.ParsedTimeout(); d > 0 {
+		timeout = d
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	switch {
 	case config.IsAuth():
-		err := features.SendAPIRequestForAuth2(secretsMap, path, debug)
+		err := features.SendAPIRequestForAuth2(ctx, secretsMap, path, debug)
 		return outcome{path: path, ok: err == nil, duration: time.Since(start), err: err}
-	case (config.IsAPI() || config.IsGraphql()):
-		status, err := apicalls.SendAndSaveAPIRequest(secretsMap, path, debug)
+	case config.IsAPI() || config.IsGraphql():
+		status, err := apicalls.SendAndSaveAPIRequest(ctx, secretsMap, path, debug)
 		return outcome{
 			path:     path,
 			ok:       err == nil,
@@ -606,9 +574,8 @@ func processTask(path string, secretsMap map[string]any, debug bool) outcome {
 // to stdout; failures always surface so a silent error isn't mistaken for OK.
 //
 // baseTimeout is the per-request timeout when a file has no YAML override.
-// Mirrors the runTasks pattern so `-dirseq` honors --timeout / HULAK_TIMEOUT
-// the same way concurrent runs do; sequential mode has no retry loop, so a
-// timeout becomes the final outcome for that file and the run continues.
+// processTask resolves the YAML override internally and threads the context
+// into the HTTP client — same cancellation path as runTasks.
 func processFilesSequentially(
 	filePaths []string,
 	secretsMap map[string]any,
@@ -618,27 +585,7 @@ func processFilesSequentially(
 ) []outcome {
 	outcomes := make([]outcome, 0, len(filePaths))
 	for _, path := range filePaths {
-		timeout := resolveFileTimeout(path, secretsMap, baseTimeout)
-
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		resCh := make(chan outcome, 1)
-		go func() {
-			resCh <- processTask(path, utils.CopyEnvMap(secretsMap), debug)
-		}()
-
-		var o outcome
-		select {
-		case res := <-resCh:
-			o = res
-		case <-ctx.Done():
-			o = outcome{
-				path: path,
-				ok:   false,
-				err:  fmt.Errorf("timeout after %v", timeout),
-			}
-		}
-		cancel()
-
+		o := processTask(path, utils.CopyEnvMap(secretsMap), debug, baseTimeout)
 		if multiFile || !o.ok {
 			printOutcome(o)
 		}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -3,6 +3,8 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -510,6 +512,105 @@ func TestResolveFileTimeout(t *testing.T) {
 				t.Errorf("got %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestProcessFilesSequentially_TimeoutEnforced verifies the sequential path
+// honors baseTimeout: when the request takes longer than the timeout, the
+// loop returns a timeout outcome and moves on instead of hanging. Regression
+// guard for the gap that existed before #206 was bundled into this branch
+// (concurrent path enforced timeouts; sequential path was unbounded).
+func TestProcessFilesSequentially_TimeoutEnforced(t *testing.T) {
+	// Hold the handler open until the test releases it in cleanup. Using a
+	// channel instead of time.Sleep avoids slow-CI flakiness and lets
+	// httptest.Server.Close() return immediately once the test finishes.
+	block := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-block:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(block) })
+
+	yaml := fmt.Sprintf("method: GET\nurl: %q\n", server.URL)
+	path := filepath.Join(t.TempDir(), "slow.hk.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	timeout := 100 * time.Millisecond
+	start := time.Now()
+	outcomes := processFilesSequentially([]string{path}, nil, false, false, timeout)
+	elapsed := time.Since(start)
+
+	if len(outcomes) != 1 {
+		t.Fatalf("got %d outcomes, want 1", len(outcomes))
+	}
+	o := outcomes[0]
+	if o.ok {
+		t.Errorf("outcome.ok = true, want false (request should have timed out)")
+	}
+	if o.err == nil || !strings.Contains(o.err.Error(), "timeout") {
+		t.Errorf("err = %v, want one containing 'timeout'", o.err)
+	}
+	// The select race fires near the timeout. Cap the slack generously so
+	// slow CI doesn't false-positive but a regression that re-introduces an
+	// unbounded sequential mode would clearly exceed the bound.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("elapsed %v — timeout did not abandon the in-flight request", elapsed)
+	}
+}
+
+// TestProcessFilesSequentially_YAMLTimeoutWins is the end-to-end check that
+// a YAML `timeout:` value actually reaches context.WithTimeout — not just
+// resolveFileTimeout in isolation. With a generous base, a wiring slip that
+// dropped the per-file override would cause the request to block until the
+// test cleanup fires, blowing past the elapsed bound.
+func TestProcessFilesSequentially_YAMLTimeoutWins(t *testing.T) {
+	block := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-block:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(block) })
+
+	yaml := fmt.Sprintf("method: GET\nurl: %q\ntimeout: 100ms\n", server.URL)
+	path := filepath.Join(t.TempDir(), "yaml-timeout.hk.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generous base — if the YAML field were ignored or lost in the wiring,
+	// the request would block on the server until cleanup, and elapsed would
+	// approach this base instead of the YAML's 100ms.
+	base := 10 * time.Second
+	start := time.Now()
+	outcomes := processFilesSequentially([]string{path}, nil, false, false, base)
+	elapsed := time.Since(start)
+
+	if len(outcomes) != 1 {
+		t.Fatalf("got %d outcomes, want 1", len(outcomes))
+	}
+	o := outcomes[0]
+	if o.ok {
+		t.Errorf("outcome.ok = true, want false")
+	}
+	if o.err == nil || !strings.Contains(o.err.Error(), "timeout") {
+		t.Errorf("err = %v, want one containing 'timeout'", o.err)
+	}
+	if !strings.Contains(o.err.Error(), "100ms") {
+		// The error message embeds the resolved timeout; confirming the YAML
+		// value reached the select arm rules out "base happened to be small
+		// enough" false positives if someone later tweaks the test.
+		t.Errorf("err = %v, want one mentioning the YAML-resolved 100ms", o.err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("elapsed %v — YAML timeout did not override base %v", elapsed, base)
 	}
 }
 

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -473,57 +473,16 @@ func TestResolveBaseTimeout(t *testing.T) {
 	}
 }
 
-// TestResolveFileTimeout verifies the YAML peek picks up valid `timeout:`
-// values, and falls back to the base for missing/invalid/unreadable files.
-func TestResolveFileTimeout(t *testing.T) {
-	dir := t.TempDir()
-
-	good := filepath.Join(dir, "good.hk.yaml")
-	if err := os.WriteFile(good, []byte("kind: API\ntimeout: 250ms\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	noTimeout := filepath.Join(dir, "none.hk.yaml")
-	if err := os.WriteFile(noTimeout, []byte("kind: API\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	// ParseConfig validates timeout, so a bad value makes the peek error out
-	// and resolveFileTimeout falls back to base — the real error surfaces
-	// later from processTask.
-	bad := filepath.Join(dir, "bad.hk.yaml")
-	if err := os.WriteFile(bad, []byte("kind: API\ntimeout: 60\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	base := 7 * time.Second
-	tests := []struct {
-		name string
-		path string
-		want time.Duration
-	}{
-		{"YAML timeout wins", good, 250 * time.Millisecond},
-		{"missing timeout falls back", noTimeout, base},
-		{"invalid timeout falls back", bad, base},
-		{"unreadable file falls back", filepath.Join(dir, "missing.yaml"), base},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := resolveFileTimeout(tc.path, nil, base)
-			if got != tc.want {
-				t.Errorf("got %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
-
 // TestProcessFilesSequentially_TimeoutEnforced verifies the sequential path
 // honors baseTimeout: when the request takes longer than the timeout, the
-// loop returns a timeout outcome and moves on instead of hanging. Regression
-// guard for the gap that existed before #206 was bundled into this branch
-// (concurrent path enforced timeouts; sequential path was unbounded).
+// context deadline cancels the HTTP request and the outcome surfaces the
+// error. Regression guard for the gap that existed before #206 was bundled
+// into this branch (concurrent path enforced timeouts; sequential path was
+// unbounded).
 func TestProcessFilesSequentially_TimeoutEnforced(t *testing.T) {
-	// Hold the handler open until the test releases it in cleanup. Using a
-	// channel instead of time.Sleep avoids slow-CI flakiness and lets
-	// httptest.Server.Close() return immediately once the test finishes.
+	// Hold the handler open until the request's context cancels or the test
+	// releases it. Using a channel instead of time.Sleep avoids slow-CI
+	// flakiness and lets httptest.Server.Close() return immediately.
 	block := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		select {
@@ -552,22 +511,22 @@ func TestProcessFilesSequentially_TimeoutEnforced(t *testing.T) {
 	if o.ok {
 		t.Errorf("outcome.ok = true, want false (request should have timed out)")
 	}
-	if o.err == nil || !strings.Contains(o.err.Error(), "timeout") {
-		t.Errorf("err = %v, want one containing 'timeout'", o.err)
+	if o.err == nil || !strings.Contains(o.err.Error(), "context deadline exceeded") {
+		t.Errorf("err = %v, want one containing 'context deadline exceeded'", o.err)
 	}
-	// The select race fires near the timeout. Cap the slack generously so
-	// slow CI doesn't false-positive but a regression that re-introduces an
-	// unbounded sequential mode would clearly exceed the bound.
+	// Cap the slack generously so slow CI doesn't false-positive but a
+	// regression that re-introduces an unbounded sequential mode would
+	// clearly exceed the bound.
 	if elapsed > 500*time.Millisecond {
-		t.Errorf("elapsed %v — timeout did not abandon the in-flight request", elapsed)
+		t.Errorf("elapsed %v — timeout did not cancel the in-flight request", elapsed)
 	}
 }
 
 // TestProcessFilesSequentially_YAMLTimeoutWins is the end-to-end check that
-// a YAML `timeout:` value actually reaches context.WithTimeout — not just
-// resolveFileTimeout in isolation. With a generous base, a wiring slip that
-// dropped the per-file override would cause the request to block until the
-// test cleanup fires, blowing past the elapsed bound.
+// a YAML `timeout:` value actually reaches context.WithTimeout inside
+// processTask. With a generous base (10s), a wiring slip that dropped the
+// per-file override would cause the request to block until the test cleanup
+// fires, blowing past the elapsed bound.
 func TestProcessFilesSequentially_YAMLTimeoutWins(t *testing.T) {
 	block := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
@@ -600,15 +559,11 @@ func TestProcessFilesSequentially_YAMLTimeoutWins(t *testing.T) {
 	if o.ok {
 		t.Errorf("outcome.ok = true, want false")
 	}
-	if o.err == nil || !strings.Contains(o.err.Error(), "timeout") {
-		t.Errorf("err = %v, want one containing 'timeout'", o.err)
+	if o.err == nil || !strings.Contains(o.err.Error(), "context deadline exceeded") {
+		t.Errorf("err = %v, want one containing 'context deadline exceeded'", o.err)
 	}
-	if !strings.Contains(o.err.Error(), "100ms") {
-		// The error message embeds the resolved timeout; confirming the YAML
-		// value reached the select arm rules out "base happened to be small
-		// enough" false positives if someone later tweaks the test.
-		t.Errorf("err = %v, want one mentioning the YAML-resolved 100ms", o.err)
-	}
+	// The elapsed time is the real proof that YAML override worked: ~100ms
+	// not ~10s. If YAML timeout were ignored, elapsed would approach base.
 	if elapsed > 500*time.Millisecond {
 		t.Errorf("elapsed %v — YAML timeout did not override base %v", elapsed, base)
 	}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -569,6 +569,72 @@ func TestProcessFilesSequentially_YAMLTimeoutWins(t *testing.T) {
 	}
 }
 
+// TestRunTasks_TimeoutEnforced verifies the concurrent path cancels the HTTP
+// request when baseTimeout expires.
+func TestRunTasks_TimeoutEnforced(t *testing.T) {
+	block := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-block:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(block) })
+
+	path := filepath.Join(t.TempDir(), "slow.hk.yaml")
+	if err := os.WriteFile(path, []byte(fmt.Sprintf("method: GET\nurl: %q\n", server.URL)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	outcomes := runTasks([]string{path}, nil, false, path, false, 100*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if len(outcomes) != 1 {
+		t.Fatalf("got %d outcomes, want 1", len(outcomes))
+	}
+	if outcomes[0].ok {
+		t.Error("outcome.ok = true, want false")
+	}
+	if outcomes[0].err == nil || !strings.Contains(outcomes[0].err.Error(), "context deadline exceeded") {
+		t.Errorf("err = %v, want context deadline exceeded", outcomes[0].err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("elapsed %v — timeout did not cancel the request", elapsed)
+	}
+}
+
+// TestProcessTask_YAMLTimeoutOverridesBase verifies processTask picks the
+// YAML timeout over baseTimeout.
+func TestProcessTask_YAMLTimeoutOverridesBase(t *testing.T) {
+	block := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-block:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(block) })
+
+	path := filepath.Join(t.TempDir(), "fast-yaml.hk.yaml")
+	if err := os.WriteFile(path, []byte(fmt.Sprintf("method: GET\nurl: %q\ntimeout: 100ms\n", server.URL)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	o := processTask(path, nil, false, 10*time.Second)
+	elapsed := time.Since(start)
+
+	if o.ok {
+		t.Error("outcome.ok = true, want false")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("elapsed %v — YAML 100ms timeout did not override 10s base", elapsed)
+	}
+}
+
 func TestIsRetryable(t *testing.T) {
 	cfgErr := &configError{errors.New("missing key")}
 	tests := []struct {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -421,6 +422,92 @@ func TestIsRunFailure(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := IsRunFailure(tc.err); got != tc.want {
 				t.Errorf("IsRunFailure(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveBaseTimeout covers the flag → env → default precedence and
+// rejects malformed env values up front (#206).
+func TestResolveBaseTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		flag     time.Duration
+		env      string // unset if empty
+		want     time.Duration
+		wantErr  bool
+		errMatch string
+	}{
+		{"all unset → default", 0, "", DefaultTimeout, false, ""},
+		{"env only", 0, "5m", 5 * time.Minute, false, ""},
+		{"flag only", 2 * time.Minute, "", 2 * time.Minute, false, ""},
+		{"flag wins over env", 2 * time.Minute, "5m", 2 * time.Minute, false, ""},
+		{"invalid env duration", 0, "not-a-duration", 0, true, "invalid HULAK_TIMEOUT"},
+		{"non-positive env duration", 0, "0s", 0, true, "must be positive"},
+		{"negative env duration", 0, "-1s", 0, true, "must be positive"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.env == "" {
+				t.Setenv(HulakTimeoutEnv, "")
+				_ = os.Unsetenv(HulakTimeoutEnv)
+			} else {
+				t.Setenv(HulakTimeoutEnv, tc.env)
+			}
+			got, err := resolveBaseTimeout(tc.flag)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("error = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				if !strings.Contains(err.Error(), tc.errMatch) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errMatch)
+				}
+				return
+			}
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveFileTimeout verifies the YAML peek picks up valid `timeout:`
+// values, and falls back to the base for missing/invalid/unreadable files.
+func TestResolveFileTimeout(t *testing.T) {
+	dir := t.TempDir()
+
+	good := filepath.Join(dir, "good.hk.yaml")
+	if err := os.WriteFile(good, []byte("kind: API\ntimeout: 250ms\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	noTimeout := filepath.Join(dir, "none.hk.yaml")
+	if err := os.WriteFile(noTimeout, []byte("kind: API\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// ParseConfig validates timeout, so a bad value makes the peek error out
+	// and resolveFileTimeout falls back to base — the real error surfaces
+	// later from processTask.
+	bad := filepath.Join(dir, "bad.hk.yaml")
+	if err := os.WriteFile(bad, []byte("kind: API\ntimeout: 60\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	base := 7 * time.Second
+	tests := []struct {
+		name string
+		path string
+		want time.Duration
+	}{
+		{"YAML timeout wins", good, 250 * time.Millisecond},
+		{"missing timeout falls back", noTimeout, base},
+		{"invalid timeout falls back", bad, base},
+		{"unreadable file falls back", filepath.Join(dir, "missing.yaml"), base},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveFileTimeout(tc.path, nil, base)
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/pkg/tui/gqlexplorer/model.go
+++ b/pkg/tui/gqlexplorer/model.go
@@ -1,6 +1,7 @@
 package gqlexplorer
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -1032,7 +1033,7 @@ func (m *Model) executeQuery() tea.Cmd {
 	m.updateActionRow()
 
 	apiCall := func() tea.Msg {
-		resp, err := apicalls.StandardCall(apiInfo, false)
+		resp, err := apicalls.StandardCall(context.Background(), apiInfo, false)
 		if err != nil {
 			return queryErrorMsg{err: err}
 		}

--- a/pkg/userFlags/cli_contract_test.go
+++ b/pkg/userFlags/cli_contract_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/xaaha/hulak/pkg/utils"
 )
@@ -169,7 +170,7 @@ func TestParseRunArgsSetsFilePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f, err := parseRunArgs("", false, false, []string{tmpFile})
+	f, err := parseRunArgs("", false, false, 0, []string{tmpFile})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -186,7 +187,7 @@ func TestParseRunArgsSetsFilePath(t *testing.T) {
 func TestParseRunArgsSetsDir(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	f, err := parseRunArgs("", false, false, []string{tmpDir})
+	f, err := parseRunArgs("", false, false, 0, []string{tmpDir})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -211,7 +212,7 @@ func TestParseRunArgsRoutesFlags(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f, err := parseRunArgs("staging", false, true, []string{tmpFile})
+	f, err := parseRunArgs("staging", false, true, 0, []string{tmpFile})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -232,7 +233,7 @@ func TestParseRunArgsRoutesFlags(t *testing.T) {
 func TestParseRunArgsSequentialDir(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	f, err := parseRunArgs("", true, false, []string{tmpDir})
+	f, err := parseRunArgs("", true, false, 0, []string{tmpDir})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -245,9 +246,28 @@ func TestParseRunArgsSequentialDir(t *testing.T) {
 	}
 }
 
+// TestParseRunArgsTimeoutPlumbed verifies the --timeout flag value lands on
+// runner.Flags so the runner can resolve it. Precedence/fallback is asserted
+// in runner.TestResolveBaseTimeout.
+func TestParseRunArgsTimeoutPlumbed(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test.hk.yaml")
+	if err := os.WriteFile(tmpFile, []byte("kind: API"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	want := 5 * time.Minute
+	f, err := parseRunArgs("", false, false, want, []string{tmpFile})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Timeout != want {
+		t.Errorf("Timeout = %v, want %v", f.Timeout, want)
+	}
+}
+
 // TestParseRunArgsBadPath verifies that a nonexistent path returns an error.
 func TestParseRunArgsBadPath(t *testing.T) {
-	_, err := parseRunArgs("", false, false, []string{"/nonexistent/path.yaml"})
+	_, err := parseRunArgs("", false, false, 0, []string{"/nonexistent/path.yaml"})
 	if err == nil {
 		t.Fatal("expected an error for nonexistent path")
 	}
@@ -261,7 +281,7 @@ func TestParseRunArgsDefaultEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f, err := parseRunArgs("", false, false, []string{tmpFile})
+	f, err := parseRunArgs("", false, false, 0, []string{tmpFile})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/userFlags/flags.go
+++ b/pkg/userFlags/flags.go
@@ -3,6 +3,7 @@ package userflags
 
 import (
 	"flag"
+	"time"
 
 	"github.com/xaaha/hulak/pkg/utils"
 )
@@ -24,8 +25,9 @@ var (
 	//   dir_0/dir_0/dir_1/is.md
 	//
 	// In the above case, the files in the shallowest directories will be processed before deeper ones.
-	flagDirseq string
-	flagDebug  bool
+	flagDirseq  string
+	flagDebug   bool
+	flagTimeout time.Duration
 
 	flagVersion bool
 	flagHelp    bool
@@ -52,6 +54,13 @@ func init() {
 	flag.StringVar(&flagDir, "dir", "", "Directory path to run concurrently")
 
 	flag.StringVar(&flagDirseq, "dirseq", "", "Directory path to run in alphabetical order")
+
+	flag.DurationVar(
+		&flagTimeout,
+		"timeout",
+		0,
+		"Per-request timeout, e.g. 5m or 90s (overrides $HULAK_TIMEOUT; default 60s)",
+	)
 
 	flag.BoolVar(&flagVersion, "v", false, "Print the version")
 	flag.BoolVar(&flagVersion, "version", false, "Print the version")

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/xaaha/hulak/pkg/envparser"
 	"github.com/xaaha/hulak/pkg/migration"
@@ -298,9 +299,16 @@ func newRunCmd() *command {
 	envFlagVal := registerEnvFlag(fs, "", "Environment to use")
 	var sequential bool
 	var debug bool
+	var timeout time.Duration
 	fs.BoolVar(&sequential, "sequential", false, "Run directory files sequentially")
 	fs.BoolVar(&sequential, "seq", false, "Run directory files sequentially")
 	fs.BoolVar(&debug, "debug", false, "Enable debug mode")
+	fs.DurationVar(
+		&timeout,
+		"timeout",
+		0,
+		"Per-request timeout, e.g. 5m or 90s (overrides $HULAK_TIMEOUT; default 60s)",
+	)
 
 	runCmd := &command{
 		Name:  "run",
@@ -335,7 +343,7 @@ func newRunCmd() *command {
 			return nil
 		}
 
-		f, err := parseRunArgs(*envFlagVal, sequential, debug, args)
+		f, err := parseRunArgs(*envFlagVal, sequential, debug, timeout, args)
 		if err != nil {
 			return err
 		}
@@ -351,7 +359,12 @@ func newRunCmd() *command {
 
 // parseRunArgs builds a runner.Flags from the path and parsed flag values.
 // The path routes to FilePath (file), Dir (concurrent), or Dirseq (sequential).
-func parseRunArgs(envFlagVal string, sequential, debug bool, args []string) (*runner.Flags, error) {
+func parseRunArgs(
+	envFlagVal string,
+	sequential, debug bool,
+	timeout time.Duration,
+	args []string,
+) (*runner.Flags, error) {
 	path := args[0]
 
 	info, err := os.Stat(path)
@@ -359,7 +372,7 @@ func parseRunArgs(envFlagVal string, sequential, debug bool, args []string) (*ru
 		return nil, fmt.Errorf("cannot access %q: %w", path, err)
 	}
 
-	f := &runner.Flags{Debug: debug}
+	f := &runner.Flags{Debug: debug, Timeout: timeout}
 
 	if envFlagVal != "" {
 		f.Env = envFlagVal

--- a/pkg/userFlags/userflags.go
+++ b/pkg/userFlags/userflags.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/xaaha/hulak/pkg/runner"
 )
@@ -20,6 +21,7 @@ type AllFlags struct {
 	Debug    bool
 	Dir      string
 	Dirseq   string
+	Timeout  time.Duration
 }
 
 // ParseFlagsSubcmds dispatches subcommands and root flags.
@@ -71,6 +73,7 @@ func ParseFlagsSubcmds() (*AllFlags, error) {
 					Debug:    flagDebug,
 					Dir:      flagDir,
 					Dirseq:   flagDirseq,
+					Timeout:  flagTimeout,
 				})
 				if err != nil {
 					return nil, err
@@ -92,8 +95,9 @@ func ParseFlagsSubcmds() (*AllFlags, error) {
 	})
 
 	return &AllFlags{
-		Env:    flagEnv,
-		EnvSet: envSet,
-		Debug:  flagDebug,
+		Env:     flagEnv,
+		EnvSet:  envSet,
+		Debug:   flagDebug,
+		Timeout: flagTimeout,
 	}, nil
 }

--- a/pkg/yamlparser/kind.go
+++ b/pkg/yamlparser/kind.go
@@ -4,6 +4,7 @@ package yamlparser
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	yaml "github.com/goccy/go-yaml"
 )
@@ -43,7 +44,29 @@ var registry = newKindRegistry()
 
 // ConfigType is the root YAML configuration structure.
 type ConfigType struct {
-	Kind Kind `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Kind Kind `json:"kind,omitempty"    yaml:"kind,omitempty"`
+	// Timeout is the optional per-request timeout, e.g. "5m", "90s", "2m30s".
+	// Parsed via time.ParseDuration; see ParsedTimeout for resolution. Empty
+	// string falls through to the runner's flag/env/default chain.
+	Timeout string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+}
+
+// ParsedTimeout returns the configured per-request timeout, or 0 if unset.
+// Returns an error when Timeout is set but not a valid positive Go duration —
+// callers should surface this as a config error so the user fixes the YAML
+// instead of silently falling back to the default.
+func (c *ConfigType) ParsedTimeout() (time.Duration, error) {
+	if c == nil || c.Timeout == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(c.Timeout)
+	if err != nil {
+		return 0, fmt.Errorf("invalid timeout %q: %w", c.Timeout, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("timeout must be positive, got %q", c.Timeout)
+	}
+	return d, nil
 }
 
 // normalize resolves case insensitivity and defaulting.
@@ -96,6 +119,13 @@ func ParseConfig(filePath string, secretsMap map[string]any) (*ConfigType, error
 	}
 
 	cfg.Kind = cfg.Kind.normalize()
+
+	// Validate the timeout eagerly so a malformed value (e.g. `timeout: 60`
+	// with no unit) fails the file with a clear config error instead of
+	// silently falling back to the default.
+	if _, err := cfg.ParsedTimeout(); err != nil {
+		return nil, fmt.Errorf("in %s: %w", filePath, err)
+	}
 
 	return &cfg, nil
 }

--- a/pkg/yamlparser/kind_test.go
+++ b/pkg/yamlparser/kind_test.go
@@ -4,7 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 )
 
 // createTempYAMLFile is the helper function
@@ -99,22 +101,30 @@ func TestParseConfig(t *testing.T) {
 		// API kinds
 		{"API lowercase", `kind: api`, true, ConfigType{Kind: KindAPI}},
 		{"API uppercase", `kind: API`, true, ConfigType{Kind: KindAPI}},
-		{"API mixed", `kind: ApI`, true, ConfigType{KindAPI}},
+		{"API mixed", `kind: ApI`, true, ConfigType{Kind: KindAPI}},
 
 		// Auth kinds
-		{"Auth lowercase", `kind: auth`, true, ConfigType{KindAuth}},
-		{"Auth uppercase", `kind: AUTH`, true, ConfigType{KindAuth}},
-		{"Auth mixed", `kind: AuTh`, true, ConfigType{KindAuth}},
+		{"Auth lowercase", `kind: auth`, true, ConfigType{Kind: KindAuth}},
+		{"Auth uppercase", `kind: AUTH`, true, ConfigType{Kind: KindAuth}},
+		{"Auth mixed", `kind: AuTh`, true, ConfigType{Kind: KindAuth}},
 
 		// GraphQL kinds
-		{"GraphQL", `kind: GraphQL`, true, ConfigType{KindGraphQL}},
-		{"graphql lower", `kind: graphql`, true, ConfigType{KindGraphQL}},
+		{"GraphQL", `kind: GraphQL`, true, ConfigType{Kind: KindGraphQL}},
+		{"graphql lower", `kind: graphql`, true, ConfigType{Kind: KindGraphQL}},
 
 		// Missing kind (defaults to API)
 		{"missing kind defaults to API", `method: POST`, true, ConfigType{Kind: KindAPI}},
 
 		// Invalid kinds
 		{"invalid kind", `kind: invalid`, true, ConfigType{Kind: "invalid"}},
+
+		// Timeout pass-through (validation tested in TestParsedTimeout).
+		{
+			"timeout passes through",
+			"kind: API\ntimeout: 5m",
+			true,
+			ConfigType{Kind: KindAPI, Timeout: "5m"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -134,6 +144,65 @@ func TestParseConfig(t *testing.T) {
 
 			if !reflect.DeepEqual(*got, tt.want) {
 				t.Errorf("ParseConfig() = %#v, want %#v", *got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseConfig_InvalidTimeout asserts that a bad `timeout:` value fails
+// the file with a clear, file-scoped error rather than silently falling back.
+func TestParseConfig_InvalidTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		errMatch string
+	}{
+		{"missing unit", "kind: API\ntimeout: 60", "invalid timeout"},
+		{"garbage", "kind: API\ntimeout: not-a-duration", "invalid timeout"},
+		{"zero", "kind: API\ntimeout: 0s", "must be positive"},
+		{"negative", "kind: API\ntimeout: -5m", "must be positive"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := createTempYAMLFile(t, tc.yaml)
+			_, err := ParseConfig(path, nil)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.errMatch) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.errMatch)
+			}
+		})
+	}
+}
+
+// TestParsedTimeout covers the value-level parsing rules: unset returns 0,
+// valid durations parse, malformed/non-positive errors clearly.
+func TestParsedTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"empty unset", "", 0, false},
+		{"5m", "5m", 5 * time.Minute, false},
+		{"90s", "90s", 90 * time.Second, false},
+		{"2m30s", "2m30s", 2*time.Minute + 30*time.Second, false},
+		{"missing unit", "60", 0, true},
+		{"garbage", "soon", 0, true},
+		{"zero", "0s", 0, true},
+		{"negative", "-1s", 0, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &ConfigType{Timeout: tc.value}
+			got, err := c.ParsedTimeout()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v, wantErr=%v", err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Replaces the hard-coded 60s request timeout with a four-layer override chain.

Closes #206.

## Completed

- [x] YAML `timeout:` field on `ConfigType` (validated eagerly in `ParseConfig`)
- [x] `--timeout <duration>` CLI flag on `hulak run` and root flags
- [x] `HULAK_TIMEOUT` env var (fail-fast on bad value)
- [x] 60s default unchanged when no override
- [x] Precedence: YAML > flag > env > default
- [x] Timeout enforced in **both** concurrent (`runTasks`) and sequential (`processFilesSequentially`) modes
- [x] `assets/schema.json` updated
- [x] `docs/body.md` and `docs/cli.md` updated

## Tests

- [x] `TestResolveBaseTimeout` — flag/env/default precedence + invalid env
- [x] `TestResolveFileTimeout` — YAML peek + fallback for unset/invalid/missing files
- [x] `TestParsedTimeout` — value-level parse rules
- [x] `TestParseConfig_InvalidTimeout` — eager validation surfaces with file path
- [x] `TestParseRunArgsTimeoutPlumbed` — flag lands on `runner.Flags`
- [x] `TestProcessFilesSequentially_TimeoutEnforced` — sequential mode honors `baseTimeout`
- [x] `TestProcessFilesSequentially_YAMLTimeoutWins` — end-to-end: YAML override reaches `context.WithTimeout`

## Test plan

- [ ] `go test ./...` passes
- [ ] `golangci-lint run ./...` clean
- [ ] Manual: `hulak run slow.hk.yaml` with `timeout: 5s` against a slow endpoint times out at ~5s
- [ ] Manual: `HULAK_TIMEOUT=5m hulak run x.hk.yaml` honors the env var
- [ ] Manual: `hulak run x.hk.yaml --timeout 30s` overrides env
- [ ] Manual: invalid `HULAK_TIMEOUT=foo` aborts before any request