### PR TITLE
feat: SSH ed25519 keys as identities and recipients (#170)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -87,6 +87,7 @@ hulak run path/to/file.yaml
 hulak run path/to/file.yaml --env staging
 hulak run path/to/dir/
 hulak run path/to/dir/ --sequential
+hulak run path/to/file.yaml --ssh-identity ~/.ssh/work_ed25519
 ```
 
 Supported flags:
@@ -97,6 +98,7 @@ Supported flags:
 | `--env`, `--environment` | Environment to use |
 | `--q`, `--quiet` | Suppress the end-of-run summary table |
 | `--seq`, `--sequential` | Run directory files sequentially |
+| `--ssh-identity` | Path to SSH private key for vault decryption |
 | `--timeout` | Per-request timeout, e.g. 5m or 90s (default 60s) |
 
 Notes:

--- a/docs/store.md
+++ b/docs/store.md
@@ -48,13 +48,17 @@ Hulak uses [age](https://age-encryption.org/) — a modern, file-based encryptio
 age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
 
 # Bob (added 2026-03-20)
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBobsPublicKeyHere
+
+# Carol (added 2026-04-01)
 age1yr5tpz76yxqeg5ktrp7g2wgkxfmq9rmef0gxhvsky2pyv6lsf8msgmd00n
 ```
 
-- **One age public key per line.**
+- **One public key per line** — both `age1...` and `ssh-ed25519` formats are supported.
 - **`#` comments are supported.** Use them to label keys (name, date added, role).
 - **Blank lines are ignored.**
-- Same format as the `-R` flag in the `age` CLI — tooling-compatible.
+- `ssh-rsa` keys are accepted with `--allow-rsa` but ed25519 is recommended.
+- `ecdsa` keys are not supported (age limitation).
 
 > [!Tip]
 > Add a comment above each key with the person's name and the date you added them. Future-you will thank present-you when someone asks "wait, who is `age1ql3z...`?".
@@ -94,6 +98,27 @@ hulak secrets migrate
 
 The legacy `env/` directory is left in place. Vault takes priority while both exist. Delete `env/` once you're confident.
 
+## Identity
+
+Hulak needs a private key to decrypt `store.age`. It checks these locations in order:
+
+| Priority | Source | When to use |
+|----------|--------|-------------|
+| 1 | `HULAK_MASTER_KEY` env var | CI/CD pipelines |
+| 2 | `~/.config/hulak/identity.txt` | Default — dedicated age keypair |
+| 3 | `HULAK_SSH_IDENTITY` env var | Point at a specific SSH key |
+| 4 | `~/.ssh/id_ed25519` | Auto-detected if no age identity exists |
+
+If you use SSH for git, hulak can reuse your existing SSH key — no separate keypair needed. Just make sure your SSH public key is added as a recipient (via `--github` or directly).
+
+```bash
+# Use a specific SSH key for this run
+hulak run requests/get-user.yaml --ssh-identity ~/.ssh/work_ed25519
+
+# Or set it for the session
+export HULAK_SSH_IDENTITY=~/.ssh/work_ed25519
+```
+
 ## Identity backup
 
 The single biggest pitfall is losing your private key. Two ways to protect against it:
@@ -121,16 +146,41 @@ hulak secrets import-key ~/Downloads/identity-backup.txt
 
 A single `store.age` can be encrypted to many recipients. Each teammate has their own private key; any of them can decrypt the shared file.
 
-### Joining a team
+### Joining a team (with GitHub — recommended)
+
+If the new member uses SSH for git, they already have keys published on GitHub. No key exchange needed:
+
+```bash
+# === Existing team member ===
+hulak secrets add-recipient --github alice --name Alice
+# ✓ Fetched 2 ssh-ed25519 keys from https://github.com/alice.keys
+# ✓ Added 2 recipients
+
+git add .hulak/recipients.txt .hulak/store.age
+git commit -m "add Alice as recipient"
+git push
+
+# === New member (Alice) ===
+git pull
+hulak secrets get API_KEY --env prod
+# Just works — her ~/.ssh/id_ed25519 matches one of the recipients
+```
+
+This also works with self-hosted GitLab, Forgejo, or any server that publishes keys at `/<username>.keys`:
+
+```bash
+hulak secrets add-recipient --github alice --keyserver https://gitlab.company.com --name Alice
+```
+
+### Joining a team (with age keys)
+
+If the new member prefers a dedicated age keypair:
 
 ```bash
 # === New member's machine ===
 hulak init
 # Shows their public key in the output:
 #   Public key: age1bob...
-
-hulak secrets list-recipients
-# Shows their own key
 ```
 
 The new member sends their **public key** (`age1bob...`) to an existing team member via Slack, email, or a PR. **Public keys are not secret.** Never share the private key from `~/.config/hulak/identity.txt`.
@@ -138,7 +188,7 @@ The new member sends their **public key** (`age1bob...`) to an existing team mem
 ```bash
 # === Existing team member ===
 hulak secrets add-recipient age1bob... --name Bob
-# ✓ Added recipient age1bob...
+# ✓ Added 1 recipient
 
 git add .hulak/recipients.txt .hulak/store.age
 git commit -m "add Bob as recipient"
@@ -305,5 +355,5 @@ Yes, during migration. Vault takes priority. After verifying everything works, d
 **How big can a single value be?**
 Functionally, anything. Practically, hulak warns at 64 KB and recommends `{{getFile "path"}}` for large blobs (certs, JSON fixtures) — those are read from disk on demand instead of decrypted on every invocation.
 
-**Does this work with hardware security keys / SSH keys?**
-Not yet. age supports SSH ed25519 keys natively, which would let `~/.ssh/id_ed25519` double as a hulak identity. Tracked in [#170](https://github.com/xaaha/hulak/issues/170).
+**Does this work with SSH keys?**
+Yes. Both `ssh-ed25519` public keys (as recipients) and `~/.ssh/id_ed25519` private keys (as identities) are supported. See [Identity](#identity) and [Team sharing](#team-sharing) above. Use `--github <username>` to add teammates directly from their GitHub SSH keys.

--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,14 @@ require (
 	github.com/lrstanley/bubblezone v1.0.0
 	github.com/muesli/termenv v0.16.0
 	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.246
+	golang.org/x/crypto v0.45.0
 	golang.org/x/net v0.47.0
 	golang.org/x/sys v0.38.0
 	golang.org/x/term v0.37.0
 )
 
 require (
+	filippo.io/edwards25519 v1.1.0 // indirect
 	filippo.io/hpke v0.4.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymanbagabas/go-udiff v0.3.1 // indirect
@@ -40,7 +42,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd h1:ZLsPO6WdZ5zatV4UfVpr7oAw
 c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd/go.mod h1:SrHC2C7r5GkDk8R+NFVzYy/sdj0Ypg9htaPXQq5Cqeo=
 filippo.io/age v1.3.1 h1:hbzdQOJkuaMEpRCLSN1/C5DX74RPcNCk6oqhKMXmZi0=
 filippo.io/age v1.3.1/go.mod h1:EZorDTYUxt836i3zdori5IJX/v2Lj6kWFU0cfh6C0D4=
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 filippo.io/hpke v0.4.0 h1:p575VVQ6ted4pL+it6M00V/f2qTZITO0zgmdKCkd5+A=
 filippo.io/hpke v0.4.0/go.mod h1:EmAN849/P3qdeK+PCMkDpDm83vRHM5cDipBJ8xbQLVY=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/man/hulak.1
+++ b/man/hulak.1
@@ -6,7 +6,7 @@ hulak \- file-based API client for the terminal
 .SH SYNOPSIS
 .B hulak
 .br
-.B hulak run [\-\-debug] [\-\-env] [\-\-q] [\-\-seq] [\-\-timeout] <path>
+.B hulak run [\-\-debug] [\-\-env] [\-\-q] [\-\-seq] [\-\-ssh-identity] [\-\-timeout] <path>
 .br
 .B hulak version
 .br
@@ -89,6 +89,9 @@ Suppress the end\-of\-run summary table
 .B \-\-seq, \-\-sequential
 Run directory files sequentially
 .TP
+.B \-\-ssh-identity <string>
+Path to SSH private key for vault decryption
+.TP
 .B \-\-timeout <duration>
 Per\-request timeout, e\&.g\&. 5m or 90s (default 60s)
 
@@ -161,6 +164,9 @@ hulak run path/to/dir/
 .RE
 .RS
 hulak run path/to/dir/ \-\-sequential
+.RE
+.RS
+hulak run path/to/file\&.yaml \-\-ssh\-identity ~/\&.ssh/work_ed25519
 .RE
 .PP
 version:

--- a/mise.toml
+++ b/mise.toml
@@ -83,6 +83,10 @@ go test ./pkg/... -timeout 30s
 echo "All checks passed!"      
 """
 
+[tasks.gendocs]
+description = "Regenerate docs/cli.md and man/hulak.1 from command tree"
+run = "go run . gendocs"
+
 [tasks.bench]
 description = "Run benchmarks"
 run = "go test -bench=. -benchmem ./... 2>&1 | grep '^Benchmark' | head -10"

--- a/pkg/apiCalls/apicalls.go
+++ b/pkg/apiCalls/apicalls.go
@@ -10,17 +10,14 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/xaaha/hulak/pkg/httpclient"
 	"github.com/xaaha/hulak/pkg/utils"
 	"github.com/xaaha/hulak/pkg/yamlparser"
 )
 
-// HTTPClient interface allows mocking HTTP calls in tests
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
-// DefaultClient is the production HTTP client
-var DefaultClient HTTPClient = &http.Client{}
+// DefaultClient is the production HTTP client.
+// Uses httpclient.New() for shared redirect policy and TLS defaults.
+var DefaultClient httpclient.HTTPClient = httpclient.New()
 
 // StandardCall calls the api and returns the json body string
 // Uses the DefaultClient for HTTP calls
@@ -34,7 +31,7 @@ func StandardCallWithClient(
 	ctx context.Context,
 	apiInfo yamlparser.APIInfo,
 	debug bool,
-	client HTTPClient,
+	client httpclient.HTTPClient,
 ) (CustomResponse, error) {
 	if apiInfo.Headers == nil {
 		apiInfo.Headers = map[string]string{}

--- a/pkg/apiCalls/mock_test.go
+++ b/pkg/apiCalls/mock_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 )
 
-// MockHTTPClient implements HTTPClient interface for testing
+// MockHTTPClient implements httpclient.HTTPClient interface for testing
 type MockHTTPClient struct {
 	DoFunc func(req *http.Request) (*http.Response, error)
 }

--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -1,0 +1,65 @@
+// Package httpclient provides a shared HTTP client interface and factory
+// for all outbound HTTP calls in hulak. Both the API runner and internal
+// fetchers (e.g. GitHub key fetch) use this so timeout, redirect, and
+// TLS behavior stay consistent and upgrade in one place.
+package httpclient
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// HTTPClient is the interface for making HTTP requests.
+// Both Client (production) and test mocks satisfy this.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Client wraps the standard *http.Client with shared defaults.
+// Use New() for production, or inject a custom *http.Client for testing.
+type Client struct {
+	HTTP *http.Client
+}
+
+// New returns a Client with sensible defaults:
+//   - No client-level timeout (use context for per-request deadlines)
+//   - Max 1 redirect, no HTTPS → HTTP downgrade
+//
+// Callers control timeout via context.WithTimeout on each request.
+func New() *Client {
+	return &Client{
+		HTTP: &http.Client{
+			CheckRedirect: safeRedirectPolicy,
+		},
+	}
+}
+
+// Do executes an HTTP request. Shorthand for c.HTTP.Do(req).
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	return c.HTTP.Do(req) //nolint:gosec // G704: hulak is a CLI — URLs are operator-provided, not untrusted
+}
+
+// ReadBody reads the response body up to maxBytes and closes it.
+// Pass 0 for no limit.
+func ReadBody(resp *http.Response, maxBytes int64) ([]byte, error) {
+	defer resp.Body.Close()
+	var reader io.Reader = resp.Body
+	if maxBytes > 0 {
+		reader = io.LimitReader(resp.Body, maxBytes)
+	}
+	return io.ReadAll(reader)
+}
+
+// safeRedirectPolicy refuses HTTPS → HTTP downgrades.
+// Redirect count is left to Go's default (10). Callers needing stricter
+// limits (e.g. key fetcher) should enforce it at their own level.
+func safeRedirectPolicy(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return fmt.Errorf("too many redirects")
+	}
+	if req.URL.Scheme == "http" && len(via) > 0 && via[0].URL.Scheme == "https" {
+		return fmt.Errorf("refusing redirect from HTTPS to HTTP")
+	}
+	return nil
+}

--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -24,7 +24,7 @@ type Client struct {
 
 // New returns a Client with sensible defaults:
 //   - No client-level timeout (use context for per-request deadlines)
-//   - Max 1 redirect, no HTTPS → HTTP downgrade
+//   - Redirects follow Go default (10), but HTTPS → HTTP downgrades are blocked
 //
 // Callers control timeout via context.WithTimeout on each request.
 func New() *Client {

--- a/pkg/httpclient/httpclient_test.go
+++ b/pkg/httpclient/httpclient_test.go
@@ -1,0 +1,165 @@
+package httpclient
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	c := New()
+	if c == nil {
+		t.Fatal("New() returned nil")
+	}
+	if c.HTTP == nil {
+		t.Fatal("New().HTTP is nil")
+	}
+}
+
+func TestDo(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := &Client{HTTP: ts.Client()}
+	req, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("Do() error: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestReadBody(t *testing.T) {
+	t.Run("reads full body", func(t *testing.T) {
+		resp := &http.Response{
+			Body: io.NopCloser(strings.NewReader("hello world")),
+		}
+		body, err := ReadBody(resp, 0)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if string(body) != "hello world" {
+			t.Errorf("body = %q, want %q", body, "hello world")
+		}
+	})
+
+	t.Run("limits body size", func(t *testing.T) {
+		resp := &http.Response{
+			Body: io.NopCloser(strings.NewReader("hello world")),
+		}
+		body, err := ReadBody(resp, 5)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if string(body) != "hello" {
+			t.Errorf("body = %q, want %q", body, "hello")
+		}
+	})
+}
+
+func TestSafeRedirectPolicy(t *testing.T) {
+	t.Run("allows first redirect", func(t *testing.T) {
+		req := &http.Request{URL: mustParseURL("https://example.com/new")}
+		err := safeRedirectPolicy(req, nil)
+		if err != nil {
+			t.Errorf("should allow first redirect, got: %v", err)
+		}
+	})
+
+	t.Run("allows normal redirects", func(t *testing.T) {
+		req := &http.Request{URL: mustParseURL("https://example.com/third")}
+		via := []*http.Request{
+			{URL: mustParseURL("https://example.com/first")},
+		}
+		err := safeRedirectPolicy(req, via)
+		if err != nil {
+			t.Errorf("should allow redirect within limit, got: %v", err)
+		}
+	})
+
+	t.Run("blocks HTTPS to HTTP downgrade", func(t *testing.T) {
+		req := &http.Request{URL: mustParseURL("http://example.com/insecure")}
+		via := []*http.Request{
+			{URL: mustParseURL("https://example.com/secure")},
+		}
+		// This hits the len(via) >= 1 check first, which is correct —
+		// but let's verify the downgrade check works by testing with
+		// the redirect policy through an actual client.
+		err := safeRedirectPolicy(req, via)
+		if err == nil {
+			t.Fatal("should block redirect")
+		}
+	})
+}
+
+func TestRedirectPolicyIntegration(t *testing.T) {
+	// Server that redirects once
+	final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("final"))
+	}))
+	defer final.Close()
+
+	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, final.URL, http.StatusFound)
+	}))
+	defer redirect.Close()
+
+	t.Run("follows redirect to final", func(t *testing.T) {
+		c := New()
+		req, _ := http.NewRequest(http.MethodGet, redirect.URL, nil)
+		resp, err := c.Do(req)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != "final" {
+			t.Errorf("body = %q, want %q", body, "final")
+		}
+	})
+}
+
+// ClientImplementsInterface verifies Client satisfies HTTPClient at compile time.
+var _ HTTPClient = (*Client)(nil)
+
+func mustParseURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+// Verify ReadBody closes the body.
+func TestReadBodyClosesBody(t *testing.T) {
+	closed := false
+	resp := &http.Response{
+		Body: &trackingCloser{
+			Reader:  bytes.NewReader([]byte("data")),
+			onClose: func() { closed = true },
+		},
+	}
+	_, _ = ReadBody(resp, 0)
+	if !closed {
+		t.Error("ReadBody should close resp.Body")
+	}
+}
+
+type trackingCloser struct {
+	io.Reader
+	onClose func()
+}
+
+func (tc *trackingCloser) Close() error {
+	tc.onClose()
+	return nil
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -42,6 +42,9 @@ type Flags struct {
 	Timeout time.Duration
 	// Quiet suppresses the end-of-run summary table for multi-file runs.
 	Quiet bool
+	// SSHIdentity overrides the SSH key path for vault decryption.
+	// Propagated via HULAK_SSH_IDENTITY for the duration of this execution.
+	SSHIdentity string
 }
 
 // DefaultTimeout is the per-request timeout used when no override is set
@@ -57,6 +60,13 @@ const HulakTimeoutEnv = "HULAK_TIMEOUT"
 // so the top-level exit code is non-zero on partial success. A nil error means
 // every dispatched request succeeded.
 func Execute(f *Flags) error {
+	// If --ssh-identity is set and the env var isn't already set by the shell,
+	// propagate it so ResolveIdentity picks it up for vault decryption.
+	if f.SSHIdentity != "" && os.Getenv(utils.SSHIdentityEnvVar) == "" {
+		os.Setenv(utils.SSHIdentityEnvVar, f.SSHIdentity)
+		defer os.Unsetenv(utils.SSHIdentityEnvVar)
+	}
+
 	// Resolve the flag/env layer of the timeout chain up front so a malformed
 	// HULAK_TIMEOUT fails fast before any request work begins.
 	baseTimeout, err := resolveBaseTimeout(f.Timeout)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -62,8 +62,13 @@ const HulakTimeoutEnv = "HULAK_TIMEOUT"
 func Execute(f *Flags) error {
 	// If --ssh-identity is set and the env var isn't already set by the shell,
 	// propagate it so ResolveIdentity picks it up for vault decryption.
+	// Uses env var (same mechanism as HULAK_MASTER_KEY) rather than threading
+	// through 4 function signatures across 3 packages. Safe because Setenv
+	// runs before any goroutines launch and Unsetenv runs after all complete.
 	if f.SSHIdentity != "" && os.Getenv(utils.SSHIdentityEnvVar) == "" {
-		os.Setenv(utils.SSHIdentityEnvVar, f.SSHIdentity)
+		if err := os.Setenv(utils.SSHIdentityEnvVar, f.SSHIdentity); err != nil {
+			return fmt.Errorf("failed to set %s: %w", utils.SSHIdentityEnvVar, err)
+		}
 		defer os.Unsetenv(utils.SSHIdentityEnvVar)
 	}
 

--- a/pkg/userFlags/cli_contract_test.go
+++ b/pkg/userFlags/cli_contract_test.go
@@ -170,7 +170,7 @@ func TestParseRunArgsSetsFilePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f, err := parseRunArgs("", false, false, false, 0, []string{tmpFile})
+	f, err := parseRunArgs("", false, false, false, 0, "", []string{tmpFile})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestParseRunArgsSetsFilePath(t *testing.T) {
 func TestParseRunArgsSetsDir(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	f, err := parseRunArgs("", false, false, false, 0, []string{tmpDir})
+	f, err := parseRunArgs("", false, false, false, 0, "", []string{tmpDir})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -212,7 +212,7 @@ func TestParseRunArgsRoutesFlags(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f, err := parseRunArgs("staging", false, true, false, 0, []string{tmpFile})
+	f, err := parseRunArgs("staging", false, true, false, 0, "", []string{tmpFile})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -235,7 +235,7 @@ func TestParseRunArgsQuietPlumbed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f, err := parseRunArgs("", false, false, true, 0, []string{tmpFile})
+	f, err := parseRunArgs("", false, false, true, 0, "", []string{tmpFile})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestParseRunArgsQuietPlumbed(t *testing.T) {
 func TestParseRunArgsSequentialDir(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	f, err := parseRunArgs("", true, false, false, 0, []string{tmpDir})
+	f, err := parseRunArgs("", true, false, false, 0, "", []string{tmpDir})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestParseRunArgsTimeoutPlumbed(t *testing.T) {
 	}
 
 	want := 5 * time.Minute
-	f, err := parseRunArgs("", false, false, false, want, []string{tmpFile})
+	f, err := parseRunArgs("", false, false, false, want, "", []string{tmpFile})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestParseRunArgsTimeoutPlumbed(t *testing.T) {
 
 // TestParseRunArgsBadPath verifies that a nonexistent path returns an error.
 func TestParseRunArgsBadPath(t *testing.T) {
-	_, err := parseRunArgs("", false, false, false, 0, []string{"/nonexistent/path.yaml"})
+	_, err := parseRunArgs("", false, false, false, 0, "", []string{"/nonexistent/path.yaml"})
 	if err == nil {
 		t.Fatal("expected an error for nonexistent path")
 	}
@@ -297,7 +297,7 @@ func TestParseRunArgsDefaultEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f, err := parseRunArgs("", false, false, false, 0, []string{tmpFile})
+	f, err := parseRunArgs("", false, false, false, 0, "", []string{tmpFile})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/userFlags/env_backup_test.go
+++ b/pkg/userFlags/env_backup_test.go
@@ -324,7 +324,7 @@ func TestRunRestore_ReencryptsToCurrentRecipients(t *testing.T) {
 
 	// Add a second recipient
 	newKey, _ := vault.GenerateKeyPair()
-	if err := runAddRecipient([]string{newKey.Recipient.String()}, "teammate", false); err != nil {
+	if err := runAddRecipient([]string{newKey.Recipient.String()}, "teammate", false, "", "", false); err != nil {
 		t.Fatalf("add recipient: %v", err)
 	}
 

--- a/pkg/userFlags/env_crud.go
+++ b/pkg/userFlags/env_crud.go
@@ -10,8 +10,6 @@ import (
 	"os"
 	"strings"
 
-	"golang.org/x/term"
-
 	"github.com/xaaha/hulak/pkg/utils"
 	"github.com/xaaha/hulak/pkg/vault"
 )
@@ -144,31 +142,8 @@ func resolveSetValue(args []string, useStdin bool, key string) (string, error) {
 		return args[1], nil
 
 	default:
-		return promptSecretValue(key)
+		return utils.PromptSecret(fmt.Sprintf("Enter value for %s: ", key))
 	}
-}
-
-// promptSecretValue reads a value from the terminal with no echo, no shell
-// history. The prompt and trailing newline go to stderr so a misuse like
-// `FOO=$(hulak secrets set BAR)` never captures them into the variable.
-func promptSecretValue(key string) (string, error) {
-	stdinFd := int(os.Stdin.Fd()) //nolint:gosec // G115 fd is small non-neg
-	// ensure intput is coming from terminal
-	if !term.IsTerminal(stdinFd) {
-		return "", errors.New(
-			"no value provided and stdin is not a terminal — pass VALUE positionally or use --stdin",
-		)
-	}
-	//nolint:gosec // G705 TTY prompt, no taint sink
-	fmt.Fprintf(os.Stderr, "Enter value for %s: ", key)
-	// read input without echo
-	bytes, err := term.ReadPassword(stdinFd)
-	// newline to stderr
-	fmt.Fprintln(os.Stderr)
-	if err != nil {
-		return "", fmt.Errorf("failed to read input: %w", err)
-	}
-	return string(bytes), nil
 }
 
 // newEnvGetCmd returns the command struct for `hulak secrets get`.

--- a/pkg/userFlags/env_recipients.go
+++ b/pkg/userFlags/env_recipients.go
@@ -25,36 +25,70 @@ func newEnvAddRecipientCmd() *command {
 	addRecipientFs := flag.NewFlagSet("env add-recipient", flag.ContinueOnError)
 	addRecipientName := addRecipientFs.String("name", "", "Human-readable label for the recipient")
 	addRecipientStdin := addRecipientFs.Bool("stdin", false, "Read keys from stdin (one per line)")
+	addRecipientGitHub := addRecipientFs.String("github", "", "Fetch ed25519 keys from GitHub (username)")
+	addRecipientKeyserver := addRecipientFs.String("keyserver", "", "Base URL of keyserver (e.g. https://gitlab.com)")
+	addRecipientAllowRSA := addRecipientFs.Bool("allow-rsa", false, "Also accept ssh-rsa keys (lower security margin)")
 
 	return &command{
 		Name:  "add-recipient",
 		Short: "Add a recipient for shared vault access",
-		Long:  "Add an age public key as a recipient so another user can decrypt the vault.\n\nThe vault is re-encrypted to all current recipients plus the new one.\nUse --name to add a human-readable label.",
+		Long: "Add an age or SSH public key as a recipient so another user can decrypt the vault.\n\n" +
+			"The vault is re-encrypted to all current recipients plus the new one.\n" +
+			"Use --name to add a human-readable label.\n" +
+			"Use --github to fetch a user's SSH keys directly from GitHub.",
 		Flags: addRecipientFs,
-		Args:  []argDef{{Name: "public-key", Required: true, Desc: "Age public key to add"}},
+		Args:  []argDef{{Name: "public-key", Desc: "Age or SSH public key to add (not needed with --github)"}},
 		Examples: []*utils.CommandHelp{
 			{
 				Command:     "hulak secrets add-recipient age1ql3z...",
-				Description: "Add a teammate's public key",
+				Description: "Add a teammate's age public key",
 			},
 			{
-				Command:     "hulak secrets add-recipient age1ql3z... --name Alice",
-				Description: "Add with a label",
+				Command:     "hulak secrets add-recipient \"ssh-ed25519 AAAA...\" --name Alice",
+				Description: "Add an SSH ed25519 public key",
+			},
+			{
+				Command:     "hulak secrets add-recipient --github alice --name Alice",
+				Description: "Fetch and add Alice's ed25519 keys from GitHub",
+			},
+			{
+				Command:     "hulak secrets add-recipient --github alice --keyserver https://gitlab.com --name Alice",
+				Description: "Fetch from a self-hosted GitLab",
 			},
 			{
 				Command:     "cat keys.txt | hulak secrets add-recipient --stdin --name Team",
 				Description: "Add multiple keys from stdin",
 			},
 		},
-		Run: func(args []string) error { return runAddRecipient(args, *addRecipientName, *addRecipientStdin) },
+		Run: func(args []string) error {
+			return runAddRecipient(args, *addRecipientName, *addRecipientStdin, *addRecipientGitHub, *addRecipientKeyserver, *addRecipientAllowRSA)
+		},
 	}
 }
 
-// resolveRecipientKeys returns public keys to add. From --stdin (one per line,
-// blank lines and # comments ignored) or from positional arg. Error if both.
-func resolveRecipientKeys(args []string, useStdin bool) ([]string, error) {
-	if useStdin && len(args) > 0 {
-		return nil, errors.New("cannot use both --stdin and a positional key — pick one")
+// resolveRecipientKeys returns public keys to add from --stdin, --github, or positional arg.
+func resolveRecipientKeys(args []string, useStdin bool, gitHubUser, keyserverURL string, allowRSA bool) ([]string, error) {
+	sources := 0
+	if useStdin {
+		sources++
+	}
+	if gitHubUser != "" {
+		sources++
+	}
+	if len(args) > 0 {
+		sources++
+	}
+	if sources > 1 {
+		return nil, errors.New("use exactly one of: positional key, --stdin, or --github")
+	}
+
+	if gitHubUser != "" {
+		baseURL := vault.GitHubKeysBase
+		if keyserverURL != "" {
+			baseURL = keyserverURL
+		}
+		url := vault.KeyserverKeysURL(baseURL, gitHubUser)
+		return fetchAndFilterKeys(url, allowRSA)
 	}
 
 	if useStdin {
@@ -77,7 +111,7 @@ func resolveRecipientKeys(args []string, useStdin bool) ([]string, error) {
 	}
 
 	if len(args) == 0 {
-		return nil, errors.New("missing required argument: public-key")
+		return nil, errors.New("missing required argument: public-key (or use --github <username>)")
 	}
 	if len(args) > 1 {
 		return nil, fmt.Errorf("too many arguments: got %d, expected 1 (public-key)", len(args))
@@ -85,15 +119,53 @@ func resolveRecipientKeys(args []string, useStdin bool) ([]string, error) {
 	return []string{args[0]}, nil
 }
 
-// runAddRecipient handles `hulak secrets add-recipient <public-key> [--name n] [--stdin]`.
-func runAddRecipient(args []string, name string, useStdin bool) error {
-	pubKeys, err := resolveRecipientKeys(args, useStdin)
+// fetchAndFilterKeys fetches keys from a URL, filters by type, and returns
+// the keys to add. Prints warnings for skipped key types.
+func fetchAndFilterKeys(url string, allowRSA bool) ([]string, error) {
+	allKeys, err := vault.FetchKeysFromURL(url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ed25519Keys, rsaKeys, skipped := vault.FilterKeysByType(allKeys)
+
+	var keys []string
+	keys = append(keys, ed25519Keys...)
+
+	if len(rsaKeys) > 0 {
+		if allowRSA {
+			utils.PrintWarningStderr(fmt.Sprintf(
+				"Including %d ssh-rsa key(s) (lower security margin)", len(rsaKeys),
+			))
+			keys = append(keys, rsaKeys...)
+		} else {
+			utils.PrintWarningStderr(fmt.Sprintf(
+				"Skipped %d ssh-rsa key(s) — use --allow-rsa to include them", len(rsaKeys),
+			))
+		}
+	}
+
+	if len(skipped) > 0 {
+		utils.PrintWarningStderr(fmt.Sprintf(
+			"Skipped %d unsupported key(s)", len(skipped),
+		))
+	}
+
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("no ed25519 keys found — ask the user to upload an ed25519 SSH key")
+	}
+
+	return keys, nil
+}
+
+// runAddRecipient handles `hulak secrets add-recipient`.
+func runAddRecipient(args []string, name string, useStdin bool, gitHubUser, keyserverURL string, allowRSA bool) error {
+	pubKeys, err := resolveRecipientKeys(args, useStdin, gitHubUser, keyserverURL, allowRSA)
 	if err != nil {
 		return err
 	}
 
 	return vault.WithStoreLock(func() error {
-		// Read current entries
 		recipPath, err := vault.RecipientsFilePath()
 		if err != nil {
 			return err
@@ -107,12 +179,28 @@ func runAddRecipient(args []string, name string, useStdin bool) error {
 			return err
 		}
 
-		// Add each key
+		// Build recipient name with source info for GitHub fetches
+		recipientName := name
+		if gitHubUser != "" && name == "" {
+			recipientName = gitHubUser
+		}
+
+		added := 0
 		for _, pubKey := range pubKeys {
-			entries, err = vault.AddRecipientEntry(entries, pubKey, name, false)
-			if err != nil {
-				return err
+			newEntries, addErr := vault.AddRecipientEntry(entries, pubKey, recipientName, allowRSA)
+			if addErr != nil {
+				if strings.Contains(addErr.Error(), "already in recipients") {
+					continue // skip duplicates silently
+				}
+				return addErr
 			}
+			entries = newEntries
+			added++
+		}
+
+		if added == 0 {
+			utils.PrintWarningStderr("No new recipients added (all duplicates)")
+			return nil
 		}
 
 		// Re-encrypt store to all recipients including new ones
@@ -126,7 +214,7 @@ func runAddRecipient(args []string, name string, useStdin bool) error {
 		}
 
 		// Write store first (prefer store updated + stale recipients
-		//	over recipients updated + stale store)
+		// over recipients updated + stale store)
 		recipients, err := vault.RecipientsFromEntries(entries)
 		if err != nil {
 			return err
@@ -138,14 +226,10 @@ func runAddRecipient(args []string, name string, useStdin bool) error {
 			return err
 		}
 
-		if len(pubKeys) == 1 {
-			keyPrefix := pubKeys[0]
-			if len(keyPrefix) > EllipsisLength {
-				keyPrefix = keyPrefix[:EllipsisLength] + utils.Ellipsis
-			}
-			utils.PrintSuccessStderr(fmt.Sprintf("Added recipient %s", keyPrefix))
+		if added == 1 {
+			utils.PrintSuccessStderr("Added 1 recipient")
 		} else {
-			utils.PrintSuccessStderr(fmt.Sprintf("Added %d recipients", len(pubKeys)))
+			utils.PrintSuccessStderr(fmt.Sprintf("Added %d recipients", added))
 		}
 		return nil
 	})
@@ -286,11 +370,12 @@ func runListRecipients(args []string) error {
 		if len(keyPrefix) > EllipsisLength {
 			keyPrefix = keyPrefix[:EllipsisLength] + utils.Ellipsis
 		}
-		rows[idx] = []string{name, keyPrefix}
+		kt := vault.ClassifyKeyType(entry.Key)
+		rows[idx] = []string{name, string(kt), keyPrefix}
 	}
 	return utils.PrintTable(
 		os.Stdout,
-		utils.StdoutHeaders([]string{"NAME", "KEY"}),
+		utils.StdoutHeaders([]string{"NAME", "TYPE", "KEY"}),
 		rows,
 		0,
 	)

--- a/pkg/userFlags/env_recipients.go
+++ b/pkg/userFlags/env_recipients.go
@@ -119,7 +119,6 @@ func resolveRecipientKeys(
 
 	if useStdin {
 		data, err := io.ReadAll(os.Stdin)
-		// Read current entries
 		if err != nil {
 			return nil, fmt.Errorf("failed to read stdin: %w", err)
 		}

--- a/pkg/userFlags/env_recipients.go
+++ b/pkg/userFlags/env_recipients.go
@@ -25,9 +25,21 @@ func newEnvAddRecipientCmd() *command {
 	addRecipientFs := flag.NewFlagSet("env add-recipient", flag.ContinueOnError)
 	addRecipientName := addRecipientFs.String("name", "", "Human-readable label for the recipient")
 	addRecipientStdin := addRecipientFs.Bool("stdin", false, "Read keys from stdin (one per line)")
-	addRecipientGitHub := addRecipientFs.String("github", "", "Fetch ed25519 keys from GitHub (username)")
-	addRecipientKeyserver := addRecipientFs.String("keyserver", "", "Base URL of keyserver (e.g. https://gitlab.com)")
-	addRecipientAllowRSA := addRecipientFs.Bool("allow-rsa", false, "Also accept ssh-rsa keys (lower security margin)")
+	addRecipientGitHub := addRecipientFs.String(
+		"github",
+		"",
+		"Fetch ed25519 keys from GitHub (username)",
+	)
+	addRecipientKeyserver := addRecipientFs.String(
+		"keyserver",
+		"",
+		"Base URL of keyserver (e.g. https://gitlab.com)",
+	)
+	addRecipientAllowRSA := addRecipientFs.Bool(
+		"allow-rsa",
+		false,
+		"Also accept ssh-rsa keys (lower security margin)",
+	)
 
 	return &command{
 		Name:  "add-recipient",
@@ -37,7 +49,9 @@ func newEnvAddRecipientCmd() *command {
 			"Use --name to add a human-readable label.\n" +
 			"Use --github to fetch a user's SSH keys directly from GitHub.",
 		Flags: addRecipientFs,
-		Args:  []argDef{{Name: "public-key", Desc: "Age or SSH public key to add (not needed with --github)"}},
+		Args: []argDef{
+			{Name: "public-key", Desc: "Age or SSH public key to add (not needed with --github)"},
+		},
 		Examples: []*utils.CommandHelp{
 			{
 				Command:     "hulak secrets add-recipient age1ql3z...",
@@ -61,13 +75,25 @@ func newEnvAddRecipientCmd() *command {
 			},
 		},
 		Run: func(args []string) error {
-			return runAddRecipient(args, *addRecipientName, *addRecipientStdin, *addRecipientGitHub, *addRecipientKeyserver, *addRecipientAllowRSA)
+			return runAddRecipient(
+				args,
+				*addRecipientName,
+				*addRecipientStdin,
+				*addRecipientGitHub,
+				*addRecipientKeyserver,
+				*addRecipientAllowRSA,
+			)
 		},
 	}
 }
 
 // resolveRecipientKeys returns public keys to add from --stdin, --github, or positional arg.
-func resolveRecipientKeys(args []string, useStdin bool, gitHubUser, keyserverURL string, allowRSA bool) ([]string, error) {
+func resolveRecipientKeys(
+	args []string,
+	useStdin bool,
+	gitHubUser, keyserverURL string,
+	allowRSA bool,
+) ([]string, error) {
 	sources := 0
 	if useStdin {
 		sources++
@@ -93,6 +119,7 @@ func resolveRecipientKeys(args []string, useStdin bool, gitHubUser, keyserverURL
 
 	if useStdin {
 		data, err := io.ReadAll(os.Stdin)
+		// Read current entries
 		if err != nil {
 			return nil, fmt.Errorf("failed to read stdin: %w", err)
 		}
@@ -159,7 +186,13 @@ func fetchAndFilterKeys(url string, allowRSA bool) ([]string, error) {
 }
 
 // runAddRecipient handles `hulak secrets add-recipient`.
-func runAddRecipient(args []string, name string, useStdin bool, gitHubUser, keyserverURL string, allowRSA bool) error {
+func runAddRecipient(
+	args []string,
+	name string,
+	useStdin bool,
+	gitHubUser, keyserverURL string,
+	allowRSA bool,
+) error {
 	pubKeys, err := resolveRecipientKeys(args, useStdin, gitHubUser, keyserverURL, allowRSA)
 	if err != nil {
 		return err

--- a/pkg/userFlags/env_recipients.go
+++ b/pkg/userFlags/env_recipients.go
@@ -109,7 +109,7 @@ func runAddRecipient(args []string, name string, useStdin bool) error {
 
 		// Add each key
 		for _, pubKey := range pubKeys {
-			entries, err = vault.AddRecipientEntry(entries, pubKey, name)
+			entries, err = vault.AddRecipientEntry(entries, pubKey, name, false)
 			if err != nil {
 				return err
 			}

--- a/pkg/userFlags/env_rotate_key_test.go
+++ b/pkg/userFlags/env_rotate_key_test.go
@@ -88,7 +88,8 @@ func TestRunRotateKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if newIdentity.String() == oldID.String() {
+		newX25519 := newIdentity.(*age.X25519Identity)
+		if newX25519.String() == oldID.String() {
 			t.Error("identity should have changed")
 		}
 
@@ -125,7 +126,7 @@ func TestRunRotateKey(t *testing.T) {
 		if strings.Contains(content, oldID.Recipient().String()) {
 			t.Error("old public key should not be in recipients.txt")
 		}
-		if !strings.Contains(content, newIdentity.Recipient().String()) {
+		if !strings.Contains(content, newX25519.Recipient().String()) {
 			t.Error("new public key should be in recipients.txt")
 		}
 	})
@@ -224,13 +225,14 @@ func TestRunRotateKey(t *testing.T) {
 
 		// Second rotation
 		midID, _ := vault.ResolveIdentity()
+		midX25519 := midID.(*age.X25519Identity)
 		if err := runRotateKey(nil); err != nil {
 			t.Fatalf("second rotation error: %v", err)
 		}
 
 		// Now .old should have the mid identity, not firstID
 		old2, _ := vault.LoadIdentityOld()
-		if old2.String() != midID.String() {
+		if old2.String() != midX25519.String() {
 			t.Error("second .old should be mid identity, not first")
 		}
 	})

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -302,6 +302,7 @@ func newRunCmd() *command {
 	var debug bool
 	var quiet bool
 	var timeout time.Duration
+	var sshIdentity string
 	fs.BoolVar(&sequential, "sequential", false, "Run directory files sequentially")
 	fs.BoolVar(&sequential, "seq", false, "Run directory files sequentially")
 	fs.BoolVar(&debug, "debug", false, "Enable debug mode")
@@ -313,6 +314,7 @@ func newRunCmd() *command {
 		0,
 		"Per-request timeout, e.g. 5m or 90s (default 60s)",
 	)
+	fs.StringVar(&sshIdentity, "ssh-identity", "", "Path to SSH private key for vault decryption")
 
 	runCmd := &command{
 		Name:  "run",
@@ -334,6 +336,10 @@ func newRunCmd() *command {
 				Command:     "hulak run path/to/dir/ --sequential",
 				Description: "Run directory files sequentially",
 			},
+			{
+				Command:     "hulak run path/to/file.yaml --ssh-identity ~/.ssh/work_ed25519",
+				Description: "Use a specific SSH key for vault decryption",
+			},
 		},
 		Flags: fs,
 		Args: []argDef{
@@ -347,7 +353,7 @@ func newRunCmd() *command {
 			return nil
 		}
 
-		f, err := parseRunArgs(*envFlagVal, sequential, debug, quiet, timeout, args)
+		f, err := parseRunArgs(*envFlagVal, sequential, debug, quiet, timeout, sshIdentity, args)
 		if err != nil {
 			return err
 		}
@@ -367,6 +373,7 @@ func parseRunArgs(
 	envFlagVal string,
 	sequential, debug, quiet bool,
 	timeout time.Duration,
+	sshIdentity string,
 	args []string,
 ) (*runner.Flags, error) {
 	path := args[0]
@@ -376,7 +383,7 @@ func parseRunArgs(
 		return nil, fmt.Errorf("cannot access %q: %w", path, err)
 	}
 
-	f := &runner.Flags{Debug: debug, Quiet: quiet, Timeout: timeout}
+	f := &runner.Flags{Debug: debug, Quiet: quiet, Timeout: timeout, SSHIdentity: sshIdentity}
 
 	if envFlagVal != "" {
 		f.Env = envFlagVal

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -45,11 +45,7 @@ const (
 )
 
 // SSH identity support
-const (
-	SSHIdentityEnvVar = "HULAK_SSH_IDENTITY"
-	SSHKeyDir         = ".ssh"
-	SSHKeyFile        = "id_ed25519"
-)
+const SSHIdentityEnvVar = "HULAK_SSH_IDENTITY"
 
 // Editor is the fallback editor used when $EDITOR is unset. POSIX guarantees
 // `vi`, so this works in bare/minimal environments (Alpine, distroless, etc.)

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -44,6 +44,13 @@ const (
 	MasterKey = "HULAK_MASTER_KEY"
 )
 
+// SSH identity support
+const (
+	SSHIdentityEnvVar = "HULAK_SSH_IDENTITY"
+	SSHKeyDir         = ".ssh"
+	SSHKeyFile        = "id_ed25519"
+)
+
 // Editor is the fallback editor used when $EDITOR is unset. POSIX guarantees
 // `vi`, so this works in bare/minimal environments (Alpine, distroless, etc.)
 // where vim/nano may not be installed. Users who prefer something else should

--- a/pkg/utils/printing.go
+++ b/pkg/utils/printing.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+
+	"golang.org/x/term"
 )
 
 // ColorError Creates an error message that optionally includes an additional error.
@@ -142,6 +144,23 @@ func ConfirmAction(prompt string) (bool, error) {
 	}
 	answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
 	return answer == "y" || answer == "yes", nil
+}
+
+// PromptSecret prints prompt to stderr and reads input with no echo.
+// Requires stdin to be a terminal — returns an error if piped.
+// Prints a trailing newline to stderr after input (ReadPassword swallows it).
+func PromptSecret(prompt string) (string, error) {
+	stdinFd := int(os.Stdin.Fd()) //nolint:gosec // G115 fd is small non-neg
+	if !term.IsTerminal(stdinFd) {
+		return "", fmt.Errorf("stdin is not a terminal — cannot prompt for secret input")
+	}
+	fmt.Fprint(os.Stderr, prompt)
+	bytes, err := term.ReadPassword(stdinFd)
+	fmt.Fprintln(os.Stderr) // newline after hidden input
+	if err != nil {
+		return "", fmt.Errorf("failed to read input: %w", err)
+	}
+	return string(bytes), nil
 }
 
 // HelpfulError formats a multi-line error with a title, a section heading, and a

--- a/pkg/vault/const.go
+++ b/pkg/vault/const.go
@@ -1,0 +1,6 @@
+package vault
+
+const (
+	AgePrefix = "age1"
+	Age       = "age"
+)

--- a/pkg/vault/const.go
+++ b/pkg/vault/const.go
@@ -1,6 +1,0 @@
-package vault
-
-const (
-	AgePrefix = "age1"
-	Age       = "age"
-)

--- a/pkg/vault/constants.go
+++ b/pkg/vault/constants.go
@@ -1,0 +1,11 @@
+package vault
+
+const (
+	AgePrefix = "age1"
+	Age       = "age"
+
+	// Default SSH key location components — joined with filepath.Join at runtime
+	// for cross-platform path separators.
+	sshKeyDir  = ".ssh"
+	sshKeyFile = "id_ed25519"
+)

--- a/pkg/vault/constants.go
+++ b/pkg/vault/constants.go
@@ -4,6 +4,10 @@ const (
 	AgePrefix = "age1"
 	Age       = "age"
 
+	// SSH key type strings as returned by the ssh library / authorized_keys format.
+	sshEd25519 = "ssh-ed25519"
+	sshRSA     = "ssh-rsa"
+
 	// Default SSH key location components — joined with filepath.Join at runtime
 	// for cross-platform path separators.
 	sshKeyDir  = ".ssh"

--- a/pkg/vault/github_keys.go
+++ b/pkg/vault/github_keys.go
@@ -94,6 +94,8 @@ func FetchKeysFromURL(url string, client *httpclient.Client) ([]string, error) {
 
 // FilterKeysByType categorizes SSH public key strings by type using
 // ClassifyKeyType. Keys are sorted into ed25519, RSA, and skipped buckets.
+// Note: sshEd25519/sshRSA constants must match the strings returned by
+// ClassifyKeyType (which derives them from the ssh library's key type field).
 func FilterKeysByType(keys []string) (ed25519Keys, rsaKeys, skippedKeys []string) {
 	for _, key := range keys {
 		switch ClassifyKeyType(key) {

--- a/pkg/vault/github_keys.go
+++ b/pkg/vault/github_keys.go
@@ -1,0 +1,109 @@
+package vault
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/xaaha/hulak/pkg/httpclient"
+)
+
+// HTTP client and URL construction for fetching SSH public keys
+// from GitHub or compatible keyservers.
+
+// GitHubKeysBase is the default keyserver base URL for GitHub.
+// Pass to KeyserverKeysURL for GitHub users.
+const GitHubKeysBase = "https://github.com"
+
+const (
+	keysSuffix       = ".keys"
+	maxBodyBytes     = 1 << 20 // 1 MiB
+	fetchKeysTimeout = 5 * time.Second
+)
+
+// KeyserverKeysURL returns the URL for a user's published SSH keys on a
+// keyserver. Use GitHubKeysBase for GitHub, or pass a custom base for
+// GitLab/Forgejo/etc. Trailing slashes on baseURL are trimmed.
+func KeyserverKeysURL(baseURL, username string) string {
+	return strings.TrimRight(baseURL, "/") + "/" + username + keysSuffix
+}
+
+// FetchKeysFromURL fetches SSH public keys from the given HTTPS URL.
+//
+// Pass a non-nil client for testing; nil uses httpclient.New().
+// Timeout is 5 seconds via context, not client-level — same pattern as the runner.
+//
+// Returns the non-empty lines from the response body. Errors on non-HTTPS URLs,
+// 404 responses, and empty bodies.
+func FetchKeysFromURL(url string, client *httpclient.Client) ([]string, error) {
+	if !strings.HasPrefix(url, "https://") {
+		return nil, fmt.Errorf(
+			"refusing to fetch keys over insecure transport — HTTPS required: %s",
+			url,
+		)
+	}
+
+	if client == nil {
+		client = httpclient.New()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), fetchKeysTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building request for %s: %w", url, err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching keys from %s: %w", url, err)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		resp.Body.Close()
+		return nil, fmt.Errorf("no keys published at %s — check the username", url)
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
+	}
+
+	body, err := httpclient.ReadBody(resp, maxBodyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("reading response from %s: %w", url, err)
+	}
+
+	if len(strings.TrimSpace(string(body))) == 0 {
+		return nil, fmt.Errorf("no keys found at %s", url)
+	}
+
+	var keys []string
+	// github returns one public key per line
+	for line := range strings.SplitSeq(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			keys = append(keys, line)
+		}
+	}
+
+	return keys, nil
+}
+
+// FilterKeysByType categorizes SSH public key strings by type using
+// ClassifyKeyType. Keys are sorted into ed25519, RSA, and skipped buckets.
+func FilterKeysByType(keys []string) (ed25519Keys, rsaKeys, skippedKeys []string) {
+	for _, key := range keys {
+		switch ClassifyKeyType(key) {
+		case sshEd25519:
+			ed25519Keys = append(ed25519Keys, key)
+		case sshRSA:
+			rsaKeys = append(rsaKeys, key)
+		default:
+			skippedKeys = append(skippedKeys, key)
+		}
+	}
+	return
+}

--- a/pkg/vault/github_keys_test.go
+++ b/pkg/vault/github_keys_test.go
@@ -140,6 +140,28 @@ func TestFetchKeysFromURL(t *testing.T) {
 	})
 }
 
+func TestKeyserverFetchIntegration(t *testing.T) {
+	ed25519Key := testSSHEd25519PubKey(t)
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the URL path matches the keyserver pattern
+		if r.URL.Path != "/alice.keys" {
+			t.Errorf("unexpected path %q, want /alice.keys", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(ed25519Key + "\n"))
+	}))
+	defer ts.Close()
+
+	url := KeyserverKeysURL(ts.URL, "alice")
+	keys, err := FetchKeysFromURL(url, testClient(ts))
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
+	}
+}
+
 func TestFilterKeysByType(t *testing.T) {
 	ed25519Key := testSSHEd25519PubKey(t)
 	rsaKey := testSSHRSAPubKey(t)

--- a/pkg/vault/github_keys_test.go
+++ b/pkg/vault/github_keys_test.go
@@ -1,0 +1,164 @@
+package vault
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/xaaha/hulak/pkg/httpclient"
+)
+
+// testClient wraps an httptest TLS server's client into an httpclient.Client.
+func testClient(ts *httptest.Server) *httpclient.Client {
+	return &httpclient.Client{HTTP: ts.Client()}
+}
+
+func TestKeyserverKeysURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseURL  string
+		username string
+		want     string
+	}{
+		{
+			name:     "github",
+			baseURL:  GitHubKeysBase,
+			username: "octocat",
+			want:     "https://github.com/octocat.keys",
+		},
+		{
+			name:     "no trailing slash",
+			baseURL:  "https://keys.example.com",
+			username: "alice",
+			want:     "https://keys.example.com/alice.keys",
+		},
+		{
+			name:     "trailing slash",
+			baseURL:  "https://keys.example.com/",
+			username: "alice",
+			want:     "https://keys.example.com/alice.keys",
+		},
+		{
+			name:     "multiple trailing slashes",
+			baseURL:  "https://keys.example.com///",
+			username: "bob",
+			want:     "https://keys.example.com/bob.keys",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := KeyserverKeysURL(tt.baseURL, tt.username)
+			if got != tt.want {
+				t.Errorf("KeyserverKeysURL(%q, %q) = %q, want %q", tt.baseURL, tt.username, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchKeysFromURL(t *testing.T) {
+	ed25519Key := testSSHEd25519PubKey(t)
+	rsaKey := testSSHRSAPubKey(t)
+
+	t.Run("fetches and returns key lines", func(t *testing.T) {
+		body := ed25519Key + "\n" + rsaKey + "\n"
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(body))
+		}))
+		defer ts.Close()
+
+		keys, err := FetchKeysFromURL(ts.URL, testClient(ts))
+		if err != nil {
+			t.Fatalf("FetchKeysFromURL() error: %v", err)
+		}
+		if len(keys) != 2 {
+			t.Fatalf("expected 2 keys, got %d: %v", len(keys), keys)
+		}
+		if keys[0] != ed25519Key {
+			t.Errorf("keys[0] = %q, want %q", truncateKey(keys[0]), truncateKey(ed25519Key))
+		}
+		if keys[1] != rsaKey {
+			t.Errorf("keys[1] = %q, want %q", truncateKey(keys[1]), truncateKey(rsaKey))
+		}
+	})
+
+	t.Run("returns error on 404", func(t *testing.T) {
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer ts.Close()
+
+		_, err := FetchKeysFromURL(ts.URL, testClient(ts))
+		if err == nil {
+			t.Fatal("expected error on 404, got nil")
+		}
+		if !strings.Contains(err.Error(), "no keys published") {
+			t.Errorf("error should mention 'no keys published', got: %v", err)
+		}
+	})
+
+	t.Run("returns error on empty body", func(t *testing.T) {
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+
+		_, err := FetchKeysFromURL(ts.URL, testClient(ts))
+		if err == nil {
+			t.Fatal("expected error on empty body, got nil")
+		}
+		if !strings.Contains(err.Error(), "no keys found") {
+			t.Errorf("error should mention 'no keys found', got: %v", err)
+		}
+	})
+
+	t.Run("skips blank lines", func(t *testing.T) {
+		body := ed25519Key + "\n\n\n" + rsaKey + "\n\n"
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(body))
+		}))
+		defer ts.Close()
+
+		keys, err := FetchKeysFromURL(ts.URL, testClient(ts))
+		if err != nil {
+			t.Fatalf("FetchKeysFromURL() error: %v", err)
+		}
+		if len(keys) != 2 {
+			t.Fatalf("expected 2 keys (blank lines skipped), got %d", len(keys))
+		}
+	})
+
+	t.Run("rejects http URL", func(t *testing.T) {
+		_, err := FetchKeysFromURL("http://example.com/user.keys", nil)
+		if err == nil {
+			t.Fatal("expected error for http:// URL, got nil")
+		}
+		if !strings.Contains(err.Error(), "HTTPS") {
+			t.Errorf("error should mention HTTPS, got: %v", err)
+		}
+	})
+}
+
+func TestFilterKeysByType(t *testing.T) {
+	ed25519Key := testSSHEd25519PubKey(t)
+	rsaKey := testSSHRSAPubKey(t)
+	ecdsaKey := "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTY="
+
+	keys := []string{ed25519Key, rsaKey, ecdsaKey, ed25519Key}
+
+	ed25519Keys, rsaKeys, skippedKeys := FilterKeysByType(keys)
+
+	if len(ed25519Keys) != 2 {
+		t.Errorf("expected 2 ed25519 keys, got %d", len(ed25519Keys))
+	}
+	if len(rsaKeys) != 1 {
+		t.Errorf("expected 1 rsa key, got %d", len(rsaKeys))
+	}
+	if len(skippedKeys) != 1 {
+		t.Errorf("expected 1 skipped key, got %d", len(skippedKeys))
+	}
+	if len(skippedKeys) > 0 && skippedKeys[0] != ecdsaKey {
+		t.Errorf("skipped key should be ecdsa, got %q", truncateKey(skippedKeys[0]))
+	}
+}

--- a/pkg/vault/keys.go
+++ b/pkg/vault/keys.go
@@ -159,17 +159,58 @@ func LoadIdentityOld() (*age.X25519Identity, error) {
 	return identity, nil
 }
 
-// ResolveIdentity returns the age identity to use for decryption.
-// Precedence: HULAK_MASTER_KEY env var → ~/.config/hulak/identity.txt.
-//
-// Wraps parse errors with user-friendly messages:
-//   - public key in env var → "this looks like a public key"
-//   - garbage in env var → hint at AGE-SECRET-KEY- format
-func ResolveIdentity() (*age.X25519Identity, error) {
+// ResolveIdentity returns the identity to use for decryption.
+// Precedence: HULAK_MASTER_KEY → identity.txt → HULAK_SSH_IDENTITY → ~/.ssh/id_ed25519.
+// Returns age.Identity (interface) — callers should not assume X25519.
+func ResolveIdentity() (age.Identity, error) {
+	// 1. HULAK_MASTER_KEY (highest precedence)
 	if raw := strings.TrimSpace(os.Getenv(utils.MasterKey)); raw != "" {
 		return parseMasterKey(raw)
 	}
-	return LoadIdentity()
+
+	// 2. identity.txt
+	if IdentityExists() {
+		return LoadIdentity()
+	}
+
+	// 3. HULAK_SSH_IDENTITY env var
+	if sshPath := strings.TrimSpace(os.Getenv(utils.SSHIdentityEnvVar)); sshPath != "" {
+		identity, err := LoadSSHIdentity(sshPath)
+		if err != nil {
+			return nil, fmt.Errorf("%s is set but key could not be loaded: %w", utils.SSHIdentityEnvVar, err)
+		}
+		utils.PrintInfoStderr(fmt.Sprintf("Using SSH identity %s", sshPath))
+		return identity, nil
+	}
+
+	// 4. Default ~/.ssh/id_ed25519
+	defaultPath := DefaultSSHIdentityPath()
+	if defaultPath != "" && utils.FileExists(defaultPath) {
+		identity, err := LoadSSHIdentity(defaultPath)
+		if err == nil {
+			utils.PrintInfoStderr(fmt.Sprintf("Using SSH identity %s (no identity.txt found)", defaultPath))
+			return identity, nil
+		}
+		// Don't error on auto-fallback failure — fall through to helpful error
+	}
+
+	// 5. Nothing found
+	return nil, noIdentityError()
+}
+
+// noIdentityError returns a helpful error when no identity could be resolved.
+func noIdentityError() error {
+	return utils.HelpfulError(
+		"no identity found — cannot decrypt the vault",
+		"Set up an identity using one of these methods",
+		[]string{
+			"Run 'hulak init' to generate an age keypair",
+			"Import an existing key with 'hulak secrets import-key'",
+			fmt.Sprintf("Set %s to an AGE-SECRET-KEY- value (for CI)", utils.MasterKey),
+			fmt.Sprintf("Set %s to point at your SSH private key", utils.SSHIdentityEnvVar),
+			"Place an ed25519 SSH key at ~/.ssh/id_ed25519 (auto-detected)",
+		},
+	)
 }
 
 // parseMasterKey parses the HULAK_MASTER_KEY value with friendly errors.

--- a/pkg/vault/keys.go
+++ b/pkg/vault/keys.go
@@ -176,7 +176,7 @@ func ResolveIdentity() (*age.X25519Identity, error) {
 func parseMasterKey(raw string) (*age.X25519Identity, error) {
 	identity, err := age.ParseX25519Identity(raw)
 	if err != nil {
-		if strings.HasPrefix(raw, "age1") {
+		if strings.HasPrefix(raw, AgePrefix) {
 			return nil, fmt.Errorf(
 				"%s contains what looks like a public key (age1...), not a private key. "+
 					"Private keys start with AGE-SECRET-KEY-",

--- a/pkg/vault/keys_test.go
+++ b/pkg/vault/keys_test.go
@@ -327,8 +327,9 @@ func TestResolveIdentity(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ResolveIdentity() error: %v", err)
 		}
-		if got.String() != envID.String() {
-			t.Errorf("got %q, want env var identity %q", got.String(), envID.String())
+		x25519 := got.(*age.X25519Identity)
+		if x25519.String() != envID.String() {
+			t.Errorf("got %q, want env var identity %q", x25519.String(), envID.String())
 		}
 	})
 
@@ -345,8 +346,9 @@ func TestResolveIdentity(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ResolveIdentity() error: %v", err)
 		}
-		if got.String() != fileID.String() {
-			t.Errorf("got %q, want file identity %q", got.String(), fileID.String())
+		x25519 := got.(*age.X25519Identity)
+		if x25519.String() != fileID.String() {
+			t.Errorf("got %q, want file identity %q", x25519.String(), fileID.String())
 		}
 	})
 
@@ -363,8 +365,9 @@ func TestResolveIdentity(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ResolveIdentity() error: %v", err)
 		}
-		if got.String() != fileID.String() {
-			t.Errorf("got %q, want file identity %q", got.String(), fileID.String())
+		x25519 := got.(*age.X25519Identity)
+		if x25519.String() != fileID.String() {
+			t.Errorf("got %q, want file identity %q", x25519.String(), fileID.String())
 		}
 	})
 
@@ -377,8 +380,9 @@ func TestResolveIdentity(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ResolveIdentity() error: %v", err)
 		}
-		if got.String() != envID.String() {
-			t.Errorf("got %q, want %q", got.String(), envID.String())
+		x25519 := got.(*age.X25519Identity)
+		if x25519.String() != envID.String() {
+			t.Errorf("got %q, want %q", x25519.String(), envID.String())
 		}
 	})
 
@@ -412,9 +416,11 @@ func TestResolveIdentity(t *testing.T) {
 		}
 	})
 
-	t.Run("no env var and no file gives original error", func(t *testing.T) {
+	t.Run("no env var and no file gives helpful error", func(t *testing.T) {
 		setupConfigDir(t)
 		t.Setenv("HULAK_MASTER_KEY", "")
+		t.Setenv("HULAK_SSH_IDENTITY", "")
+		t.Setenv("HOME", t.TempDir()) // empty home, no ~/.ssh/id_ed25519
 
 		_, err := ResolveIdentity()
 		if err == nil {
@@ -706,6 +712,109 @@ func TestLoadIdentityOld(t *testing.T) {
 		_, err := LoadIdentityOld()
 		if err == nil {
 			t.Error("LoadIdentityOld() should error when no .old file")
+		}
+	})
+}
+
+func TestResolveIdentitySSHFallback(t *testing.T) {
+	t.Run("falls back to HULAK_SSH_IDENTITY", func(t *testing.T) {
+		setupConfigDir(t) // no identity.txt
+		t.Setenv("HULAK_MASTER_KEY", "")
+		t.Setenv("HULAK_SSH_IDENTITY", "")
+
+		dir := t.TempDir()
+		keyPath, _ := writeTestSSHKey(t, dir)
+		t.Setenv("HULAK_SSH_IDENTITY", keyPath)
+
+		got, err := ResolveIdentity()
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("identity is nil")
+		}
+	})
+
+	t.Run("falls back to default SSH key", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+		t.Setenv("HULAK_SSH_IDENTITY", "")
+
+		home := t.TempDir()
+		sshDir := filepath.Join(home, ".ssh")
+		if err := os.MkdirAll(sshDir, 0o700); err != nil {
+			t.Fatalf("mkdir .ssh: %v", err)
+		}
+		writeTestSSHKey(t, sshDir)
+		t.Setenv("HOME", home)
+
+		got, err := ResolveIdentity()
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("identity is nil")
+		}
+	})
+
+	t.Run("age identity.txt wins over SSH", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+		t.Setenv("HULAK_SSH_IDENTITY", "")
+
+		ageID, _ := age.GenerateX25519Identity()
+		if err := SetIdentity(ageID.String()); err != nil {
+			t.Fatalf("SetIdentity: %v", err)
+		}
+
+		dir := t.TempDir()
+		keyPath, _ := writeTestSSHKey(t, dir)
+		t.Setenv("HULAK_SSH_IDENTITY", keyPath)
+
+		got, err := ResolveIdentity()
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		x25519, ok := got.(*age.X25519Identity)
+		if !ok {
+			t.Fatal("expected X25519Identity when identity.txt exists")
+		}
+		if x25519.String() != ageID.String() {
+			t.Error("should use age identity over SSH")
+		}
+	})
+
+	t.Run("HULAK_MASTER_KEY wins over everything", func(t *testing.T) {
+		setupConfigDir(t)
+		envID, _ := age.GenerateX25519Identity()
+		t.Setenv("HULAK_MASTER_KEY", envID.String())
+
+		dir := t.TempDir()
+		keyPath, _ := writeTestSSHKey(t, dir)
+		t.Setenv("HULAK_SSH_IDENTITY", keyPath)
+
+		got, err := ResolveIdentity()
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		x25519, ok := got.(*age.X25519Identity)
+		if !ok {
+			t.Fatal("expected X25519Identity from HULAK_MASTER_KEY")
+		}
+		if x25519.String() != envID.String() {
+			t.Error("HULAK_MASTER_KEY should win")
+		}
+	})
+
+	t.Run("no identity anywhere gives helpful error", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+		t.Setenv("HULAK_SSH_IDENTITY", "")
+		t.Setenv("HOME", t.TempDir()) // empty home, no ~/.ssh/id_ed25519
+
+		_, err := ResolveIdentity()
+		if err == nil {
+			t.Fatal("expected error")
 		}
 	})
 }

--- a/pkg/vault/recipients.go
+++ b/pkg/vault/recipients.go
@@ -31,7 +31,8 @@ func RecipientsFilePath() (string, error) {
 	return filepath.Join(markerPath, utils.RecipientsFile), nil
 }
 
-// LoadRecipients reads .hulak/recipients.txt via age.ParseRecipients.
+// LoadRecipients reads .hulak/recipients.txt and returns age.Recipient values.
+// Supports both age (age1...) and SSH (ssh-ed25519, ssh-rsa) key formats.
 // Returns error if the file is missing or contains zero recipients.
 func LoadRecipients() ([]age.Recipient, error) {
 	path, err := RecipientsFilePath()
@@ -44,16 +45,12 @@ func LoadRecipients() ([]age.Recipient, error) {
 		return nil, fmt.Errorf("failed to read recipients file: %w", err)
 	}
 
-	recipients, err := age.ParseRecipients(bytes.NewReader(data))
+	entries, err := ParseRecipientsFileContent(data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse recipients: %w", err)
+		return nil, err
 	}
 
-	if len(recipients) == 0 {
-		return nil, fmt.Errorf("recipients file contains no valid recipients")
-	}
-
-	return recipients, nil
+	return RecipientsFromEntries(entries)
 }
 
 // ParseRecipientsFileContent reads raw bytes and returns structured entries
@@ -123,9 +120,10 @@ func SaveRecipients(entries []RecipientEntry) error {
 
 // AddRecipientEntry validates the new key, checks for duplicates, and returns
 // the updated entry list. Does not write to disk — caller does that.
-func AddRecipientEntry(entries []RecipientEntry, pubKey, name string) ([]RecipientEntry, error) {
-	if _, err := age.ParseX25519Recipient(pubKey); err != nil {
-		return nil, fmt.Errorf("invalid age public key: %w", err)
+// Set allowRSA to true to accept ssh-rsa keys.
+func AddRecipientEntry(entries []RecipientEntry, pubKey, name string, allowRSA bool) ([]RecipientEntry, error) {
+	if _, _, err := ParseRecipientKey(pubKey, allowRSA); err != nil {
+		return nil, err
 	}
 
 	for _, e := range entries {
@@ -212,12 +210,14 @@ func SwapRecipientKey(
 }
 
 // RecipientsFromEntries converts RecipientEntry slice to age.Recipient slice.
+// Accepts all key types already present in recipients.txt (including ssh-rsa),
+// since they were validated at add time.
 func RecipientsFromEntries(entries []RecipientEntry) ([]age.Recipient, error) {
 	recipients := make([]age.Recipient, len(entries))
 	for i, e := range entries {
-		r, err := age.ParseX25519Recipient(e.Key)
+		r, _, err := ParseRecipientKey(e.Key, true)
 		if err != nil {
-			return nil, fmt.Errorf("invalid key in recipients: %w", err)
+			return nil, fmt.Errorf("invalid key in recipients.txt line %d: %w", i+1, err)
 		}
 		recipients[i] = r
 	}

--- a/pkg/vault/recipients_test.go
+++ b/pkg/vault/recipients_test.go
@@ -219,7 +219,7 @@ func TestAddRecipientEntry(t *testing.T) {
 		key2, _ := GenerateKeyPair()
 
 		existing := []RecipientEntry{{Key: key1.Recipient.String(), Name: "Alice"}}
-		got, err := AddRecipientEntry(existing, key2.Recipient.String(), "Bob")
+		got, err := AddRecipientEntry(existing, key2.Recipient.String(), "Bob", false)
 		if err != nil {
 			t.Fatalf("error: %v", err)
 		}
@@ -231,14 +231,14 @@ func TestAddRecipientEntry(t *testing.T) {
 	t.Run("rejects duplicate key", func(t *testing.T) {
 		key1, _ := GenerateKeyPair()
 		existing := []RecipientEntry{{Key: key1.Recipient.String(), Name: "Alice"}}
-		_, err := AddRecipientEntry(existing, key1.Recipient.String(), "Alice Again")
+		_, err := AddRecipientEntry(existing, key1.Recipient.String(), "Alice Again", false)
 		if err == nil {
 			t.Fatal("expected duplicate error")
 		}
 	})
 
 	t.Run("rejects malformed key", func(t *testing.T) {
-		_, err := AddRecipientEntry(nil, "not-a-valid-key", "Bad")
+		_, err := AddRecipientEntry(nil, "not-a-valid-key", "Bad", false)
 		if err == nil {
 			t.Fatal("expected parse error")
 		}
@@ -246,7 +246,7 @@ func TestAddRecipientEntry(t *testing.T) {
 
 	t.Run("no name produces empty Name field", func(t *testing.T) {
 		key1, _ := GenerateKeyPair()
-		got, err := AddRecipientEntry(nil, key1.Recipient.String(), "")
+		got, err := AddRecipientEntry(nil, key1.Recipient.String(), "", false)
 		if err != nil {
 			t.Fatalf("error: %v", err)
 		}

--- a/pkg/vault/ssh_identity.go
+++ b/pkg/vault/ssh_identity.go
@@ -1,0 +1,87 @@
+package vault
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"filippo.io/age"
+	"filippo.io/age/agessh"
+	"github.com/xaaha/hulak/pkg/utils"
+	"golang.org/x/crypto/ssh"
+)
+
+// Contains SSH private key loading for vault decryption.
+// SSH ed25519 (and rsa) keys are converted into age.Identity values
+// via the agessh bridge so the same Decrypt() path works for both
+// native age keys and SSH keys.
+
+// LoadSSHIdentity reads an SSH private key file at path and returns an
+// age.Identity suitable for vault decryption.
+//
+// For unencrypted keys the identity is ready immediately.
+// For passphrase-protected keys the passphrase is prompted interactively
+// on stderr/stdin at first use (lazy — the callback fires inside age.Decrypt).
+func LoadSSHIdentity(path string) (age.Identity, error) {
+	pemBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read SSH key %s: %w", path, err)
+	}
+
+	// Try parsing as an unencrypted key first.
+	identity, err := agessh.ParseIdentity(pemBytes)
+	if err == nil {
+		return identity, nil
+	}
+
+	// Check whether the key is passphrase-protected.
+	if identity, encErr := tryPassphraseProtectedKey(pemBytes, path); encErr == nil {
+		return identity, nil
+	}
+
+	// Neither unencrypted parse nor encrypted detection succeeded.
+	return nil, fmt.Errorf(
+		"failed to parse SSH key %s: %w\n"+
+			"Expected an OpenSSH-formatted private key (ssh-keygen generates this by default)",
+		path, err,
+	)
+}
+
+// tryPassphraseProtectedKey detects if pemBytes is a passphrase-protected SSH key
+// and returns a lazy-decrypting identity that prompts on first use.
+func tryPassphraseProtectedKey(pemBytes []byte, path string) (age.Identity, error) {
+	var passErr *ssh.PassphraseMissingError
+
+	// attempt to parse, could work
+	_, rawErr := ssh.ParseRawPrivateKey(pemBytes)
+	if !errors.As(rawErr, &passErr) || passErr.PublicKey == nil {
+		return nil, fmt.Errorf("not a passphrase-protected key")
+	}
+
+	return agessh.NewEncryptedSSHIdentity(
+		passErr.PublicKey,
+		pemBytes,
+		func() ([]byte, error) { return readPassphrase(path) },
+	)
+}
+
+// readPassphrase prompts for a passphrase with no echo using the centralized prompt.
+func readPassphrase(keyPath string) ([]byte, error) {
+	pass, err := utils.PromptSecret(fmt.Sprintf("Enter passphrase for %s: ", keyPath))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read passphrase: %w", err)
+	}
+	return []byte(pass), nil
+}
+
+// DefaultSSHIdentityPath returns the default SSH private key path
+// (~/.ssh/id_ed25519). Returns empty string if the home directory
+// cannot be determined. Uses filepath.Join for cross-platform separators.
+func DefaultSSHIdentityPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, utils.SSHKeyDir, utils.SSHKeyFile)
+}

--- a/pkg/vault/ssh_identity.go
+++ b/pkg/vault/ssh_identity.go
@@ -83,5 +83,5 @@ func DefaultSSHIdentityPath() string {
 	if err != nil {
 		return ""
 	}
-	return filepath.Join(home, utils.SSHKeyDir, utils.SSHKeyFile)
+	return filepath.Join(home, sshKeyDir, sshKeyFile)
 }

--- a/pkg/vault/ssh_identity_test.go
+++ b/pkg/vault/ssh_identity_test.go
@@ -1,0 +1,105 @@
+package vault
+
+import (
+	"crypto/ed25519"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// writeTestSSHKey generates an unencrypted ed25519 SSH private key, writes it
+// to dir/id_ed25519, and returns the file path plus the public key in
+// authorized_keys format.
+func writeTestSSHKey(t *testing.T, dir string) (keyPath string, pubKeyStr string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey: %v", err)
+	}
+	pemBlock, err := ssh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		t.Fatalf("MarshalPrivateKey: %v", err)
+	}
+	keyPath = filepath.Join(dir, "id_ed25519")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(pemBlock), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		t.Fatalf("NewPublicKey: %v", err)
+	}
+	pubKeyStr = strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshPub)))
+	return keyPath, pubKeyStr
+}
+
+func TestLoadSSHIdentity(t *testing.T) {
+	t.Run("loads unencrypted ed25519 key", func(t *testing.T) {
+		dir := t.TempDir()
+		keyPath, _ := writeTestSSHKey(t, dir)
+
+		identity, err := LoadSSHIdentity(keyPath)
+		if err != nil {
+			t.Fatalf("LoadSSHIdentity() error: %v", err)
+		}
+		if identity == nil {
+			t.Fatal("LoadSSHIdentity() returned nil identity")
+		}
+	})
+
+	t.Run("errors on missing file", func(t *testing.T) {
+		_, err := LoadSSHIdentity("/tmp/nonexistent_key_file_12345")
+		if err == nil {
+			t.Fatal("LoadSSHIdentity() should error on missing file")
+		}
+	})
+
+	t.Run("errors on non-SSH content", func(t *testing.T) {
+		dir := t.TempDir()
+		badPath := filepath.Join(dir, "not_ssh")
+		if err := os.WriteFile(badPath, []byte("this is plain text, not an SSH key"), 0o600); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+
+		_, err := LoadSSHIdentity(badPath)
+		if err == nil {
+			t.Fatal("LoadSSHIdentity() should error on non-SSH content")
+		}
+		if !strings.Contains(err.Error(), "OpenSSH") {
+			t.Errorf("error %q should mention OPENSSH format", err.Error())
+		}
+	})
+
+	t.Run("errors on empty file", func(t *testing.T) {
+		dir := t.TempDir()
+		emptyPath := filepath.Join(dir, "empty_key")
+		if err := os.WriteFile(emptyPath, []byte(""), 0o600); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+
+		_, err := LoadSSHIdentity(emptyPath)
+		if err == nil {
+			t.Fatal("LoadSSHIdentity() should error on empty file")
+		}
+		if !strings.Contains(err.Error(), "OpenSSH") {
+			t.Errorf("error %q should mention OPENSSH format", err.Error())
+		}
+	})
+}
+
+func TestDefaultSSHIdentityPath(t *testing.T) {
+	got := DefaultSSHIdentityPath()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+
+	want := filepath.Join(home, ".ssh", "id_ed25519")
+	if got != want {
+		t.Errorf("DefaultSSHIdentityPath() = %q, want %q", got, want)
+	}
+}

--- a/pkg/vault/ssh_recipients.go
+++ b/pkg/vault/ssh_recipients.go
@@ -49,6 +49,13 @@ func ClassifyKeyType(key string) KeyType {
 func ParseRecipientKey(key string, allowRSA bool) (age.Recipient, KeyType, error) {
 	k := strings.TrimSpace(key)
 
+	// Sanity check: public keys are short. A line longer than this is not a
+	// valid key — reject early before handing to the ssh parser.
+	const maxKeyLen = 8 << 10 // 8 KiB — generous for RSA 4096; ed25519 is ~80 bytes
+	if len(k) > maxKeyLen {
+		return nil, "", fmt.Errorf("key too large (%d bytes, max %d)", len(k), maxKeyLen)
+	}
+
 	// Try age X25519 first
 	if strings.HasPrefix(k, AgePrefix) {
 		r, err := age.ParseX25519Recipient(k)

--- a/pkg/vault/ssh_recipients.go
+++ b/pkg/vault/ssh_recipients.go
@@ -1,0 +1,97 @@
+package vault
+
+import (
+	"fmt"
+	"strings"
+
+	"filippo.io/age"
+	"filippo.io/age/agessh"
+	"github.com/xaaha/hulak/pkg/utils"
+	"golang.org/x/crypto/ssh"
+)
+
+// Contains SSH-aware recipient key parsing: detects key type from a string
+// and returns an age.Recipient suitable for encryption.
+
+// KeyType classifies the format of a public key string.
+// For SSH keys, the value is the protocol's key type field (e.g. "ssh-ed25519").
+// ClassifyKeyType derives it from the key itself.
+type KeyType string
+
+// ClassifyKeyType extracts the key type from a public key string.
+// For SSH keys (space-delimited), returns the first field (e.g. "ssh-ed25519").
+// For age keys (age1... prefix), returns "age".
+// Returns empty string for unrecognized formats.
+func ClassifyKeyType(key string) KeyType {
+	k := strings.TrimSpace(key)
+
+	if strings.HasPrefix(k, AgePrefix) {
+		return Age
+	}
+
+	// SSH authorized_keys format: "<type> <base64data> [comment]"
+	if typ, _, ok := strings.Cut(k, " "); ok {
+		return KeyType(typ)
+	}
+
+	return ""
+}
+
+// ParseRecipientKey parses a public key string and returns an age.Recipient.
+//
+// Supported formats:
+//   - age X25519 keys (age1...)
+//   - SSH ed25519 keys (ssh-ed25519 ...)
+//   - SSH RSA keys (ssh-rsa ...) — only when allowRSA is true
+//
+// Unsupported SSH key types (ecdsa, dsa, etc.) are rejected.
+// Key type detection is handled by the ssh library — no hardcoded type strings.
+func ParseRecipientKey(key string, allowRSA bool) (age.Recipient, KeyType, error) {
+	k := strings.TrimSpace(key)
+
+	// Try age X25519 first
+	if strings.HasPrefix(k, AgePrefix) {
+		r, err := age.ParseX25519Recipient(k)
+		if err != nil {
+			return nil, Age, fmt.Errorf("invalid age key %q: %w", truncateKey(k), err)
+		}
+		return r, Age, nil
+	}
+
+	// Try SSH: let the ssh library parse and tell us the type
+	pubKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(k))
+	if err != nil {
+		return nil, "", fmt.Errorf("unrecognized recipient format: %s", truncateKey(k))
+	}
+
+	kt := KeyType(pubKey.Type())
+
+	// RSA needs explicit opt-in
+	if pubKey.Type() == ssh.KeyAlgoRSA && !allowRSA {
+		return nil, kt, fmt.Errorf(
+			"%s keys are not accepted by default (slow, large ciphertexts); "+
+				"use --allow-rsa to override", kt,
+		)
+	}
+
+	// Let agessh handle the actual recipient creation.
+	// It supports ed25519 and rsa; rejects everything else (ecdsa, dsa, etc.)
+	r, err := agessh.ParseRecipient(k)
+	if err != nil {
+		return nil, kt, fmt.Errorf(
+			"%s keys are not supported by age encryption — use ed25519 or age keys", kt,
+		)
+	}
+
+	return r, kt, nil
+}
+
+// truncateKey shortens a key string for display in error messages.
+// Keys longer than 40 characters are trimmed with "..." appended.
+func truncateKey(key string) string {
+	const maxLen = 40
+	if len(key) <= maxLen {
+		return key
+	}
+	return key[:maxLen] + utils.Ellipsis
+}

--- a/pkg/vault/ssh_recipients_test.go
+++ b/pkg/vault/ssh_recipients_test.go
@@ -1,0 +1,243 @@
+package vault
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// testSSHEd25519PubKey generates a fresh SSH ed25519 public key string
+// in authorized_keys format (e.g. "ssh-ed25519 AAAA...").
+func testSSHEd25519PubKey(t *testing.T) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey: %v", err)
+	}
+	sshPub, err := ssh.NewPublicKey(priv.Public())
+	if err != nil {
+		t.Fatalf("NewPublicKey: %v", err)
+	}
+	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshPub)))
+}
+
+// testSSHRSAPubKey generates a fresh SSH RSA public key string
+// in authorized_keys format (e.g. "ssh-rsa AAAA...").
+func testSSHRSAPubKey(t *testing.T) string {
+	t.Helper()
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	sshPub, err := ssh.NewPublicKey(&privKey.PublicKey)
+	if err != nil {
+		t.Fatalf("NewPublicKey: %v", err)
+	}
+	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshPub)))
+}
+
+func TestClassifyKeyType(t *testing.T) {
+	ed25519Key := testSSHEd25519PubKey(t)
+	rsaKey := testSSHRSAPubKey(t)
+
+	tests := []struct {
+		name string
+		key  string
+		want KeyType
+	}{
+		{
+			name: "age X25519 key",
+			key:  "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",
+			want: "age",
+		},
+		{
+			name: "ssh-ed25519 key",
+			key:  ed25519Key,
+			want: "ssh-ed25519",
+		},
+		{
+			name: "ssh-rsa key",
+			key:  rsaKey,
+			want: "ssh-rsa",
+		},
+		{
+			name: "ecdsa key",
+			key:  "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTY=",
+			want: "ecdsa-sha2-nistp256",
+		},
+		{
+			name: "unknown key",
+			key:  "not-a-real-key",
+			want: "",
+		},
+		{
+			name: "empty string",
+			key:  "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyKeyType(tt.key)
+			if got != tt.want {
+				t.Errorf("ClassifyKeyType(%q) = %v, want %v", truncateKey(tt.key), got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseRecipientKey(t *testing.T) {
+	ed25519Key := testSSHEd25519PubKey(t)
+	rsaKey := testSSHRSAPubKey(t)
+
+	t.Run("parse age X25519 key", func(t *testing.T) {
+		key := "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
+		r, kt, err := ParseRecipientKey(key, false)
+		if err != nil {
+			t.Fatalf("ParseRecipientKey() error: %v", err)
+		}
+		if r == nil {
+			t.Fatal("ParseRecipientKey() returned nil recipient")
+		}
+		if kt != "age" {
+			t.Errorf("ParseRecipientKey() KeyType = %v, want age", kt)
+		}
+	})
+
+	t.Run("parse ssh-ed25519 key", func(t *testing.T) {
+		r, kt, err := ParseRecipientKey(ed25519Key, false)
+		if err != nil {
+			t.Fatalf("ParseRecipientKey() error: %v", err)
+		}
+		if r == nil {
+			t.Fatal("ParseRecipientKey() returned nil recipient")
+		}
+		if kt != "ssh-ed25519" {
+			t.Errorf("ParseRecipientKey() KeyType = %v, want ssh-ed25519", kt)
+		}
+	})
+
+	t.Run("reject ssh-rsa by default", func(t *testing.T) {
+		_, _, err := ParseRecipientKey(rsaKey, false)
+		if err == nil {
+			t.Fatal("ParseRecipientKey() should reject ssh-rsa by default")
+		}
+		if !strings.Contains(err.Error(), "--allow-rsa") {
+			t.Errorf("error should mention --allow-rsa, got: %v", err)
+		}
+	})
+
+	t.Run("reject ecdsa", func(t *testing.T) {
+		_, _, err := ParseRecipientKey("ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTY=", false)
+		if err == nil {
+			t.Fatal("ParseRecipientKey() should reject ecdsa")
+		}
+		if !strings.Contains(err.Error(), "ecdsa") {
+			t.Errorf("error should mention ecdsa, got: %v", err)
+		}
+	})
+
+	t.Run("reject unrecognized format", func(t *testing.T) {
+		_, _, err := ParseRecipientKey("not-a-real-key-format", false)
+		if err == nil {
+			t.Fatal("ParseRecipientKey() should reject unrecognized format")
+		}
+		if !strings.Contains(err.Error(), "unrecognized recipient format") {
+			t.Errorf("error should mention unrecognized, got: %v", err)
+		}
+	})
+
+	t.Run("trim whitespace", func(t *testing.T) {
+		key := "  age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p  \n"
+		r, kt, err := ParseRecipientKey(key, false)
+		if err != nil {
+			t.Fatalf("ParseRecipientKey() error: %v", err)
+		}
+		if r == nil {
+			t.Fatal("ParseRecipientKey() returned nil recipient")
+		}
+		if kt != "age" {
+			t.Errorf("ParseRecipientKey() KeyType = %v, want age", kt)
+		}
+	})
+
+	t.Run("trim whitespace on ssh-ed25519", func(t *testing.T) {
+		key := "  " + ed25519Key + "  \n"
+		r, kt, err := ParseRecipientKey(key, false)
+		if err != nil {
+			t.Fatalf("ParseRecipientKey() error: %v", err)
+		}
+		if r == nil {
+			t.Fatal("ParseRecipientKey() returned nil recipient")
+		}
+		if kt != "ssh-ed25519" {
+			t.Errorf("ParseRecipientKey() KeyType = %v, want ssh-ed25519", kt)
+		}
+	})
+}
+
+func TestParseRecipientKeyAllowRSA(t *testing.T) {
+	rsaKey := testSSHRSAPubKey(t)
+
+	t.Run("accept ssh-rsa when allowed", func(t *testing.T) {
+		r, kt, err := ParseRecipientKey(rsaKey, true)
+		if err != nil {
+			t.Fatalf("ParseRecipientKey(allowRSA=true) error: %v", err)
+		}
+		if r == nil {
+			t.Fatal("ParseRecipientKey(allowRSA=true) returned nil recipient")
+		}
+		if kt != "ssh-rsa" {
+			t.Errorf("ParseRecipientKey(allowRSA=true) KeyType = %v, want ssh-rsa", kt)
+		}
+	})
+
+	t.Run("still reject ecdsa when rsa allowed", func(t *testing.T) {
+		_, _, err := ParseRecipientKey("ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTY=", true)
+		if err == nil {
+			t.Fatal("ParseRecipientKey(allowRSA=true) should still reject ecdsa")
+		}
+	})
+}
+
+func TestTruncateKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "short key",
+			input: "age1abc",
+			want:  "age1abc",
+		},
+		{
+			name:  "exactly 40 chars",
+			input: strings.Repeat("a", 40),
+			want:  strings.Repeat("a", 40),
+		},
+		{
+			name:  "longer than 40 chars",
+			input: strings.Repeat("a", 50),
+			want:  strings.Repeat("a", 40) + "...",
+		},
+		{
+			name:  "empty",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := truncateKey(tt.input); got != tt.want {
+				t.Errorf("truncateKey(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Support SSH ed25519 keys as both **recipients** (public keys for encryption) and **identities** (private keys for decryption)
- Add `--github <username>` flag to fetch SSH keys directly from GitHub for zero-friction team onboarding
- Add `--keyserver <url>` for self-hosted GitLab/Forgejo/Codeberg
- Add `--ssh-identity` flag and `HULAK_SSH_IDENTITY` env var for SSH key selection
- Add `--allow-rsa` flag for opt-in ssh-rsa support
- Centralize HTTP client in new `pkg/httpclient` package (shared by runner and key fetcher)
- Centralize secret prompting in `utils.PromptSecret`
- Add TYPE column to `list-recipients` output

### Identity fallback chain
`HULAK_MASTER_KEY` → `identity.txt` → `HULAK_SSH_IDENTITY` → `~/.ssh/id_ed25519`

### Flagship use case
```bash
# Add teammate — no key exchange needed
hulak secrets add-recipient --github alice --name Alice

# Teammate decrypts — just works with their SSH key
hulak secrets get API_KEY --env prod
```

## New files
- `pkg/httpclient/` — shared HTTP client with redirect policy, body limits
- `pkg/vault/ssh_recipients.go` — SSH-aware recipient key parsing
- `pkg/vault/ssh_identity.go` — SSH private key loading with passphrase support
- `pkg/vault/github_keys.go` — GitHub/keyserver key fetching

## Test plan
- [ ] `mise check` passes (lint + unit tests)
- [ ] `hulak secrets add-recipient --github <your-username> --name Test` fetches and adds keys
- [ ] `hulak secrets list-recipients` shows TYPE column (age vs ssh-ed25519)
- [ ] `hulak run` with no `identity.txt` but `~/.ssh/id_ed25519` present auto-detects SSH key
- [ ] `hulak run --ssh-identity <path>` uses specified SSH key
- [ ] `HULAK_SSH_IDENTITY=<path> hulak secrets get KEY` works
- [ ] Existing age-only workflows unchanged (no regression)

Closes #170