### PR TITLE
Vault-aware hulak doctor with --fix, --json, and health checks

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -125,13 +125,16 @@ By default, creates an encrypted vault (.hulak/store.age) plus an example 'apiOp
 Run 'hulak init classic' (aliases: plain, no-vault) to use the plaintext env/
 layout instead. Use -env to scaffold specific environments.
 
+Init generates an age keypair for encryption. After setup, you can use an SSH
+ed25519 key for vault operations by adding it as a recipient
+('hulak secrets add-recipient "ssh-ed25519 ..."') and setting HULAK_SSH_IDENTITY
+or passing --ssh-identity on commands like 'run'.
+
 ```bash
 hulak init
 hulak init -env staging prod
 hulak init classic
-hulak init plain
 hulak init classic -env staging prod
-hulak init classic --help
 ```
 
 Supported flags:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -149,6 +149,9 @@ Notes:
 
 Convert Postman v2.1 environment and collection JSON exports into hulak .hk.yaml and .env files.
 
+Only Postman collections and environments are supported at this time.
+To migrate plaintext env/ files to the encrypted vault, use 'hulak secrets migrate' instead.
+
 ```bash
 hulak migrate collection.json
 hulak migrate env.json collection.json
@@ -156,12 +159,25 @@ hulak migrate env.json collection.json
 
 ### `doctor`
 
-Inspect your hulak project for common issues: missing .gitignore entries,
-loose file permissions on env files, and secrets leaked into git history.
+Inspect your hulak project for common issues.
+
+Vault backend: identity, store, recipients, and drift checks.
+Classic backend: .gitignore, file permissions, git history.
 
 ```bash
 hulak doctor
+hulak doctor --fix
+hulak doctor --fix --yes
+hulak doctor --json
 ```
+
+Supported flags:
+
+| Flag | Meaning |
+| ---- | ------- |
+| `--fix` | Auto-repair safe issues (chmod, .gitignore) |
+| `--json` | Output findings as JSON to stdout |
+| `--yes` | Skip confirmation prompts (use with --fix) |
 
 ### `gql`
 

--- a/man/hulak.1
+++ b/man/hulak.1
@@ -14,7 +14,7 @@ hulak \- file-based API client for the terminal
 .br
 .B hulak migrate <files>
 .br
-.B hulak doctor
+.B hulak doctor [\-\-fix] [\-\-json] [\-\-yes]
 .br
 .B hulak gql [\-\-env] <path>
 .br
@@ -209,6 +209,15 @@ doctor:
 .PP
 .RS
 hulak doctor
+.RE
+.RS
+hulak doctor \-\-fix
+.RE
+.RS
+hulak doctor \-\-fix \-\-yes
+.RE
+.RS
+hulak doctor \-\-json
 .RE
 .PP
 gql:

--- a/man/hulak.1
+++ b/man/hulak.1
@@ -187,13 +187,7 @@ hulak init \-env staging prod
 hulak init classic
 .RE
 .RS
-hulak init plain
-.RE
-.RS
 hulak init classic \-env staging prod
-.RE
-.RS
-hulak init classic \-\-help
 .RE
 .PP
 migrate:

--- a/pkg/userFlags/doctor.go
+++ b/pkg/userFlags/doctor.go
@@ -2,50 +2,308 @@ package userflags
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
 )
 
-type warning struct {
-	message string
-	fix     string
+// severity ranks a doctor finding from informational to blocking.
+type severity int
+
+const (
+	sevInfo  severity = iota // context-only, does not affect exit code
+	sevOk                    // check passed
+	sevWarn                  // potential problem
+	sevError                 // must fix before vault is usable
+)
+
+func (s severity) String() string {
+	switch s {
+	case sevInfo:
+		return "info"
+	case sevOk:
+		return "ok"
+	case sevWarn:
+		return "warn"
+	case sevError:
+		return "error"
+	default:
+		return "unknown"
+	}
 }
 
-func runDoctor() {
-	envPath, err := utils.CreatePath(utils.EnvironmentFolder)
-	if err != nil {
-		utils.PrintWarning(fmt.Sprintf(
-			"%s/ could not be resolved", utils.EnvironmentFolder,
-		))
+// finding is a single doctor check result.
+type finding struct {
+	check    string       // stable ID, e.g. "identity-mode"
+	severity severity     // one of sevInfo / sevOk / sevWarn / sevError
+	message  string       // human-readable description
+	fix      string       // remediation advice (always informational)
+	auto     func() error // non-nil iff --fix can safely repair this
+}
+
+// doctorReport collects all findings for a single run.
+type doctorReport struct {
+	project  string
+	backend  string
+	findings []finding
+}
+
+// summary counts findings by severity.
+type summary struct {
+	Ok    int `json:"ok"`
+	Warn  int `json:"warn"`
+	Error int `json:"error"`
+	Info  int `json:"info"`
+}
+
+func (r *doctorReport) summary() summary {
+	var s summary
+	for _, f := range r.findings {
+		switch f.severity {
+		case sevInfo:
+			s.Info++
+		case sevOk:
+			s.Ok++
+		case sevWarn:
+			s.Warn++
+		case sevError:
+			s.Error++
+		}
+	}
+	return s
+}
+
+// exitCode returns 0 for ok/info-only, 1 for warnings, 2 for errors.
+func (r *doctorReport) exitCode() int {
+	s := r.summary()
+	if s.Error > 0 {
+		return 2
+	}
+	if s.Warn > 0 {
+		return 1
+	}
+	return 0
+}
+
+// --- human output (stderr) -------------------------------------------------
+
+func (r *doctorReport) printHuman() {
+	utils.PrintInfoStderr(fmt.Sprintf("Project: %s", r.project))
+	utils.PrintInfoStderr(fmt.Sprintf("Backend: %s\n", r.backend))
+
+	for _, f := range r.findings {
+		printFinding(f)
+	}
+
+	s := r.summary()
+	utils.PrintInfoStderr(fmt.Sprintf("\n%d ok, %d warning, %d error", s.Ok, s.Warn, s.Error))
+}
+
+func printFinding(f finding) {
+	switch f.severity {
+	case sevOk:
+		// ✔ message
+		fmt.Fprintf(os.Stderr, "%s%s%s %s\n", utils.Green, utils.CheckMark, utils.ColorReset, f.message)
+	case sevWarn:
+		// ⚠ warning: message
+		fmt.Fprintf(os.Stderr, "%s%s warning:%s %s\n", utils.Yellow, utils.WarningMark, utils.ColorReset, f.message)
+	case sevError:
+		// ✖ error: message
+		fmt.Fprintf(os.Stderr, "%s%s error:%s %s\n", utils.Red, utils.CrossMark, utils.ColorReset, f.message)
+	case sevInfo:
+		// ℹ info: message
+		fmt.Fprintf(os.Stderr, "%s%s info:%s %s\n", utils.Blue, utils.InfoMark, utils.ColorReset, f.message)
+	}
+	if f.fix != "" {
+		utils.PrintInfoStderr(fmt.Sprintf("  Fix: %s", f.fix))
+	}
+}
+
+// --- JSON output (stdout) --------------------------------------------------
+
+type jsonFinding struct {
+	Check       string `json:"check"`
+	Severity    string `json:"severity"`
+	Message     string `json:"message"`
+	Fix         string `json:"fix,omitempty"`
+	AutoFixable bool   `json:"auto_fixable"`
+}
+
+type jsonReport struct {
+	Project  string        `json:"project"`
+	Backend  string        `json:"backend"`
+	Findings []jsonFinding `json:"findings"`
+	Summary  summary       `json:"summary"`
+}
+
+func (r *doctorReport) printJSON() {
+	jf := make([]jsonFinding, len(r.findings))
+	for i, f := range r.findings {
+		jf[i] = jsonFinding{
+			Check:       f.check,
+			Severity:    f.severity.String(),
+			Message:     f.message,
+			Fix:         f.fix,
+			AutoFixable: f.auto != nil,
+		}
+	}
+	jr := jsonReport{
+		Project:  r.project,
+		Backend:  r.backend,
+		Findings: jf,
+		Summary:  r.summary(),
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(jr) // stdout write failure is unrecoverable
+}
+
+// --- --fix flow ------------------------------------------------------------
+
+func (r *doctorReport) runFixes(autoYes bool) {
+	for i, f := range r.findings {
+		if f.auto == nil {
+			continue
+		}
+		printFinding(f)
+
+		if !autoYes {
+			ok, err := utils.ConfirmAction("  Fix? [Y/n] ")
+			if err != nil || !ok {
+				continue
+			}
+		}
+
+		if err := f.auto(); err != nil {
+			utils.PrintErrorStderr(fmt.Sprintf("  failed: %v", err))
+			continue
+		}
+
+		// re-check shows green on success
+		r.findings[i].severity = sevOk
+		r.findings[i].fix = ""
+		r.findings[i].auto = nil
+		utils.PrintSuccessStderr("  fixed")
+	}
+}
+
+// --- orchestrator ----------------------------------------------------------
+
+type doctorOpts struct {
+	fix     bool
+	yes     bool
+	jsonOut bool
+}
+
+func runDoctor(opts doctorOpts) {
+	projectRoot, found := utils.FindProjectRoot()
+	storeType := vault.DetectStore()
+
+	if opts.fix && opts.jsonOut {
+		utils.PrintErrorStderr("--fix and --json are mutually exclusive")
+		os.Exit(1)
+	}
+
+	if !found || storeType == vault.StoreNone {
+		utils.PrintInfoStderr("Not a hulak project. Run 'hulak init' to start one.")
 		return
 	}
 
-	info, statErr := os.Stat(envPath)
-	if statErr != nil || !info.IsDir() {
-		utils.PrintWarning(fmt.Sprintf(
-			"%s/ directory not found. Create it:\n    hulak init", utils.EnvironmentFolder,
-		))
-		return
+	report := &doctorReport{project: projectRoot}
+
+	switch storeType {
+	case vault.StoreAge:
+		report.backend = "vault (.hulak/store.age)"
+		report.findings = collectVaultFindings()
+	case vault.StoreClassic:
+		report.backend = "classic (env/)"
+		report.findings = collectClassicFindings(projectRoot)
 	}
 
+	if opts.jsonOut {
+		report.printJSON()
+		os.Exit(report.exitCode())
+	}
+
+	if opts.fix {
+		report.printHuman()
+		report.runFixes(opts.yes)
+	} else {
+		report.printHuman()
+	}
+
+	os.Exit(report.exitCode())
+}
+
+// collectVaultFindings runs all vault-aware checks.
+func collectVaultFindings() []finding {
+	return append([]finding{},
+		// Bootstrap chain (checks 1-12)
+		checkIdentityPresent(),
+		checkIdentityMode(),
+		checkIdentityNotInGit(),
+		checkIdentityLeakedInProject(),
+		checkConfigDirMode(),
+		checkStoreMode(),
+		checkStoreEncrypted(),
+		checkStoreDecrypts(),
+		checkRecipientsExist(),
+		checkRecipientsValid(),
+		checkRecipientsMode(),
+		checkRecipientsCommitted(),
+		// Drift + remaining checks (13-18)
+		checkRecipientDrift(),
+		checkStoreNotGitignored(),
+		checkLegacyKeyPub(),
+		checkDualBackend(),
+		checkDualIdentity(),
+		checkStoreSize(),
+	)
+}
+
+// collectClassicFindings wraps legacy checks into findings and adds
+// an info-level suggestion to migrate to the vault backend.
+func collectClassicFindings(projectRoot string) []finding {
+	envPath := filepath.Join(projectRoot, utils.EnvironmentFolder)
+
+	// Print inventory header
 	printInventory(envPath)
 
+	// Run legacy checks and convert to findings
 	warnings := collectWarnings(envPath)
+
+	var findings []finding
 	if len(warnings) == 0 {
-		utils.PrintGreen(fmt.Sprintf("  %s No issues found", utils.CheckMark))
-		return
+		findings = append(findings, finding{
+			check:    "classic-health",
+			severity: sevOk,
+			message:  "classic backend looks healthy",
+		})
 	}
 	for _, w := range warnings {
-		msg := fmt.Sprintf("  %s %s", utils.CrossMark, w.message)
-		if w.fix != "" {
-			msg += "\n    " + w.fix
-		}
-		utils.PrintWarning(msg)
+		findings = append(findings, finding{
+			check:    "classic-issue",
+			severity: sevWarn,
+			message:  w.message,
+			fix:      w.fix,
+		})
 	}
+
+	// Suggest migration
+	findings = append(findings, finding{
+		check:    "migrate-suggestion",
+		severity: sevInfo,
+		message:  "consider migrating to the encrypted vault with 'hulak secrets migrate'",
+	})
+
+	return findings
 }
 
 func printInventory(envPath string) {
@@ -54,14 +312,21 @@ func printInventory(envPath string) {
 		return
 	}
 
-	fmt.Println(utils.EnvironmentFolder + "/")
+	utils.PrintInfoStderr(utils.EnvironmentFolder + "/")
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
 		}
-		fmt.Println("  " + e.Name())
+		utils.PrintInfoStderr("  " + e.Name())
 	}
-	fmt.Println()
+	utils.PrintInfoStderr("")
+}
+
+// --- legacy helpers (classic backend checks) ---
+
+type warning struct {
+	message string
+	fix     string
 }
 
 func collectWarnings(envPath string) []warning {

--- a/pkg/userFlags/doctor.go
+++ b/pkg/userFlags/doctor.go
@@ -13,6 +13,8 @@ import (
 	"github.com/xaaha/hulak/pkg/vault"
 )
 
+// --- severity ----------------------------------------------------------------
+
 // severity ranks a doctor finding from informational to blocking.
 type severity int
 
@@ -38,6 +40,22 @@ func (s severity) String() string {
 	}
 }
 
+// sevDisplay maps a severity to its terminal presentation.
+type sevDisplay struct {
+	color string
+	mark  string
+	label string // prefix for human output; empty for sevOk
+}
+
+var sevDisplays = [4]sevDisplay{
+	sevInfo:  {utils.Blue, utils.InfoMark, "info:"},
+	sevOk:    {utils.Green, utils.CheckMark, ""},
+	sevWarn:  {utils.Yellow, utils.WarningMark, "warning:"},
+	sevError: {utils.Red, utils.CrossMark, "error:"},
+}
+
+// --- finding -----------------------------------------------------------------
+
 // finding is a single doctor check result.
 type finding struct {
 	check    string       // stable ID, e.g. "identity-mode"
@@ -46,6 +64,16 @@ type finding struct {
 	fix      string       // remediation advice (always informational)
 	auto     func() error // non-nil iff --fix can safely repair this
 }
+
+func skipFinding(check, reason string) finding {
+	return finding{check: check, severity: sevInfo, message: reason}
+}
+
+func okFinding(check, msg string) finding {
+	return finding{check: check, severity: sevOk, message: msg}
+}
+
+// --- report ------------------------------------------------------------------
 
 // doctorReport collects all findings for a single run.
 type doctorReport struct {
@@ -91,7 +119,7 @@ func (r *doctorReport) exitCode() int {
 	return 0
 }
 
-// --- human output (stderr) -------------------------------------------------
+// --- human output (stderr) ---------------------------------------------------
 
 func (r *doctorReport) printHuman() {
 	utils.PrintInfoStderr(fmt.Sprintf("Project: %s", r.project))
@@ -106,26 +134,18 @@ func (r *doctorReport) printHuman() {
 }
 
 func printFinding(f finding) {
-	switch f.severity {
-	case sevOk:
-		// ✔ message
-		fmt.Fprintf(os.Stderr, "%s%s%s %s\n", utils.Green, utils.CheckMark, utils.ColorReset, f.message)
-	case sevWarn:
-		// ⚠ warning: message
-		fmt.Fprintf(os.Stderr, "%s%s warning:%s %s\n", utils.Yellow, utils.WarningMark, utils.ColorReset, f.message)
-	case sevError:
-		// ✖ error: message
-		fmt.Fprintf(os.Stderr, "%s%s error:%s %s\n", utils.Red, utils.CrossMark, utils.ColorReset, f.message)
-	case sevInfo:
-		// ℹ info: message
-		fmt.Fprintf(os.Stderr, "%s%s info:%s %s\n", utils.Blue, utils.InfoMark, utils.ColorReset, f.message)
+	d := sevDisplays[f.severity]
+	if d.label != "" {
+		fmt.Fprintf(os.Stderr, "%s%s %s%s %s\n", d.color, d.mark, d.label, utils.ColorReset, f.message)
+	} else {
+		fmt.Fprintf(os.Stderr, "%s%s%s %s\n", d.color, d.mark, utils.ColorReset, f.message)
 	}
 	if f.fix != "" {
 		utils.PrintInfoStderr(fmt.Sprintf("  Fix: %s", f.fix))
 	}
 }
 
-// --- JSON output (stdout) --------------------------------------------------
+// --- JSON output (stdout) ----------------------------------------------------
 
 type jsonFinding struct {
 	Check       string `json:"check"`
@@ -153,19 +173,18 @@ func (r *doctorReport) printJSON() {
 			AutoFixable: f.auto != nil,
 		}
 	}
-	jr := jsonReport{
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(jsonReport{
 		Project:  r.project,
 		Backend:  r.backend,
 		Findings: jf,
 		Summary:  r.summary(),
-	}
-
-	enc := json.NewEncoder(os.Stdout)
-	enc.SetIndent("", "  ")
-	_ = enc.Encode(jr) // stdout write failure is unrecoverable
+	})
 }
 
-// --- --fix flow ------------------------------------------------------------
+// --- --fix flow --------------------------------------------------------------
 
 // runFixes applies auto-fixable findings. Findings were already printed by
 // printHuman, so this only shows the fix prompt and result.
@@ -194,7 +213,7 @@ func (r *doctorReport) runFixes(autoYes bool) {
 	}
 }
 
-// --- orchestrator ----------------------------------------------------------
+// --- orchestrator ------------------------------------------------------------
 
 type doctorOpts struct {
 	fix     bool
@@ -246,72 +265,44 @@ func runDoctor(opts doctorOpts) int {
 
 // collectVaultFindings runs all vault-aware checks.
 func collectVaultFindings() []finding {
-	return append([]finding{},
-		// Bootstrap chain (checks 1-12)
+	return []finding{
+		// Identity chain
 		checkIdentityPresent(),
 		checkIdentityMode(),
 		checkIdentityNotInGit(),
 		checkIdentityLeakedInProject(),
-		checkConfigDirMode(),
+		// Store
 		checkStoreMode(),
 		checkStoreEncrypted(),
 		checkStoreDecrypts(),
+		// Recipients
 		checkRecipientsExist(),
 		checkRecipientsValid(),
-		checkRecipientsMode(),
 		checkRecipientsCommitted(),
-		// Drift + remaining checks (13-18)
+		// Drift + misc
 		checkRecipientDrift(),
 		checkStoreNotGitignored(),
 		checkLegacyKeyPub(),
 		checkDualBackend(),
 		checkDualIdentity(),
 		checkStoreSize(),
-	)
+	}
 }
 
-// collectClassicFindings wraps legacy checks into findings and adds
-// an info-level suggestion to migrate to the vault backend.
+// collectClassicFindings runs classic-backend checks and suggests migration.
 func collectClassicFindings(projectRoot string) []finding {
 	envPath := filepath.Join(projectRoot, utils.EnvironmentFolder)
-
 	printInventory(envPath)
 
 	var findings []finding
-	for _, w := range checkGitignore() {
-		findings = append(findings, finding{
-			check:    "classic-gitignore",
-			severity: sevWarn,
-			message:  w.message,
-			fix:      w.fix,
-		})
-	}
-	for _, w := range checkEnvPermissions(envPath) {
-		findings = append(findings, finding{
-			check:    "classic-permissions",
-			severity: sevWarn,
-			message:  w.message,
-			fix:      w.fix,
-		})
-	}
-	for _, w := range checkGitHistory() {
-		findings = append(findings, finding{
-			check:    "classic-git-history",
-			severity: sevWarn,
-			message:  w.message,
-			fix:      w.fix,
-		})
-	}
+	findings = append(findings, checkGitignore()...)
+	findings = append(findings, checkEnvPermissions(envPath)...)
+	findings = append(findings, checkGitHistory()...)
 
 	if len(findings) == 0 {
-		findings = append(findings, finding{
-			check:    "classic-health",
-			severity: sevOk,
-			message:  "classic backend looks healthy",
-		})
+		findings = append(findings, okFinding("classic-health", "classic backend looks healthy"))
 	}
 
-	// Suggest migration
 	findings = append(findings, finding{
 		check:    "migrate-suggestion",
 		severity: sevInfo,
@@ -321,69 +312,27 @@ func collectClassicFindings(projectRoot string) []finding {
 	return findings
 }
 
-func printInventory(envPath string) {
-	entries, err := os.ReadDir(envPath)
-	if err != nil {
-		return
+// --- classic checks ----------------------------------------------------------
+
+func checkGitignore() []finding {
+	notIgnored := finding{
+		check:    "classic-gitignore",
+		severity: sevWarn,
+		message:  fmt.Sprintf("%s/ is not gitignored — secrets may be committed", utils.EnvironmentFolder),
+		fix:      fmt.Sprintf("echo \"%s/\" >> .gitignore", utils.EnvironmentFolder),
 	}
 
-	utils.PrintInfoStderr(utils.EnvironmentFolder + "/")
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		utils.PrintInfoStderr("  " + e.Name())
-	}
-	utils.PrintInfoStderr("")
-}
-
-// --- legacy helpers (classic backend checks) ---
-
-type warning struct {
-	message string
-	fix     string
-}
-
-func collectWarnings(envPath string) []warning {
-	var warnings []warning
-	warnings = append(warnings, checkGitignore()...)
-	warnings = append(warnings, checkEnvPermissions(envPath)...)
-	warnings = append(warnings, checkGitHistory()...)
-	return warnings
-}
-
-func checkGitignore() []warning {
 	gitignorePath, err := utils.CreatePath(".gitignore")
-	if err != nil {
-		return []warning{{
-			message: fmt.Sprintf(
-				"%s/ is not gitignored — secrets may be committed",
-				utils.EnvironmentFolder,
-			),
-			fix: fmt.Sprintf(
-				"echo \"%s/\" >> .gitignore",
-				utils.EnvironmentFolder,
-			),
-		}}
-	}
-
-	if !utils.FileExists(gitignorePath) {
-		return []warning{{
-			message: fmt.Sprintf(
-				"%s/ is not gitignored — secrets may be committed",
-				utils.EnvironmentFolder,
-			),
-			fix: fmt.Sprintf(
-				"echo \"%s/\" >> .gitignore",
-				utils.EnvironmentFolder,
-			),
-		}}
+	if err != nil || !utils.FileExists(gitignorePath) {
+		return []finding{notIgnored}
 	}
 
 	file, err := os.Open(gitignorePath)
 	if err != nil {
-		return []warning{{
-			message: "could not read .gitignore",
+		return []finding{{
+			check:    "classic-gitignore",
+			severity: sevWarn,
+			message:  "could not read .gitignore",
 		}}
 	}
 	defer file.Close()
@@ -397,25 +346,16 @@ func checkGitignore() []warning {
 		}
 	}
 
-	return []warning{{
-		message: fmt.Sprintf(
-			"%s/ is not gitignored — secrets may be committed",
-			utils.EnvironmentFolder,
-		),
-		fix: fmt.Sprintf(
-			"echo \"%s/\" >> .gitignore",
-			utils.EnvironmentFolder,
-		),
-	}}
+	return []finding{notIgnored}
 }
 
-func checkEnvPermissions(envPath string) []warning {
+func checkEnvPermissions(envPath string) []finding {
 	entries, err := os.ReadDir(envPath)
 	if err != nil {
 		return nil
 	}
 
-	var warnings []warning
+	var findings []finding
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), utils.DefaultEnvFileSuffix) {
 			continue
@@ -425,7 +365,9 @@ func checkEnvPermissions(envPath string) []warning {
 			continue
 		}
 		if info.Mode().Perm()&0o077 != 0 {
-			warnings = append(warnings, warning{
+			findings = append(findings, finding{
+				check:    "classic-permissions",
+				severity: sevWarn,
 				message: fmt.Sprintf(
 					"%s has loose permissions (%o)",
 					e.Name(), info.Mode().Perm(),
@@ -437,10 +379,10 @@ func checkEnvPermissions(envPath string) []warning {
 			})
 		}
 	}
-	return warnings
+	return findings
 }
 
-func checkGitHistory() []warning {
+func checkGitHistory() []finding {
 	if _, err := exec.LookPath("git"); err != nil {
 		return nil
 	}
@@ -470,11 +412,29 @@ func checkGitHistory() []warning {
 		return nil
 	}
 
-	return []warning{{
+	return []finding{{
+		check:    "classic-git-history",
+		severity: sevWarn,
 		message: fmt.Sprintf(
 			"%s files found in git history: %s",
 			utils.DefaultEnvFileSuffix, strings.Join(files, ", "),
 		),
 		fix: "consider removing with git filter-repo or BFG Repo-Cleaner",
 	}}
+}
+
+func printInventory(envPath string) {
+	entries, err := os.ReadDir(envPath)
+	if err != nil {
+		return
+	}
+
+	utils.PrintInfoStderr(utils.EnvironmentFolder + "/")
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		utils.PrintInfoStderr("  " + e.Name())
+	}
+	utils.PrintInfoStderr("")
 }

--- a/pkg/userFlags/doctor.go
+++ b/pkg/userFlags/doctor.go
@@ -40,18 +40,17 @@ func (s severity) String() string {
 	}
 }
 
-// sevDisplay maps a severity to its terminal presentation.
+// sevDisplay maps a severity to its colored mark for table output.
 type sevDisplay struct {
 	color string
 	mark  string
-	label string // prefix for human output; empty for sevOk
 }
 
 var sevDisplays = [4]sevDisplay{
-	sevInfo:  {utils.Blue, utils.InfoMark, "info:"},
-	sevOk:    {utils.Green, utils.CheckMark, ""},
-	sevWarn:  {utils.Yellow, utils.WarningMark, "warning:"},
-	sevError: {utils.Red, utils.CrossMark, "error:"},
+	sevInfo:  {utils.Blue, utils.InfoMark},
+	sevOk:    {utils.Green, utils.CheckMark},
+	sevWarn:  {utils.Yellow, utils.WarningMark},
+	sevError: {utils.Red, utils.CrossMark},
 }
 
 // --- finding -----------------------------------------------------------------
@@ -125,24 +124,32 @@ func (r *doctorReport) printHuman() {
 	utils.PrintInfoStderr(fmt.Sprintf("Project: %s", r.project))
 	utils.PrintInfoStderr(fmt.Sprintf("Backend: %s\n", r.backend))
 
+	headers := []string{"RESULT", "MESSAGE"}
+	hasFix := false
 	for _, f := range r.findings {
-		printFinding(f)
+		if f.fix != "" {
+			hasFix = true
+			break
+		}
 	}
+	if hasFix {
+		headers = append(headers, "FIX")
+	}
+
+	rows := make([][]string, len(r.findings))
+	for i, f := range r.findings {
+		d := sevDisplays[f.severity]
+		row := []string{d.color + d.mark + utils.ColorReset, f.message}
+		if hasFix {
+			row = append(row, f.fix)
+		}
+		rows[i] = row
+	}
+
+	_ = utils.PrintTable(os.Stderr, headers, rows, 0)
 
 	s := r.summary()
 	utils.PrintInfoStderr(fmt.Sprintf("\n%d ok, %d warning, %d error", s.Ok, s.Warn, s.Error))
-}
-
-func printFinding(f finding) {
-	d := sevDisplays[f.severity]
-	if d.label != "" {
-		fmt.Fprintf(os.Stderr, "%s%s %s%s %s\n", d.color, d.mark, d.label, utils.ColorReset, f.message)
-	} else {
-		fmt.Fprintf(os.Stderr, "%s%s%s %s\n", d.color, d.mark, utils.ColorReset, f.message)
-	}
-	if f.fix != "" {
-		utils.PrintInfoStderr(fmt.Sprintf("  Fix: %s", f.fix))
-	}
 }
 
 // --- JSON output (stdout) ----------------------------------------------------

--- a/pkg/userFlags/doctor.go
+++ b/pkg/userFlags/doctor.go
@@ -167,30 +167,30 @@ func (r *doctorReport) printJSON() {
 
 // --- --fix flow ------------------------------------------------------------
 
+// runFixes applies auto-fixable findings. Findings were already printed by
+// printHuman, so this only shows the fix prompt and result.
 func (r *doctorReport) runFixes(autoYes bool) {
 	for i, f := range r.findings {
 		if f.auto == nil {
 			continue
 		}
-		printFinding(f)
 
 		if !autoYes {
-			ok, err := utils.ConfirmAction("  Fix? [Y/n] ")
+			ok, err := utils.ConfirmAction(fmt.Sprintf("  Fix %s (%s)? [Y/n] ", f.check, f.fix))
 			if err != nil || !ok {
 				continue
 			}
 		}
 
 		if err := f.auto(); err != nil {
-			utils.PrintErrorStderr(fmt.Sprintf("  failed: %v", err))
+			utils.PrintErrorStderr(fmt.Sprintf("  fix %s failed: %v", f.check, err))
 			continue
 		}
 
-		// re-check shows green on success
 		r.findings[i].severity = sevOk
 		r.findings[i].fix = ""
 		r.findings[i].auto = nil
-		utils.PrintSuccessStderr("  fixed")
+		utils.PrintSuccessStderr(fmt.Sprintf("  fixed: %s", f.check))
 	}
 }
 
@@ -202,18 +202,20 @@ type doctorOpts struct {
 	jsonOut bool
 }
 
-func runDoctor(opts doctorOpts) {
+// runDoctor runs all health checks and returns the exit code:
+// 0 = ok/info only, 1 = warnings, 2 = errors.
+func runDoctor(opts doctorOpts) int {
 	projectRoot, found := utils.FindProjectRoot()
 	storeType := vault.DetectStore()
 
 	if opts.fix && opts.jsonOut {
 		utils.PrintErrorStderr("--fix and --json are mutually exclusive")
-		os.Exit(1)
+		return 1
 	}
 
 	if !found || storeType == vault.StoreNone {
 		utils.PrintInfoStderr("Not a hulak project. Run 'hulak init' to start one.")
-		return
+		return 0
 	}
 
 	report := &doctorReport{project: projectRoot}
@@ -229,7 +231,7 @@ func runDoctor(opts doctorOpts) {
 
 	if opts.jsonOut {
 		report.printJSON()
-		os.Exit(report.exitCode())
+		return report.exitCode()
 	}
 
 	if opts.fix {
@@ -239,7 +241,7 @@ func runDoctor(opts doctorOpts) {
 		report.printHuman()
 	}
 
-	os.Exit(report.exitCode())
+	return report.exitCode()
 }
 
 // collectVaultFindings runs all vault-aware checks.
@@ -273,26 +275,39 @@ func collectVaultFindings() []finding {
 func collectClassicFindings(projectRoot string) []finding {
 	envPath := filepath.Join(projectRoot, utils.EnvironmentFolder)
 
-	// Print inventory header
 	printInventory(envPath)
 
-	// Run legacy checks and convert to findings
-	warnings := collectWarnings(envPath)
-
 	var findings []finding
-	if len(warnings) == 0 {
+	for _, w := range checkGitignore() {
+		findings = append(findings, finding{
+			check:    "classic-gitignore",
+			severity: sevWarn,
+			message:  w.message,
+			fix:      w.fix,
+		})
+	}
+	for _, w := range checkEnvPermissions(envPath) {
+		findings = append(findings, finding{
+			check:    "classic-permissions",
+			severity: sevWarn,
+			message:  w.message,
+			fix:      w.fix,
+		})
+	}
+	for _, w := range checkGitHistory() {
+		findings = append(findings, finding{
+			check:    "classic-git-history",
+			severity: sevWarn,
+			message:  w.message,
+			fix:      w.fix,
+		})
+	}
+
+	if len(findings) == 0 {
 		findings = append(findings, finding{
 			check:    "classic-health",
 			severity: sevOk,
 			message:  "classic backend looks healthy",
-		})
-	}
-	for _, w := range warnings {
-		findings = append(findings, finding{
-			check:    "classic-issue",
-			severity: sevWarn,
-			message:  w.message,
-			fix:      w.fix,
 		})
 	}
 

--- a/pkg/userFlags/doctor_checks.go
+++ b/pkg/userFlags/doctor_checks.go
@@ -1,0 +1,891 @@
+package userflags
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
+)
+
+// ── vault checks ───────────────────────────────────────────────────────────
+
+// checkIdentityPresent verifies that at least one identity source resolves.
+// Check #1.
+func checkIdentityPresent() finding {
+	_, err := vault.ResolveIdentity()
+	if err != nil {
+		return finding{
+			check:    "identity-present",
+			severity: sevError,
+			message:  "no identity found (identity.txt, HULAK_MASTER_KEY, or SSH key)",
+			fix:      "run 'hulak init' or set HULAK_MASTER_KEY for CI",
+		}
+	}
+	return finding{
+		check:    "identity-present",
+		severity: sevOk,
+		message:  "identity resolves",
+	}
+}
+
+// checkIdentityMode verifies identity.txt is mode 0600.
+// Check #2. Auto-fixable.
+func checkIdentityMode() finding {
+	path, err := vault.IdentityPath()
+	if err != nil || !utils.FileExists(path) {
+		return finding{
+			check:    "identity-mode",
+			severity: sevInfo,
+			message:  "identity.txt not present (skipping mode check)",
+		}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return finding{
+			check:    "identity-mode",
+			severity: sevError,
+			message:  fmt.Sprintf("cannot stat identity file: %v", err),
+		}
+	}
+
+	perm := info.Mode().Perm()
+	if perm == utils.SecretPer {
+		return finding{
+			check:    "identity-mode",
+			severity: sevOk,
+			message:  "identity file mode is 0600",
+		}
+	}
+
+	return finding{
+		check:    "identity-mode",
+		severity: sevError,
+		message:  fmt.Sprintf("identity file mode is %04o (should be 0600)", perm),
+		fix:      fmt.Sprintf("chmod 600 %s", path),
+		auto: func() error {
+			return os.Chmod(path, utils.SecretPer)
+		},
+	}
+}
+
+// checkIdentityNotInGit walks parents of identity file looking for .git/.
+// Follows symlinks. Check #3.
+func checkIdentityNotInGit() finding {
+	path, err := vault.IdentityPath()
+	if err != nil || !utils.FileExists(path) {
+		return finding{
+			check:    "identity-in-git",
+			severity: sevInfo,
+			message:  "identity.txt not present (skipping git check)",
+		}
+	}
+
+	// Resolve symlinks to catch the dotfiles repo case
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		resolved = path
+	}
+
+	// Walk up from both original and resolved paths
+	for _, p := range uniquePaths(filepath.Dir(path), filepath.Dir(resolved)) {
+		if isInsideGitRepo(p) {
+			return finding{
+				check:    "identity-in-git",
+				severity: sevError,
+				message:  fmt.Sprintf("identity file is inside a git repository (%s)", p),
+				fix:      "move identity.txt outside any git-tracked directory",
+			}
+		}
+	}
+
+	return finding{
+		check:    "identity-in-git",
+		severity: sevOk,
+		message:  "identity file is not git-tracked",
+	}
+}
+
+// isInsideGitRepo walks from dir upward looking for a .git/ directory.
+func isInsideGitRepo(dir string) bool {
+	for {
+		gitDir := filepath.Join(dir, ".git")
+		if info, err := os.Lstat(gitDir); err == nil && info.IsDir() {
+			return true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+		dir = parent
+	}
+}
+
+// uniquePaths deduplicates two directory paths.
+func uniquePaths(a, b string) []string {
+	if a == b {
+		return []string{a}
+	}
+	return []string{a, b}
+}
+
+// checkIdentityLeakedInProject scans tracked files for AGE-SECRET-KEY- prefix.
+// Check #4.
+func checkIdentityLeakedInProject() finding {
+	projectRoot, ok := utils.FindProjectRoot()
+	if !ok {
+		return finding{
+			check:    "identity-leaked-in-project",
+			severity: sevInfo,
+			message:  "no project root found (skipping leak scan)",
+		}
+	}
+
+	leaked := scanForSecretKey(projectRoot)
+	if len(leaked) > 0 {
+		return finding{
+			check:    "identity-leaked-in-project",
+			severity: sevError,
+			message:  fmt.Sprintf("AGE-SECRET-KEY- found in project file(s): %s", strings.Join(leaked, ", ")),
+			fix:      "remove the secret key and run 'hulak secrets rotate-key'",
+		}
+	}
+
+	return finding{
+		check:    "identity-leaked-in-project",
+		severity: sevOk,
+		message:  "no secret keys found in project files",
+	}
+}
+
+// scanForSecretKey walks the project looking for files containing AGE-SECRET-KEY-.
+// Skips binary-looking files, files > 1 MiB, and the identity file itself
+// (which is *supposed* to contain a secret key).
+func scanForSecretKey(root string) []string {
+	files := trackedFiles(root)
+	if files == nil {
+		files = walkTextFiles(root)
+	}
+
+	// Exclude the identity file — it legitimately contains AGE-SECRET-KEY-.
+	identityPath, _ := vault.IdentityPath()
+	if identityPath != "" {
+		resolved, err := filepath.EvalSymlinks(identityPath)
+		if err == nil {
+			identityPath = resolved
+		}
+	}
+
+	var leaked []string
+	for _, path := range files {
+		abs, _ := filepath.Abs(path)
+		resolved, err := filepath.EvalSymlinks(abs)
+		if err == nil {
+			abs = resolved
+		}
+		if identityPath != "" && abs == identityPath {
+			continue
+		}
+		if containsSecretKeyPrefix(path) {
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				rel = path
+			}
+			leaked = append(leaked, rel)
+		}
+	}
+	return leaked
+}
+
+// trackedFiles returns git-tracked files. Returns nil if not in a git repo.
+func trackedFiles(root string) []string {
+	cmd := exec.Command("git", "ls-files", "-z")
+	cmd.Dir = root
+	output, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+
+	var files []string
+	for _, f := range strings.Split(string(output), "\x00") {
+		f = strings.TrimSpace(f)
+		if f != "" {
+			files = append(files, filepath.Join(root, f))
+		}
+	}
+	return files
+}
+
+// walkTextFiles returns all regular files ≤ 1 MiB under root.
+func walkTextFiles(root string) []string {
+	var files []string
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		// Skip hidden dirs (except .hulak)
+		if d.IsDir() && strings.HasPrefix(d.Name(), ".") && d.Name() != utils.HiddenProjectName {
+			return filepath.SkipDir
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil || info.Size() > 1<<20 {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	return files
+}
+
+// containsSecretKeyPrefix checks if a file contains the AGE-SECRET-KEY- prefix.
+func containsSecretKeyPrefix(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), "AGE-SECRET-KEY-") {
+			return true
+		}
+	}
+	return false
+}
+
+// checkConfigDirMode verifies ~/.config/hulak/ is mode 0700.
+// Check #5. Auto-fixable.
+func checkConfigDirMode() finding {
+	path, err := vault.IdentityPath()
+	if err != nil {
+		return finding{
+			check:    "config-dir-mode",
+			severity: sevInfo,
+			message:  "config directory not resolved (skipping mode check)",
+		}
+	}
+
+	configDir := filepath.Dir(path)
+	info, err := os.Stat(configDir)
+	if err != nil {
+		return finding{
+			check:    "config-dir-mode",
+			severity: sevInfo,
+			message:  "config directory does not exist (skipping mode check)",
+		}
+	}
+
+	perm := info.Mode().Perm()
+	if perm == utils.SecretDirPer {
+		return finding{
+			check:    "config-dir-mode",
+			severity: sevOk,
+			message:  "config directory mode is 0700",
+		}
+	}
+
+	return finding{
+		check:    "config-dir-mode",
+		severity: sevWarn,
+		message:  fmt.Sprintf("config directory mode is %04o (should be 0700)", perm),
+		fix:      fmt.Sprintf("chmod 700 %s", configDir),
+		auto: func() error {
+			return os.Chmod(configDir, utils.SecretDirPer)
+		},
+	}
+}
+
+// checkStoreMode verifies store.age is mode 0600.
+// Check #6. Auto-fixable.
+func checkStoreMode() finding {
+	path, err := vault.StorePath()
+	if err != nil || !utils.FileExists(path) {
+		return finding{
+			check:    "store-mode",
+			severity: sevInfo,
+			message:  "store.age not found (skipping mode check)",
+		}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return finding{
+			check:    "store-mode",
+			severity: sevError,
+			message:  fmt.Sprintf("cannot stat store.age: %v", err),
+		}
+	}
+
+	perm := info.Mode().Perm()
+	if perm == utils.SecretPer {
+		return finding{
+			check:    "store-mode",
+			severity: sevOk,
+			message:  "store.age mode is 0600",
+		}
+	}
+
+	return finding{
+		check:    "store-mode",
+		severity: sevError,
+		message:  fmt.Sprintf("store.age mode is %04o (should be 0600)", perm),
+		fix:      fmt.Sprintf("chmod 600 %s", path),
+		auto: func() error {
+			return os.Chmod(path, utils.SecretPer)
+		},
+	}
+}
+
+// checkStoreEncrypted verifies store.age starts with the age header.
+// Check #7.
+func checkStoreEncrypted() finding {
+	path, err := vault.StorePath()
+	if err != nil || !utils.FileExists(path) {
+		return finding{
+			check:    "store-encrypted",
+			severity: sevInfo,
+			message:  "store.age not found (skipping encryption check)",
+		}
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return finding{
+			check:    "store-encrypted",
+			severity: sevError,
+			message:  fmt.Sprintf("cannot open store.age: %v", err),
+		}
+	}
+	defer f.Close()
+
+	header := make([]byte, 64)
+	n, err := f.Read(header)
+	if err != nil || n == 0 {
+		return finding{
+			check:    "store-encrypted",
+			severity: sevError,
+			message:  "store.age is empty or unreadable",
+			fix:      "the store may be corrupt — check if you need to restore from backup",
+		}
+	}
+
+	headerStr := string(header[:n])
+	if strings.HasPrefix(headerStr, "age-encryption.org/v1") {
+		return finding{
+			check:    "store-encrypted",
+			severity: sevOk,
+			message:  "store.age has valid encryption header",
+		}
+	}
+
+	return finding{
+		check:    "store-encrypted",
+		severity: sevError,
+		message:  "store.age does not start with age encryption header",
+		fix:      "the file may contain plaintext or be corrupt — re-encrypt or restore from backup",
+	}
+}
+
+// checkStoreDecrypts tries to decrypt store.age with the current identity.
+// Check #8.
+func checkStoreDecrypts() finding {
+	identity, err := vault.ResolveIdentity()
+	if err != nil {
+		return finding{
+			check:    "store-decrypts",
+			severity: sevInfo,
+			message:  "no identity available (skipping decryption check)",
+		}
+	}
+
+	_, err = vault.ReadStore(identity)
+	if err != nil {
+		return finding{
+			check:    "store-decrypts",
+			severity: sevError,
+			message:  fmt.Sprintf("store.age cannot be decrypted: %v", err),
+			fix:      "check that your identity matches the recipients list, or run 'hulak secrets rotate-key'",
+		}
+	}
+
+	return finding{
+		check:    "store-decrypts",
+		severity: sevOk,
+		message:  "store.age decrypts with current identity",
+	}
+}
+
+// checkRecipientsExist verifies recipients.txt exists.
+// Check #9.
+func checkRecipientsExist() finding {
+	path, err := vault.RecipientsFilePath()
+	if err != nil {
+		return finding{
+			check:    "recipients-exist",
+			severity: sevError,
+			message:  "recipients.txt not found",
+			fix:      "run 'hulak secrets add-recipient' to create it",
+		}
+	}
+
+	if !utils.FileExists(path) {
+		return finding{
+			check:    "recipients-exist",
+			severity: sevError,
+			message:  "recipients.txt does not exist",
+			fix:      "run 'hulak secrets add-recipient' to create it",
+		}
+	}
+
+	return finding{
+		check:    "recipients-exist",
+		severity: sevOk,
+		message:  "recipients.txt exists",
+	}
+}
+
+// checkRecipientsValid verifies recipients.txt has ≥1 valid entry.
+// Check #10.
+func checkRecipientsValid() finding {
+	path, err := vault.RecipientsFilePath()
+	if err != nil || !utils.FileExists(path) {
+		return finding{
+			check:    "recipients-valid",
+			severity: sevInfo,
+			message:  "recipients.txt not found (skipping validation)",
+		}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return finding{
+			check:    "recipients-valid",
+			severity: sevError,
+			message:  fmt.Sprintf("cannot read recipients.txt: %v", err),
+		}
+	}
+
+	entries, err := vault.ParseRecipientsFileContent(data)
+	if err != nil || len(entries) == 0 {
+		return finding{
+			check:    "recipients-valid",
+			severity: sevError,
+			message:  "recipients.txt has no valid entries",
+			fix:      "run 'hulak secrets add-recipient' to add one",
+		}
+	}
+
+	return finding{
+		check:    "recipients-valid",
+		severity: sevOk,
+		message:  fmt.Sprintf("recipients.txt has %d valid entry(ies)", len(entries)),
+	}
+}
+
+// checkRecipientsMode verifies recipients.txt is mode 0644 (warn if stricter).
+// Check #11. Auto-fixable.
+func checkRecipientsMode() finding {
+	path, err := vault.RecipientsFilePath()
+	if err != nil || !utils.FileExists(path) {
+		return finding{
+			check:    "recipients-mode",
+			severity: sevInfo,
+			message:  "recipients.txt not found (skipping mode check)",
+		}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return finding{
+			check:    "recipients-mode",
+			severity: sevError,
+			message:  fmt.Sprintf("cannot stat recipients.txt: %v", err),
+		}
+	}
+
+	perm := info.Mode().Perm()
+	if perm == utils.FilePer {
+		return finding{
+			check:    "recipients-mode",
+			severity: sevOk,
+			message:  "recipients.txt mode is 0644",
+		}
+	}
+
+	return finding{
+		check:    "recipients-mode",
+		severity: sevWarn,
+		message:  fmt.Sprintf("recipients.txt mode is %04o (expected 0644)", perm),
+		fix:      fmt.Sprintf("chmod 644 %s", path),
+		auto: func() error {
+			return os.Chmod(path, utils.FilePer)
+		},
+	}
+}
+
+// checkRecipientsCommitted checks if recipients.txt is committed or staged in git.
+// Check #12.
+func checkRecipientsCommitted() finding {
+	path, err := vault.RecipientsFilePath()
+	if err != nil || !utils.FileExists(path) {
+		return finding{
+			check:    "recipients-committed",
+			severity: sevInfo,
+			message:  "recipients.txt not found (skipping commit check)",
+		}
+	}
+
+	if _, err := exec.LookPath("git"); err != nil {
+		return finding{
+			check:    "recipients-committed",
+			severity: sevInfo,
+			message:  "git not available (skipping commit check)",
+		}
+	}
+
+	// Check if the file is tracked by git (committed or staged)
+	projectRoot, _ := utils.FindProjectRoot()
+	rel, err := filepath.Rel(projectRoot, path)
+	if err != nil {
+		rel = path
+	}
+
+	cmd := exec.Command("git", "ls-files", "--error-unmatch", rel)
+	cmd.Dir = projectRoot
+	if err := cmd.Run(); err == nil {
+		return finding{
+			check:    "recipients-committed",
+			severity: sevOk,
+			message:  "recipients.txt is committed",
+		}
+	}
+
+	// Check if staged but not yet committed
+	cmd = exec.Command("git", "diff", "--cached", "--name-only", "--", rel)
+	cmd.Dir = projectRoot
+	output, err := cmd.Output()
+	if err == nil && strings.TrimSpace(string(output)) != "" {
+		return finding{
+			check:    "recipients-committed",
+			severity: sevOk,
+			message:  "recipients.txt is staged",
+		}
+	}
+
+	return finding{
+		check:    "recipients-committed",
+		severity: sevWarn,
+		message:  "recipients.txt is not committed or staged",
+		fix:      fmt.Sprintf("git add %s", rel),
+	}
+}
+
+// ── drift + remaining checks ───────────────────────────────────────────────
+
+// checkRecipientDrift counts recipient stanzas in store.age header and
+// compares to the number of entries in recipients.txt.
+// Check #13.
+func checkRecipientDrift() finding {
+	storePath, err := vault.StorePath()
+	if err != nil || !utils.FileExists(storePath) {
+		return finding{
+			check:    "recipient-drift",
+			severity: sevInfo,
+			message:  "store.age not found (skipping drift check)",
+		}
+	}
+
+	recipientsPath, err := vault.RecipientsFilePath()
+	if err != nil || !utils.FileExists(recipientsPath) {
+		return finding{
+			check:    "recipient-drift",
+			severity: sevInfo,
+			message:  "recipients.txt not found (skipping drift check)",
+		}
+	}
+
+	stanzaCount, err := countStanzas(storePath)
+	if err != nil {
+		return finding{
+			check:    "recipient-drift",
+			severity: sevInfo,
+			message:  fmt.Sprintf("could not parse store.age header: %v", err),
+		}
+	}
+
+	data, err := os.ReadFile(recipientsPath)
+	if err != nil {
+		return finding{
+			check:    "recipient-drift",
+			severity: sevInfo,
+			message:  "could not read recipients.txt (skipping drift check)",
+		}
+	}
+
+	entries, err := vault.ParseRecipientsFileContent(data)
+	if err != nil {
+		return finding{
+			check:    "recipient-drift",
+			severity: sevInfo,
+			message:  "could not parse recipients.txt (skipping drift check)",
+		}
+	}
+
+	if stanzaCount == len(entries) {
+		return finding{
+			check:    "recipient-drift",
+			severity: sevOk,
+			message:  fmt.Sprintf("recipient count matches store stanzas (%d)", stanzaCount),
+		}
+	}
+
+	return finding{
+		check:    "recipient-drift",
+		severity: sevWarn,
+		message: fmt.Sprintf(
+			"recipients.txt has %d entries but store.age has %d stanzas — re-encryption needed",
+			len(entries), stanzaCount,
+		),
+		fix: "run 'hulak secrets rotate-key' to re-encrypt for all current recipients",
+	}
+}
+
+// countStanzas counts lines starting with "->" in the age binary header
+// (before the "---" MAC line). Returns error if the file is armored or
+// doesn't look like a valid age binary file.
+func countStanzas(path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	if !scanner.Scan() {
+		return 0, fmt.Errorf("empty file")
+	}
+
+	first := scanner.Text()
+	if strings.HasPrefix(first, "-----BEGIN AGE ENCRYPTED FILE-----") {
+		return 0, fmt.Errorf("armored format not supported for stanza counting")
+	}
+	if !strings.HasPrefix(first, "age-encryption.org/") {
+		return 0, fmt.Errorf("not an age encrypted file")
+	}
+
+	count := 0
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "---") {
+			break
+		}
+		if strings.HasPrefix(line, "-> ") {
+			count++
+		}
+	}
+	return count, scanner.Err()
+}
+
+// checkStoreNotGitignored warns when store.age is gitignored but there are
+// multiple recipients (team project).
+// Check #14.
+func checkStoreNotGitignored() finding {
+	recipientsPath, err := vault.RecipientsFilePath()
+	if err != nil || !utils.FileExists(recipientsPath) {
+		return finding{
+			check:    "store-not-gitignored",
+			severity: sevInfo,
+			message:  "recipients.txt not found (skipping gitignore check)",
+		}
+	}
+
+	data, err := os.ReadFile(recipientsPath)
+	if err != nil {
+		return finding{
+			check:    "store-not-gitignored",
+			severity: sevInfo,
+			message:  "could not read recipients.txt (skipping gitignore check)",
+		}
+	}
+
+	entries, _ := vault.ParseRecipientsFileContent(data)
+	if len(entries) <= 1 {
+		return finding{
+			check:    "store-not-gitignored",
+			severity: sevOk,
+			message:  "single-recipient project — .gitignore check not applicable",
+		}
+	}
+
+	// Check if store.age is gitignored
+	if _, err := exec.LookPath("git"); err != nil {
+		return finding{
+			check:    "store-not-gitignored",
+			severity: sevInfo,
+			message:  "git not available (skipping gitignore check)",
+		}
+	}
+
+	projectRoot, _ := utils.FindProjectRoot()
+	storePath, err := vault.StorePath()
+	if err != nil {
+		return finding{
+			check:    "store-not-gitignored",
+			severity: sevInfo,
+			message:  "store path not resolved (skipping gitignore check)",
+		}
+	}
+
+	rel, err := filepath.Rel(projectRoot, storePath)
+	if err != nil {
+		rel = storePath
+	}
+
+	cmd := exec.Command("git", "check-ignore", "-q", rel)
+	cmd.Dir = projectRoot
+	if cmd.Run() == nil {
+		// File IS gitignored
+		return finding{
+			check:    "store-not-gitignored",
+			severity: sevWarn,
+			message:  "store.age is in .gitignore — teammates won't be able to decrypt",
+			fix:      "remove the store.age entry from .gitignore for team projects",
+		}
+	}
+
+	return finding{
+		check:    "store-not-gitignored",
+		severity: sevOk,
+		message:  "store.age is not gitignored",
+	}
+}
+
+// checkLegacyKeyPub detects a lingering .hulak/key.pub file.
+// Check #15.
+func checkLegacyKeyPub() finding {
+	markerPath, err := utils.GetProjectMarker()
+	if err != nil {
+		return finding{
+			check:    "legacy-key-pub",
+			severity: sevInfo,
+			message:  "project marker not found (skipping legacy check)",
+		}
+	}
+
+	keyPubPath := filepath.Join(markerPath, "key.pub")
+	if utils.FileExists(keyPubPath) {
+		return finding{
+			check:    "legacy-key-pub",
+			severity: sevInfo,
+			message:  "legacy .hulak/key.pub found — recipients.txt is now the authoritative recipient list",
+			fix:      fmt.Sprintf("rm %s", keyPubPath),
+		}
+	}
+
+	return finding{
+		check:    "legacy-key-pub",
+		severity: sevOk,
+		message:  "no legacy key.pub found",
+	}
+}
+
+// checkDualBackend detects both env/ and .hulak/store.age existing.
+// Check #16.
+func checkDualBackend() finding {
+	projectRoot, ok := utils.FindProjectRoot()
+	if !ok {
+		return finding{
+			check:    "dual-backend",
+			severity: sevInfo,
+			message:  "no project root (skipping dual backend check)",
+		}
+	}
+
+	envDir := filepath.Join(projectRoot, utils.EnvironmentFolder)
+	storeDir := filepath.Join(projectRoot, utils.HiddenProjectName, utils.StoreFile)
+
+	hasEnv := utils.DirExists(envDir)
+	hasStore := utils.FileExists(storeDir)
+
+	if hasEnv && hasStore {
+		return finding{
+			check:    "dual-backend",
+			severity: sevError,
+			message:  "both env/ and .hulak/store.age exist",
+			fix:      "verify the migration with 'hulak secrets migrate', then remove env/",
+		}
+	}
+
+	return finding{
+		check:    "dual-backend",
+		severity: sevOk,
+		message:  "single backend in use",
+	}
+}
+
+// checkDualIdentity detects when both HULAK_MASTER_KEY and identity.txt exist.
+// Check #17.
+func checkDualIdentity() finding {
+	hasMasterKey := strings.TrimSpace(os.Getenv(utils.MasterKey)) != ""
+	hasIdentityFile := vault.IdentityExists()
+
+	if hasMasterKey && hasIdentityFile {
+		return finding{
+			check:    "dual-identity",
+			severity: sevInfo,
+			message:  "both HULAK_MASTER_KEY and identity.txt are present — HULAK_MASTER_KEY takes precedence",
+		}
+	}
+
+	return finding{
+		check:    "dual-identity",
+		severity: sevOk,
+		message:  "single identity source",
+	}
+}
+
+// checkStoreSize warns if store.age exceeds 1 MiB.
+// Check #18.
+func checkStoreSize() finding {
+	path, err := vault.StorePath()
+	if err != nil || !utils.FileExists(path) {
+		return finding{
+			check:    "store-size",
+			severity: sevInfo,
+			message:  "store.age not found (skipping size check)",
+		}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return finding{
+			check:    "store-size",
+			severity: sevInfo,
+			message:  "cannot stat store.age (skipping size check)",
+		}
+	}
+
+	if info.Size() > vault.MaxStoreSizeWarnBytes {
+		sizeMB := float64(info.Size()) / (1 << 20)
+		return finding{
+			check:    "store-size",
+			severity: sevWarn,
+			message:  fmt.Sprintf("store.age is %.1f MiB — consider using getFile for large values", sizeMB),
+		}
+	}
+
+	return finding{
+		check:    "store-size",
+		severity: sevOk,
+		message:  "store.age size is within limits",
+	}
+}

--- a/pkg/userFlags/doctor_checks.go
+++ b/pkg/userFlags/doctor_checks.go
@@ -74,8 +74,11 @@ func checkIdentityMode() finding {
 	}
 }
 
-// checkIdentityNotInGit walks parents of identity file looking for .git/.
-// Follows symlinks. Check #3.
+// checkIdentityNotInGit verifies the identity file is not tracked by git.
+// Walks parents looking for .git/, then uses git ls-files to distinguish
+// "tracked" (sevError) from "in repo but untracked" (sevWarn). The latter
+// is common with dotfiles managers (yadm, stow) that place .git/ above
+// ~/.config but typically don't track the identity. Check #3.
 func checkIdentityNotInGit() finding {
 	path, err := vault.IdentityPath()
 	if err != nil || !utils.FileExists(path) {
@@ -92,15 +95,38 @@ func checkIdentityNotInGit() finding {
 		resolved = path
 	}
 
-	// Walk up from both original and resolved paths
-	for _, p := range uniquePaths(filepath.Dir(path), filepath.Dir(resolved)) {
-		if isInsideGitRepo(p) {
+	// Check both original and resolved paths (catches symlinked dotfiles)
+	type candidate struct {
+		dir  string // directory containing identity file
+		file string // full path to identity file
+	}
+	candidates := []candidate{{filepath.Dir(path), path}}
+	if resolved != path {
+		candidates = append(candidates, candidate{filepath.Dir(resolved), resolved})
+	}
+
+	for _, c := range candidates {
+		if !isInsideGitRepo(c.dir) {
+			continue
+		}
+
+		// .git/ found in a parent. Check whether the file is actually
+		// tracked — dotfiles managers commonly place .git/ above
+		// ~/.config but don't track the identity file.
+		if isFileGitTracked(c.dir, c.file) {
 			return finding{
 				check:    "identity-in-git",
 				severity: sevError,
-				message:  fmt.Sprintf("identity file is inside a git repository (%s)", p),
-				fix:      "move identity.txt outside any git-tracked directory",
+				message:  fmt.Sprintf("identity file is tracked by git (%s)", c.dir),
+				fix:      "remove from tracking with 'git rm --cached <path>' and add to .gitignore",
 			}
+		}
+
+		return finding{
+			check:    "identity-in-git",
+			severity: sevWarn,
+			message:  fmt.Sprintf("identity file is inside a git repository (%s) but not tracked", c.dir),
+			fix:      "verify identity.txt stays in .gitignore, or move it outside the repo",
 		}
 	}
 
@@ -126,12 +152,16 @@ func isInsideGitRepo(dir string) bool {
 	}
 }
 
-// uniquePaths deduplicates two directory paths.
-func uniquePaths(a, b string) []string {
-	if a == b {
-		return []string{a}
+// isFileGitTracked checks if filePath is tracked (committed or staged) by git.
+// dir should be within the git repo. Returns false if git is unavailable or
+// the path is not inside a valid git repository.
+func isFileGitTracked(dir, filePath string) bool {
+	if _, err := exec.LookPath("git"); err != nil {
+		return false
 	}
-	return []string{a, b}
+	cmd := exec.Command("git", "ls-files", "--error-unmatch", filePath)
+	cmd.Dir = dir
+	return cmd.Run() == nil
 }
 
 // checkIdentityLeakedInProject scans tracked files for AGE-SECRET-KEY- prefix.
@@ -662,6 +692,8 @@ func checkRecipientDrift() finding {
 // countStanzas counts lines starting with "->" in the age binary header
 // (before the "---" MAC line). Returns error if the file is armored or
 // doesn't look like a valid age binary file.
+// Note: hulak always writes the binary (non-armored) age format, so
+// rejecting armored files here is expected.
 func countStanzas(path string) (int, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/pkg/userFlags/doctor_checks.go
+++ b/pkg/userFlags/doctor_checks.go
@@ -12,13 +12,51 @@ import (
 	"github.com/xaaha/hulak/pkg/vault"
 )
 
-// ── vault checks ───────────────────────────────────────────────────────────
+// --- permission check helper -------------------------------------------------
+
+// modeCheck describes a file permission check.
+type modeCheck struct {
+	check    string
+	label    string // human name: "identity file", "store.age"
+	expected os.FileMode
+	failSev  severity
+}
+
+// checkFileMode verifies a file's permission mode and returns an auto-fixable
+// finding if the mode doesn't match.
+func checkFileMode(path string, mc modeCheck) finding {
+	if !utils.FileExists(path) {
+		return skipFinding(mc.check, mc.label+" not found (skipping mode check)")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return finding{
+			check:    mc.check,
+			severity: sevError,
+			message:  fmt.Sprintf("cannot stat %s: %v", mc.label, err),
+		}
+	}
+
+	perm := info.Mode().Perm()
+	if perm == mc.expected {
+		return okFinding(mc.check, fmt.Sprintf("%s mode is %04o", mc.label, mc.expected))
+	}
+
+	return finding{
+		check:    mc.check,
+		severity: mc.failSev,
+		message:  fmt.Sprintf("%s mode is %04o (should be %04o)", mc.label, perm, mc.expected),
+		fix:      fmt.Sprintf("chmod %o %s", mc.expected, path),
+		auto:     func() error { return os.Chmod(path, mc.expected) },
+	}
+}
+
+// --- vault checks ------------------------------------------------------------
 
 // checkIdentityPresent verifies that at least one identity source resolves.
-// Check #1.
 func checkIdentityPresent() finding {
-	_, err := vault.ResolveIdentity()
-	if err != nil {
+	if _, err := vault.ResolveIdentity(); err != nil {
 		return finding{
 			check:    "identity-present",
 			severity: sevError,
@@ -26,79 +64,40 @@ func checkIdentityPresent() finding {
 			fix:      "run 'hulak init' or set HULAK_MASTER_KEY for CI",
 		}
 	}
-	return finding{
-		check:    "identity-present",
-		severity: sevOk,
-		message:  "identity resolves",
-	}
+	return okFinding("identity-present", "identity resolves")
 }
 
-// checkIdentityMode verifies identity.txt is mode 0600.
-// Check #2. Auto-fixable.
+// checkIdentityMode verifies identity.txt is mode 0600. Auto-fixable.
 func checkIdentityMode() finding {
 	path, err := vault.IdentityPath()
-	if err != nil || !utils.FileExists(path) {
-		return finding{
-			check:    "identity-mode",
-			severity: sevInfo,
-			message:  "identity.txt not present (skipping mode check)",
-		}
-	}
-
-	info, err := os.Stat(path)
 	if err != nil {
-		return finding{
-			check:    "identity-mode",
-			severity: sevError,
-			message:  fmt.Sprintf("cannot stat identity file: %v", err),
-		}
+		return skipFinding("identity-mode", "identity.txt not present (skipping mode check)")
 	}
-
-	perm := info.Mode().Perm()
-	if perm == utils.SecretPer {
-		return finding{
-			check:    "identity-mode",
-			severity: sevOk,
-			message:  "identity file mode is 0600",
-		}
-	}
-
-	return finding{
-		check:    "identity-mode",
-		severity: sevError,
-		message:  fmt.Sprintf("identity file mode is %04o (should be 0600)", perm),
-		fix:      fmt.Sprintf("chmod 600 %s", path),
-		auto: func() error {
-			return os.Chmod(path, utils.SecretPer)
-		},
-	}
+	return checkFileMode(path, modeCheck{
+		check: "identity-mode", label: "identity file",
+		expected: utils.SecretPer, failSev: sevError,
+	})
 }
 
 // checkIdentityNotInGit verifies the identity file is not tracked by git.
 // Walks parents looking for .git/, then uses git ls-files to distinguish
 // "tracked" (sevError) from "in repo but untracked" (sevWarn). The latter
 // is common with dotfiles managers (yadm, stow) that place .git/ above
-// ~/.config but typically don't track the identity. Check #3.
+// ~/.config but typically don't track the identity.
 func checkIdentityNotInGit() finding {
 	path, err := vault.IdentityPath()
 	if err != nil || !utils.FileExists(path) {
-		return finding{
-			check:    "identity-in-git",
-			severity: sevInfo,
-			message:  "identity.txt not present (skipping git check)",
-		}
+		return skipFinding("identity-in-git", "identity.txt not present (skipping git check)")
 	}
 
-	// Resolve symlinks to catch the dotfiles repo case
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		resolved = path
 	}
 
-	// Check both original and resolved paths (catches symlinked dotfiles)
 	type candidate struct {
-		dir  string // directory containing identity file
-		file string // full path to identity file
+		dir  string
+		file string
 	}
 	candidates := []candidate{{filepath.Dir(path), path}}
 	if resolved != path {
@@ -110,9 +109,6 @@ func checkIdentityNotInGit() finding {
 			continue
 		}
 
-		// .git/ found in a parent. Check whether the file is actually
-		// tracked — dotfiles managers commonly place .git/ above
-		// ~/.config but don't track the identity file.
 		if isFileGitTracked(c.dir, c.file) {
 			return finding{
 				check:    "identity-in-git",
@@ -130,12 +126,354 @@ func checkIdentityNotInGit() finding {
 		}
 	}
 
+	return okFinding("identity-in-git", "identity file is not git-tracked")
+}
+
+// checkIdentityLeakedInProject scans tracked files for AGE-SECRET-KEY- prefix.
+func checkIdentityLeakedInProject() finding {
+	projectRoot, ok := utils.FindProjectRoot()
+	if !ok {
+		return skipFinding("identity-leaked-in-project", "no project root found (skipping leak scan)")
+	}
+
+	leaked := scanForSecretKey(projectRoot)
+	if len(leaked) > 0 {
+		return finding{
+			check:    "identity-leaked-in-project",
+			severity: sevError,
+			message:  fmt.Sprintf("AGE-SECRET-KEY- found in project file(s): %s", strings.Join(leaked, ", ")),
+			fix:      "remove the secret key and run 'hulak secrets rotate-key'",
+		}
+	}
+
+	return okFinding("identity-leaked-in-project", "no secret keys found in project files")
+}
+
+// checkStoreMode verifies store.age is mode 0600. Auto-fixable.
+func checkStoreMode() finding {
+	path, err := vault.StorePath()
+	if err != nil {
+		return skipFinding("store-mode", "store.age not found (skipping mode check)")
+	}
+	return checkFileMode(path, modeCheck{
+		check: "store-mode", label: "store.age",
+		expected: utils.SecretPer, failSev: sevError,
+	})
+}
+
+// checkStoreEncrypted verifies store.age starts with the age header.
+func checkStoreEncrypted() finding {
+	path, err := vault.StorePath()
+	if err != nil || !utils.FileExists(path) {
+		return skipFinding("store-encrypted", "store.age not found (skipping encryption check)")
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return finding{
+			check:    "store-encrypted",
+			severity: sevError,
+			message:  fmt.Sprintf("cannot open store.age: %v", err),
+		}
+	}
+	defer f.Close()
+
+	header := make([]byte, 64)
+	n, err := f.Read(header)
+	if err != nil || n == 0 {
+		return finding{
+			check:    "store-encrypted",
+			severity: sevError,
+			message:  "store.age is empty or unreadable",
+			fix:      "the store may be corrupt — check if you need to restore from backup",
+		}
+	}
+
+	if strings.HasPrefix(string(header[:n]), "age-encryption.org/v1") {
+		return okFinding("store-encrypted", "store.age has valid encryption header")
+	}
+
 	return finding{
-		check:    "identity-in-git",
-		severity: sevOk,
-		message:  "identity file is not git-tracked",
+		check:    "store-encrypted",
+		severity: sevError,
+		message:  "store.age does not start with age encryption header",
+		fix:      "the file may contain plaintext or be corrupt — re-encrypt or restore from backup",
 	}
 }
+
+// checkStoreDecrypts tries to decrypt store.age with the current identity.
+func checkStoreDecrypts() finding {
+	identity, err := vault.ResolveIdentity()
+	if err != nil {
+		return skipFinding("store-decrypts", "no identity available (skipping decryption check)")
+	}
+
+	if _, err = vault.ReadStore(identity); err != nil {
+		return finding{
+			check:    "store-decrypts",
+			severity: sevError,
+			message:  fmt.Sprintf("store.age cannot be decrypted: %v", err),
+			fix:      "check that your identity matches the recipients list, or run 'hulak secrets rotate-key'",
+		}
+	}
+
+	return okFinding("store-decrypts", "store.age decrypts with current identity")
+}
+
+// checkRecipientsExist verifies recipients.txt exists.
+func checkRecipientsExist() finding {
+	path, err := vault.RecipientsFilePath()
+	if err != nil || !utils.FileExists(path) {
+		return finding{
+			check:    "recipients-exist",
+			severity: sevError,
+			message:  "recipients.txt not found",
+			fix:      "run 'hulak secrets add-recipient' to create it",
+		}
+	}
+	return okFinding("recipients-exist", "recipients.txt exists")
+}
+
+// checkRecipientsValid verifies recipients.txt has ≥1 valid entry.
+func checkRecipientsValid() finding {
+	path, err := vault.RecipientsFilePath()
+	if err != nil || !utils.FileExists(path) {
+		return skipFinding("recipients-valid", "recipients.txt not found (skipping validation)")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return finding{
+			check:    "recipients-valid",
+			severity: sevError,
+			message:  fmt.Sprintf("cannot read recipients.txt: %v", err),
+		}
+	}
+
+	entries, err := vault.ParseRecipientsFileContent(data)
+	if err != nil || len(entries) == 0 {
+		return finding{
+			check:    "recipients-valid",
+			severity: sevError,
+			message:  "recipients.txt has no valid entries",
+			fix:      "run 'hulak secrets add-recipient' to add one",
+		}
+	}
+
+	return okFinding("recipients-valid", fmt.Sprintf("recipients.txt has %d valid entry(ies)", len(entries)))
+}
+
+// checkRecipientsCommitted checks if recipients.txt is committed or staged.
+func checkRecipientsCommitted() finding {
+	path, err := vault.RecipientsFilePath()
+	if err != nil || !utils.FileExists(path) {
+		return skipFinding("recipients-committed", "recipients.txt not found (skipping commit check)")
+	}
+
+	if _, err := exec.LookPath("git"); err != nil {
+		return skipFinding("recipients-committed", "git not available (skipping commit check)")
+	}
+
+	projectRoot, _ := utils.FindProjectRoot()
+	rel, err := filepath.Rel(projectRoot, path)
+	if err != nil {
+		rel = path
+	}
+
+	// Committed?
+	cmd := exec.Command("git", "ls-files", "--error-unmatch", rel)
+	cmd.Dir = projectRoot
+	if cmd.Run() == nil {
+		return okFinding("recipients-committed", "recipients.txt is committed")
+	}
+
+	// Staged?
+	cmd = exec.Command("git", "diff", "--cached", "--name-only", "--", rel)
+	cmd.Dir = projectRoot
+	output, err := cmd.Output()
+	if err == nil && strings.TrimSpace(string(output)) != "" {
+		return okFinding("recipients-committed", "recipients.txt is staged")
+	}
+
+	return finding{
+		check:    "recipients-committed",
+		severity: sevWarn,
+		message:  "recipients.txt is not committed or staged",
+		fix:      fmt.Sprintf("git add %s", rel),
+	}
+}
+
+// --- drift + misc checks -----------------------------------------------------
+
+// checkRecipientDrift compares recipient stanzas in store.age header to
+// the number of entries in recipients.txt.
+func checkRecipientDrift() finding {
+	storePath, err := vault.StorePath()
+	if err != nil || !utils.FileExists(storePath) {
+		return skipFinding("recipient-drift", "store.age not found (skipping drift check)")
+	}
+
+	recipientsPath, err := vault.RecipientsFilePath()
+	if err != nil || !utils.FileExists(recipientsPath) {
+		return skipFinding("recipient-drift", "recipients.txt not found (skipping drift check)")
+	}
+
+	stanzaCount, err := countStanzas(storePath)
+	if err != nil {
+		return skipFinding("recipient-drift", fmt.Sprintf("could not parse store.age header: %v", err))
+	}
+
+	data, err := os.ReadFile(recipientsPath)
+	if err != nil {
+		return skipFinding("recipient-drift", "could not read recipients.txt (skipping drift check)")
+	}
+
+	entries, err := vault.ParseRecipientsFileContent(data)
+	if err != nil {
+		return skipFinding("recipient-drift", "could not parse recipients.txt (skipping drift check)")
+	}
+
+	if stanzaCount == len(entries) {
+		return okFinding("recipient-drift", fmt.Sprintf("recipient count matches store stanzas (%d)", stanzaCount))
+	}
+
+	return finding{
+		check:    "recipient-drift",
+		severity: sevWarn,
+		message: fmt.Sprintf(
+			"recipients.txt has %d entries but store.age has %d stanzas — re-encryption needed",
+			len(entries), stanzaCount,
+		),
+		fix: "run 'hulak secrets rotate-key' to re-encrypt for all current recipients",
+	}
+}
+
+// checkStoreNotGitignored warns when store.age is gitignored in a team project.
+func checkStoreNotGitignored() finding {
+	recipientsPath, err := vault.RecipientsFilePath()
+	if err != nil || !utils.FileExists(recipientsPath) {
+		return skipFinding("store-not-gitignored", "recipients.txt not found (skipping gitignore check)")
+	}
+
+	data, err := os.ReadFile(recipientsPath)
+	if err != nil {
+		return skipFinding("store-not-gitignored", "could not read recipients.txt (skipping gitignore check)")
+	}
+
+	entries, _ := vault.ParseRecipientsFileContent(data)
+	if len(entries) <= 1 {
+		return okFinding("store-not-gitignored", "single-recipient project — .gitignore check not applicable")
+	}
+
+	if _, err := exec.LookPath("git"); err != nil {
+		return skipFinding("store-not-gitignored", "git not available (skipping gitignore check)")
+	}
+
+	projectRoot, _ := utils.FindProjectRoot()
+	storePath, err := vault.StorePath()
+	if err != nil {
+		return skipFinding("store-not-gitignored", "store path not resolved (skipping gitignore check)")
+	}
+
+	rel, err := filepath.Rel(projectRoot, storePath)
+	if err != nil {
+		rel = storePath
+	}
+
+	cmd := exec.Command("git", "check-ignore", "-q", rel)
+	cmd.Dir = projectRoot
+	if cmd.Run() == nil {
+		return finding{
+			check:    "store-not-gitignored",
+			severity: sevWarn,
+			message:  "store.age is in .gitignore — teammates won't be able to decrypt",
+			fix:      "remove the store.age entry from .gitignore for team projects",
+		}
+	}
+
+	return okFinding("store-not-gitignored", "store.age is not gitignored")
+}
+
+// checkLegacyKeyPub detects a lingering .hulak/key.pub file.
+func checkLegacyKeyPub() finding {
+	markerPath, err := utils.GetProjectMarker()
+	if err != nil {
+		return skipFinding("legacy-key-pub", "project marker not found (skipping legacy check)")
+	}
+
+	keyPubPath := filepath.Join(markerPath, "key.pub")
+	if utils.FileExists(keyPubPath) {
+		return finding{
+			check:    "legacy-key-pub",
+			severity: sevInfo,
+			message:  "legacy .hulak/key.pub found — recipients.txt is now the authoritative recipient list",
+			fix:      fmt.Sprintf("rm %s", keyPubPath),
+		}
+	}
+
+	return okFinding("legacy-key-pub", "no legacy key.pub found")
+}
+
+// checkDualBackend detects both env/ and .hulak/store.age existing.
+func checkDualBackend() finding {
+	projectRoot, ok := utils.FindProjectRoot()
+	if !ok {
+		return skipFinding("dual-backend", "no project root (skipping dual backend check)")
+	}
+
+	envDir := filepath.Join(projectRoot, utils.EnvironmentFolder)
+	storeDir := filepath.Join(projectRoot, utils.HiddenProjectName, utils.StoreFile)
+
+	if utils.DirExists(envDir) && utils.FileExists(storeDir) {
+		return finding{
+			check:    "dual-backend",
+			severity: sevError,
+			message:  "both env/ and .hulak/store.age exist",
+			fix:      "verify the migration with 'hulak secrets migrate', then remove env/",
+		}
+	}
+
+	return okFinding("dual-backend", "single backend in use")
+}
+
+// checkDualIdentity detects when both HULAK_MASTER_KEY and identity.txt exist.
+func checkDualIdentity() finding {
+	hasMasterKey := strings.TrimSpace(os.Getenv(utils.MasterKey)) != ""
+	if hasMasterKey && vault.IdentityExists() {
+		return finding{
+			check:    "dual-identity",
+			severity: sevInfo,
+			message:  "both HULAK_MASTER_KEY and identity.txt are present — HULAK_MASTER_KEY takes precedence",
+		}
+	}
+	return okFinding("dual-identity", "single identity source")
+}
+
+// checkStoreSize warns if store.age exceeds 1 MiB.
+func checkStoreSize() finding {
+	path, err := vault.StorePath()
+	if err != nil || !utils.FileExists(path) {
+		return skipFinding("store-size", "store.age not found (skipping size check)")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return skipFinding("store-size", "cannot stat store.age (skipping size check)")
+	}
+
+	if info.Size() > vault.MaxStoreSizeWarnBytes {
+		sizeMB := float64(info.Size()) / (1 << 20)
+		return finding{
+			check:    "store-size",
+			severity: sevWarn,
+			message:  fmt.Sprintf("store.age is %.1f MiB — consider using getFile for large values", sizeMB),
+		}
+	}
+
+	return okFinding("store-size", "store.age size is within limits")
+}
+
+// --- helpers -----------------------------------------------------------------
 
 // isInsideGitRepo walks from dir upward looking for a .git/ directory.
 func isInsideGitRepo(dir string) bool {
@@ -153,8 +491,7 @@ func isInsideGitRepo(dir string) bool {
 }
 
 // isFileGitTracked checks if filePath is tracked (committed or staged) by git.
-// dir should be within the git repo. Returns false if git is unavailable or
-// the path is not inside a valid git repository.
+// Returns false if git is unavailable or the path is not inside a valid repo.
 func isFileGitTracked(dir, filePath string) bool {
 	if _, err := exec.LookPath("git"); err != nil {
 		return false
@@ -164,49 +501,17 @@ func isFileGitTracked(dir, filePath string) bool {
 	return cmd.Run() == nil
 }
 
-// checkIdentityLeakedInProject scans tracked files for AGE-SECRET-KEY- prefix.
-// Check #4.
-func checkIdentityLeakedInProject() finding {
-	projectRoot, ok := utils.FindProjectRoot()
-	if !ok {
-		return finding{
-			check:    "identity-leaked-in-project",
-			severity: sevInfo,
-			message:  "no project root found (skipping leak scan)",
-		}
-	}
-
-	leaked := scanForSecretKey(projectRoot)
-	if len(leaked) > 0 {
-		return finding{
-			check:    "identity-leaked-in-project",
-			severity: sevError,
-			message:  fmt.Sprintf("AGE-SECRET-KEY- found in project file(s): %s", strings.Join(leaked, ", ")),
-			fix:      "remove the secret key and run 'hulak secrets rotate-key'",
-		}
-	}
-
-	return finding{
-		check:    "identity-leaked-in-project",
-		severity: sevOk,
-		message:  "no secret keys found in project files",
-	}
-}
-
 // scanForSecretKey walks the project looking for files containing AGE-SECRET-KEY-.
-// Skips binary-looking files, files > 1 MiB, and the identity file itself
-// (which is *supposed* to contain a secret key).
+// Skips files > 1 MiB and the identity file itself.
 func scanForSecretKey(root string) []string {
 	files := trackedFiles(root)
 	if files == nil {
 		files = walkTextFiles(root)
 	}
 
-	// Exclude the identity file — it legitimately contains AGE-SECRET-KEY-.
 	identityPath, _ := vault.IdentityPath()
 	if identityPath != "" {
-		resolved, err := filepath.EvalSymlinks(identityPath)
-		if err == nil {
+		if resolved, err := filepath.EvalSymlinks(identityPath); err == nil {
 			identityPath = resolved
 		}
 	}
@@ -214,8 +519,7 @@ func scanForSecretKey(root string) []string {
 	var leaked []string
 	for _, path := range files {
 		abs, _ := filepath.Abs(path)
-		resolved, err := filepath.EvalSymlinks(abs)
-		if err == nil {
+		if resolved, err := filepath.EvalSymlinks(abs); err == nil {
 			abs = resolved
 		}
 		if identityPath != "" && abs == identityPath {
@@ -243,8 +547,7 @@ func trackedFiles(root string) []string {
 
 	var files []string
 	for _, f := range strings.Split(string(output), "\x00") {
-		f = strings.TrimSpace(f)
-		if f != "" {
+		if f = strings.TrimSpace(f); f != "" {
 			files = append(files, filepath.Join(root, f))
 		}
 	}
@@ -258,7 +561,6 @@ func walkTextFiles(root string) []string {
 		if err != nil {
 			return nil
 		}
-		// Skip hidden dirs (except .hulak)
 		if d.IsDir() && strings.HasPrefix(d.Name(), ".") && d.Name() != utils.HiddenProjectName {
 			return filepath.SkipDir
 		}
@@ -292,408 +594,8 @@ func containsSecretKeyPrefix(path string) bool {
 	return false
 }
 
-// checkConfigDirMode verifies ~/.config/hulak/ is mode 0700.
-// Check #5. Auto-fixable.
-func checkConfigDirMode() finding {
-	path, err := vault.IdentityPath()
-	if err != nil {
-		return finding{
-			check:    "config-dir-mode",
-			severity: sevInfo,
-			message:  "config directory not resolved (skipping mode check)",
-		}
-	}
-
-	configDir := filepath.Dir(path)
-	info, err := os.Stat(configDir)
-	if err != nil {
-		return finding{
-			check:    "config-dir-mode",
-			severity: sevInfo,
-			message:  "config directory does not exist (skipping mode check)",
-		}
-	}
-
-	perm := info.Mode().Perm()
-	if perm == utils.SecretDirPer {
-		return finding{
-			check:    "config-dir-mode",
-			severity: sevOk,
-			message:  "config directory mode is 0700",
-		}
-	}
-
-	return finding{
-		check:    "config-dir-mode",
-		severity: sevWarn,
-		message:  fmt.Sprintf("config directory mode is %04o (should be 0700)", perm),
-		fix:      fmt.Sprintf("chmod 700 %s", configDir),
-		auto: func() error {
-			return os.Chmod(configDir, utils.SecretDirPer)
-		},
-	}
-}
-
-// checkStoreMode verifies store.age is mode 0600.
-// Check #6. Auto-fixable.
-func checkStoreMode() finding {
-	path, err := vault.StorePath()
-	if err != nil || !utils.FileExists(path) {
-		return finding{
-			check:    "store-mode",
-			severity: sevInfo,
-			message:  "store.age not found (skipping mode check)",
-		}
-	}
-
-	info, err := os.Stat(path)
-	if err != nil {
-		return finding{
-			check:    "store-mode",
-			severity: sevError,
-			message:  fmt.Sprintf("cannot stat store.age: %v", err),
-		}
-	}
-
-	perm := info.Mode().Perm()
-	if perm == utils.SecretPer {
-		return finding{
-			check:    "store-mode",
-			severity: sevOk,
-			message:  "store.age mode is 0600",
-		}
-	}
-
-	return finding{
-		check:    "store-mode",
-		severity: sevError,
-		message:  fmt.Sprintf("store.age mode is %04o (should be 0600)", perm),
-		fix:      fmt.Sprintf("chmod 600 %s", path),
-		auto: func() error {
-			return os.Chmod(path, utils.SecretPer)
-		},
-	}
-}
-
-// checkStoreEncrypted verifies store.age starts with the age header.
-// Check #7.
-func checkStoreEncrypted() finding {
-	path, err := vault.StorePath()
-	if err != nil || !utils.FileExists(path) {
-		return finding{
-			check:    "store-encrypted",
-			severity: sevInfo,
-			message:  "store.age not found (skipping encryption check)",
-		}
-	}
-
-	f, err := os.Open(path)
-	if err != nil {
-		return finding{
-			check:    "store-encrypted",
-			severity: sevError,
-			message:  fmt.Sprintf("cannot open store.age: %v", err),
-		}
-	}
-	defer f.Close()
-
-	header := make([]byte, 64)
-	n, err := f.Read(header)
-	if err != nil || n == 0 {
-		return finding{
-			check:    "store-encrypted",
-			severity: sevError,
-			message:  "store.age is empty or unreadable",
-			fix:      "the store may be corrupt — check if you need to restore from backup",
-		}
-	}
-
-	headerStr := string(header[:n])
-	if strings.HasPrefix(headerStr, "age-encryption.org/v1") {
-		return finding{
-			check:    "store-encrypted",
-			severity: sevOk,
-			message:  "store.age has valid encryption header",
-		}
-	}
-
-	return finding{
-		check:    "store-encrypted",
-		severity: sevError,
-		message:  "store.age does not start with age encryption header",
-		fix:      "the file may contain plaintext or be corrupt — re-encrypt or restore from backup",
-	}
-}
-
-// checkStoreDecrypts tries to decrypt store.age with the current identity.
-// Check #8.
-func checkStoreDecrypts() finding {
-	identity, err := vault.ResolveIdentity()
-	if err != nil {
-		return finding{
-			check:    "store-decrypts",
-			severity: sevInfo,
-			message:  "no identity available (skipping decryption check)",
-		}
-	}
-
-	_, err = vault.ReadStore(identity)
-	if err != nil {
-		return finding{
-			check:    "store-decrypts",
-			severity: sevError,
-			message:  fmt.Sprintf("store.age cannot be decrypted: %v", err),
-			fix:      "check that your identity matches the recipients list, or run 'hulak secrets rotate-key'",
-		}
-	}
-
-	return finding{
-		check:    "store-decrypts",
-		severity: sevOk,
-		message:  "store.age decrypts with current identity",
-	}
-}
-
-// checkRecipientsExist verifies recipients.txt exists.
-// Check #9.
-func checkRecipientsExist() finding {
-	path, err := vault.RecipientsFilePath()
-	if err != nil {
-		return finding{
-			check:    "recipients-exist",
-			severity: sevError,
-			message:  "recipients.txt not found",
-			fix:      "run 'hulak secrets add-recipient' to create it",
-		}
-	}
-
-	if !utils.FileExists(path) {
-		return finding{
-			check:    "recipients-exist",
-			severity: sevError,
-			message:  "recipients.txt does not exist",
-			fix:      "run 'hulak secrets add-recipient' to create it",
-		}
-	}
-
-	return finding{
-		check:    "recipients-exist",
-		severity: sevOk,
-		message:  "recipients.txt exists",
-	}
-}
-
-// checkRecipientsValid verifies recipients.txt has ≥1 valid entry.
-// Check #10.
-func checkRecipientsValid() finding {
-	path, err := vault.RecipientsFilePath()
-	if err != nil || !utils.FileExists(path) {
-		return finding{
-			check:    "recipients-valid",
-			severity: sevInfo,
-			message:  "recipients.txt not found (skipping validation)",
-		}
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return finding{
-			check:    "recipients-valid",
-			severity: sevError,
-			message:  fmt.Sprintf("cannot read recipients.txt: %v", err),
-		}
-	}
-
-	entries, err := vault.ParseRecipientsFileContent(data)
-	if err != nil || len(entries) == 0 {
-		return finding{
-			check:    "recipients-valid",
-			severity: sevError,
-			message:  "recipients.txt has no valid entries",
-			fix:      "run 'hulak secrets add-recipient' to add one",
-		}
-	}
-
-	return finding{
-		check:    "recipients-valid",
-		severity: sevOk,
-		message:  fmt.Sprintf("recipients.txt has %d valid entry(ies)", len(entries)),
-	}
-}
-
-// checkRecipientsMode verifies recipients.txt is mode 0644 (warn if stricter).
-// Check #11. Auto-fixable.
-func checkRecipientsMode() finding {
-	path, err := vault.RecipientsFilePath()
-	if err != nil || !utils.FileExists(path) {
-		return finding{
-			check:    "recipients-mode",
-			severity: sevInfo,
-			message:  "recipients.txt not found (skipping mode check)",
-		}
-	}
-
-	info, err := os.Stat(path)
-	if err != nil {
-		return finding{
-			check:    "recipients-mode",
-			severity: sevError,
-			message:  fmt.Sprintf("cannot stat recipients.txt: %v", err),
-		}
-	}
-
-	perm := info.Mode().Perm()
-	if perm == utils.FilePer {
-		return finding{
-			check:    "recipients-mode",
-			severity: sevOk,
-			message:  "recipients.txt mode is 0644",
-		}
-	}
-
-	return finding{
-		check:    "recipients-mode",
-		severity: sevWarn,
-		message:  fmt.Sprintf("recipients.txt mode is %04o (expected 0644)", perm),
-		fix:      fmt.Sprintf("chmod 644 %s", path),
-		auto: func() error {
-			return os.Chmod(path, utils.FilePer)
-		},
-	}
-}
-
-// checkRecipientsCommitted checks if recipients.txt is committed or staged in git.
-// Check #12.
-func checkRecipientsCommitted() finding {
-	path, err := vault.RecipientsFilePath()
-	if err != nil || !utils.FileExists(path) {
-		return finding{
-			check:    "recipients-committed",
-			severity: sevInfo,
-			message:  "recipients.txt not found (skipping commit check)",
-		}
-	}
-
-	if _, err := exec.LookPath("git"); err != nil {
-		return finding{
-			check:    "recipients-committed",
-			severity: sevInfo,
-			message:  "git not available (skipping commit check)",
-		}
-	}
-
-	// Check if the file is tracked by git (committed or staged)
-	projectRoot, _ := utils.FindProjectRoot()
-	rel, err := filepath.Rel(projectRoot, path)
-	if err != nil {
-		rel = path
-	}
-
-	cmd := exec.Command("git", "ls-files", "--error-unmatch", rel)
-	cmd.Dir = projectRoot
-	if err := cmd.Run(); err == nil {
-		return finding{
-			check:    "recipients-committed",
-			severity: sevOk,
-			message:  "recipients.txt is committed",
-		}
-	}
-
-	// Check if staged but not yet committed
-	cmd = exec.Command("git", "diff", "--cached", "--name-only", "--", rel)
-	cmd.Dir = projectRoot
-	output, err := cmd.Output()
-	if err == nil && strings.TrimSpace(string(output)) != "" {
-		return finding{
-			check:    "recipients-committed",
-			severity: sevOk,
-			message:  "recipients.txt is staged",
-		}
-	}
-
-	return finding{
-		check:    "recipients-committed",
-		severity: sevWarn,
-		message:  "recipients.txt is not committed or staged",
-		fix:      fmt.Sprintf("git add %s", rel),
-	}
-}
-
-// ── drift + remaining checks ───────────────────────────────────────────────
-
-// checkRecipientDrift counts recipient stanzas in store.age header and
-// compares to the number of entries in recipients.txt.
-// Check #13.
-func checkRecipientDrift() finding {
-	storePath, err := vault.StorePath()
-	if err != nil || !utils.FileExists(storePath) {
-		return finding{
-			check:    "recipient-drift",
-			severity: sevInfo,
-			message:  "store.age not found (skipping drift check)",
-		}
-	}
-
-	recipientsPath, err := vault.RecipientsFilePath()
-	if err != nil || !utils.FileExists(recipientsPath) {
-		return finding{
-			check:    "recipient-drift",
-			severity: sevInfo,
-			message:  "recipients.txt not found (skipping drift check)",
-		}
-	}
-
-	stanzaCount, err := countStanzas(storePath)
-	if err != nil {
-		return finding{
-			check:    "recipient-drift",
-			severity: sevInfo,
-			message:  fmt.Sprintf("could not parse store.age header: %v", err),
-		}
-	}
-
-	data, err := os.ReadFile(recipientsPath)
-	if err != nil {
-		return finding{
-			check:    "recipient-drift",
-			severity: sevInfo,
-			message:  "could not read recipients.txt (skipping drift check)",
-		}
-	}
-
-	entries, err := vault.ParseRecipientsFileContent(data)
-	if err != nil {
-		return finding{
-			check:    "recipient-drift",
-			severity: sevInfo,
-			message:  "could not parse recipients.txt (skipping drift check)",
-		}
-	}
-
-	if stanzaCount == len(entries) {
-		return finding{
-			check:    "recipient-drift",
-			severity: sevOk,
-			message:  fmt.Sprintf("recipient count matches store stanzas (%d)", stanzaCount),
-		}
-	}
-
-	return finding{
-		check:    "recipient-drift",
-		severity: sevWarn,
-		message: fmt.Sprintf(
-			"recipients.txt has %d entries but store.age has %d stanzas — re-encryption needed",
-			len(entries), stanzaCount,
-		),
-		fix: "run 'hulak secrets rotate-key' to re-encrypt for all current recipients",
-	}
-}
-
-// countStanzas counts lines starting with "->" in the age binary header
-// (before the "---" MAC line). Returns error if the file is armored or
-// doesn't look like a valid age binary file.
-// Note: hulak always writes the binary (non-armored) age format, so
-// rejecting armored files here is expected.
+// countStanzas counts "->" lines in the age binary header (before "---").
+// hulak always writes binary (non-armored) format; armored files are rejected.
 func countStanzas(path string) (int, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -725,199 +627,4 @@ func countStanzas(path string) (int, error) {
 		}
 	}
 	return count, scanner.Err()
-}
-
-// checkStoreNotGitignored warns when store.age is gitignored but there are
-// multiple recipients (team project).
-// Check #14.
-func checkStoreNotGitignored() finding {
-	recipientsPath, err := vault.RecipientsFilePath()
-	if err != nil || !utils.FileExists(recipientsPath) {
-		return finding{
-			check:    "store-not-gitignored",
-			severity: sevInfo,
-			message:  "recipients.txt not found (skipping gitignore check)",
-		}
-	}
-
-	data, err := os.ReadFile(recipientsPath)
-	if err != nil {
-		return finding{
-			check:    "store-not-gitignored",
-			severity: sevInfo,
-			message:  "could not read recipients.txt (skipping gitignore check)",
-		}
-	}
-
-	entries, _ := vault.ParseRecipientsFileContent(data)
-	if len(entries) <= 1 {
-		return finding{
-			check:    "store-not-gitignored",
-			severity: sevOk,
-			message:  "single-recipient project — .gitignore check not applicable",
-		}
-	}
-
-	// Check if store.age is gitignored
-	if _, err := exec.LookPath("git"); err != nil {
-		return finding{
-			check:    "store-not-gitignored",
-			severity: sevInfo,
-			message:  "git not available (skipping gitignore check)",
-		}
-	}
-
-	projectRoot, _ := utils.FindProjectRoot()
-	storePath, err := vault.StorePath()
-	if err != nil {
-		return finding{
-			check:    "store-not-gitignored",
-			severity: sevInfo,
-			message:  "store path not resolved (skipping gitignore check)",
-		}
-	}
-
-	rel, err := filepath.Rel(projectRoot, storePath)
-	if err != nil {
-		rel = storePath
-	}
-
-	cmd := exec.Command("git", "check-ignore", "-q", rel)
-	cmd.Dir = projectRoot
-	if cmd.Run() == nil {
-		// File IS gitignored
-		return finding{
-			check:    "store-not-gitignored",
-			severity: sevWarn,
-			message:  "store.age is in .gitignore — teammates won't be able to decrypt",
-			fix:      "remove the store.age entry from .gitignore for team projects",
-		}
-	}
-
-	return finding{
-		check:    "store-not-gitignored",
-		severity: sevOk,
-		message:  "store.age is not gitignored",
-	}
-}
-
-// checkLegacyKeyPub detects a lingering .hulak/key.pub file.
-// Check #15.
-func checkLegacyKeyPub() finding {
-	markerPath, err := utils.GetProjectMarker()
-	if err != nil {
-		return finding{
-			check:    "legacy-key-pub",
-			severity: sevInfo,
-			message:  "project marker not found (skipping legacy check)",
-		}
-	}
-
-	keyPubPath := filepath.Join(markerPath, "key.pub")
-	if utils.FileExists(keyPubPath) {
-		return finding{
-			check:    "legacy-key-pub",
-			severity: sevInfo,
-			message:  "legacy .hulak/key.pub found — recipients.txt is now the authoritative recipient list",
-			fix:      fmt.Sprintf("rm %s", keyPubPath),
-		}
-	}
-
-	return finding{
-		check:    "legacy-key-pub",
-		severity: sevOk,
-		message:  "no legacy key.pub found",
-	}
-}
-
-// checkDualBackend detects both env/ and .hulak/store.age existing.
-// Check #16.
-func checkDualBackend() finding {
-	projectRoot, ok := utils.FindProjectRoot()
-	if !ok {
-		return finding{
-			check:    "dual-backend",
-			severity: sevInfo,
-			message:  "no project root (skipping dual backend check)",
-		}
-	}
-
-	envDir := filepath.Join(projectRoot, utils.EnvironmentFolder)
-	storeDir := filepath.Join(projectRoot, utils.HiddenProjectName, utils.StoreFile)
-
-	hasEnv := utils.DirExists(envDir)
-	hasStore := utils.FileExists(storeDir)
-
-	if hasEnv && hasStore {
-		return finding{
-			check:    "dual-backend",
-			severity: sevError,
-			message:  "both env/ and .hulak/store.age exist",
-			fix:      "verify the migration with 'hulak secrets migrate', then remove env/",
-		}
-	}
-
-	return finding{
-		check:    "dual-backend",
-		severity: sevOk,
-		message:  "single backend in use",
-	}
-}
-
-// checkDualIdentity detects when both HULAK_MASTER_KEY and identity.txt exist.
-// Check #17.
-func checkDualIdentity() finding {
-	hasMasterKey := strings.TrimSpace(os.Getenv(utils.MasterKey)) != ""
-	hasIdentityFile := vault.IdentityExists()
-
-	if hasMasterKey && hasIdentityFile {
-		return finding{
-			check:    "dual-identity",
-			severity: sevInfo,
-			message:  "both HULAK_MASTER_KEY and identity.txt are present — HULAK_MASTER_KEY takes precedence",
-		}
-	}
-
-	return finding{
-		check:    "dual-identity",
-		severity: sevOk,
-		message:  "single identity source",
-	}
-}
-
-// checkStoreSize warns if store.age exceeds 1 MiB.
-// Check #18.
-func checkStoreSize() finding {
-	path, err := vault.StorePath()
-	if err != nil || !utils.FileExists(path) {
-		return finding{
-			check:    "store-size",
-			severity: sevInfo,
-			message:  "store.age not found (skipping size check)",
-		}
-	}
-
-	info, err := os.Stat(path)
-	if err != nil {
-		return finding{
-			check:    "store-size",
-			severity: sevInfo,
-			message:  "cannot stat store.age (skipping size check)",
-		}
-	}
-
-	if info.Size() > vault.MaxStoreSizeWarnBytes {
-		sizeMB := float64(info.Size()) / (1 << 20)
-		return finding{
-			check:    "store-size",
-			severity: sevWarn,
-			message:  fmt.Sprintf("store.age is %.1f MiB — consider using getFile for large values", sizeMB),
-		}
-	}
-
-	return finding{
-		check:    "store-size",
-		severity: sevOk,
-		message:  "store.age size is within limits",
-	}
 }

--- a/pkg/userFlags/doctor_test.go
+++ b/pkg/userFlags/doctor_test.go
@@ -298,7 +298,8 @@ func TestCheckEnvPermissions(t *testing.T) {
 				t.Errorf("checkEnvPermissions() returned %d warnings, want %d: %+v",
 					len(warnings), tc.wantWarnings, warnings)
 			}
-			if tc.wantContains != "" && len(warnings) > 0 && !warningsContain(warnings, tc.wantContains) {
+			if tc.wantContains != "" && len(warnings) > 0 &&
+				!warningsContain(warnings, tc.wantContains) {
 				t.Errorf("warnings %+v do not contain %q", warnings, tc.wantContains)
 			}
 		})
@@ -402,44 +403,5 @@ func TestCollectWarnings(t *testing.T) {
 			t.Errorf("expected at least 2 warnings (gitignore + permissions), got %d: %+v",
 				len(warnings), warnings)
 		}
-	})
-}
-
-func TestRunDoctor(t *testing.T) {
-	t.Run("healthy project shows no issues", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		envDir := createEnvDir(t, tmpDir)
-		createEnvFile(t, envDir, "global", utils.SecretPer, "KEY=value")
-
-		content := utils.EnvironmentFolder + "/\n"
-		if err := os.WriteFile(
-			filepath.Join(tmpDir, ".gitignore"), []byte(content), utils.FilePer,
-		); err != nil {
-			t.Fatal(err)
-		}
-
-		restore := chdirTemp(t, tmpDir)
-		defer restore()
-
-		runDoctor()
-	})
-
-	t.Run("missing env dir does not panic", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		restore := chdirTemp(t, tmpDir)
-		defer restore()
-
-		runDoctor()
-	})
-
-	t.Run("project with warnings does not panic", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		envDir := createEnvDir(t, tmpDir)
-		createEnvFile(t, envDir, "global", 0o644, "KEY=value")
-
-		restore := chdirTemp(t, tmpDir)
-		defer restore()
-
-		runDoctor()
 	})
 }

--- a/pkg/userFlags/doctor_test.go
+++ b/pkg/userFlags/doctor_test.go
@@ -75,10 +75,10 @@ func gitAddCommit(t *testing.T, message string) {
 	}
 }
 
-// warningsContain returns true if any warning message contains the substring.
-func warningsContain(warnings []warning, substr string) bool {
-	for _, w := range warnings {
-		if strings.Contains(w.message, substr) || strings.Contains(w.fix, substr) {
+// findingsContain returns true if any finding message or fix contains substr.
+func findingsContain(findings []finding, substr string) bool {
+	for _, f := range findings {
+		if strings.Contains(f.message, substr) || strings.Contains(f.fix, substr) {
 			return true
 		}
 	}
@@ -89,11 +89,11 @@ func TestCheckGitignore(t *testing.T) {
 	tests := []struct {
 		name         string
 		setup        func(t *testing.T, dir string)
-		wantWarnings bool
+		wantFindings bool
 		wantContains string
 	}{
 		{
-			name: "no warning when gitignore contains env/",
+			name: "no finding when gitignore contains env/",
 			setup: func(t *testing.T, dir string) {
 				createEnvDir(t, dir)
 				content := "node_modules/\n" + utils.EnvironmentFolder + "/\n*.log\n"
@@ -103,10 +103,10 @@ func TestCheckGitignore(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			wantWarnings: false,
+			wantFindings: false,
 		},
 		{
-			name: "no warning when gitignore contains env without trailing slash",
+			name: "no finding when gitignore contains env without trailing slash",
 			setup: func(t *testing.T, dir string) {
 				createEnvDir(t, dir)
 				content := utils.EnvironmentFolder + "\n"
@@ -116,10 +116,10 @@ func TestCheckGitignore(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			wantWarnings: false,
+			wantFindings: false,
 		},
 		{
-			name: "no warning when entry has surrounding whitespace",
+			name: "no finding when entry has surrounding whitespace",
 			setup: func(t *testing.T, dir string) {
 				createEnvDir(t, dir)
 				content := "  " + utils.EnvironmentFolder + "/  \n"
@@ -129,7 +129,7 @@ func TestCheckGitignore(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			wantWarnings: false,
+			wantFindings: false,
 		},
 		{
 			name: "warns when gitignore does not contain env entry",
@@ -142,7 +142,7 @@ func TestCheckGitignore(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			wantWarnings: true,
+			wantFindings: true,
 			wantContains: "not gitignored",
 		},
 		{
@@ -150,7 +150,7 @@ func TestCheckGitignore(t *testing.T) {
 			setup: func(t *testing.T, dir string) {
 				createEnvDir(t, dir)
 			},
-			wantWarnings: true,
+			wantFindings: true,
 			wantContains: "not gitignored",
 		},
 		{
@@ -163,15 +163,15 @@ func TestCheckGitignore(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			wantWarnings: true,
+			wantFindings: true,
 			wantContains: "not gitignored",
 		},
 		{
-			name: "includes fix command in warning",
+			name: "includes fix command in finding",
 			setup: func(t *testing.T, dir string) {
 				createEnvDir(t, dir)
 			},
-			wantWarnings: true,
+			wantFindings: true,
 			wantContains: "echo",
 		},
 	}
@@ -183,14 +183,14 @@ func TestCheckGitignore(t *testing.T) {
 			restore := chdirTemp(t, tmpDir)
 			defer restore()
 
-			warnings := checkGitignore()
-			hasWarnings := len(warnings) > 0
-			if hasWarnings != tc.wantWarnings {
-				t.Errorf("checkGitignore() returned %d warnings, wantWarnings=%v",
-					len(warnings), tc.wantWarnings)
+			findings := checkGitignore()
+			hasFindings := len(findings) > 0
+			if hasFindings != tc.wantFindings {
+				t.Errorf("checkGitignore() returned %d findings, wantFindings=%v",
+					len(findings), tc.wantFindings)
 			}
-			if tc.wantContains != "" && hasWarnings && !warningsContain(warnings, tc.wantContains) {
-				t.Errorf("warnings %+v do not contain %q", warnings, tc.wantContains)
+			if tc.wantContains != "" && hasFindings && !findingsContain(findings, tc.wantContains) {
+				t.Errorf("findings %+v do not contain %q", findings, tc.wantContains)
 			}
 		})
 	}
@@ -204,23 +204,23 @@ func TestCheckEnvPermissions(t *testing.T) {
 	tests := []struct {
 		name         string
 		setup        func(t *testing.T, envDir string)
-		wantWarnings int
+		wantFindings int
 		wantContains string
 	}{
 		{
-			name: "no warnings when all env files have restrictive permissions",
+			name: "no findings when all env files have restrictive permissions",
 			setup: func(t *testing.T, envDir string) {
 				createEnvFile(t, envDir, "global", utils.SecretPer, "SECRET=value")
 				createEnvFile(t, envDir, "prod", utils.SecretPer, "PROD_KEY=123")
 			},
-			wantWarnings: 0,
+			wantFindings: 0,
 		},
 		{
 			name: "warns per file with world-readable permissions",
 			setup: func(t *testing.T, envDir string) {
 				createEnvFile(t, envDir, "global", 0o644, "SECRET=leaked")
 			},
-			wantWarnings: 1,
+			wantFindings: 1,
 			wantContains: "global",
 		},
 		{
@@ -228,13 +228,13 @@ func TestCheckEnvPermissions(t *testing.T) {
 			setup: func(t *testing.T, envDir string) {
 				createEnvFile(t, envDir, "staging", 0o640, "KEY=value")
 			},
-			wantWarnings: 1,
+			wantFindings: 1,
 			wantContains: "staging",
 		},
 		{
-			name:         "no warnings when env dir is empty",
+			name:         "no findings when env dir is empty",
 			setup:        func(_ *testing.T, _ string) {},
-			wantWarnings: 0,
+			wantFindings: 0,
 		},
 		{
 			name: "skips non-env files",
@@ -247,7 +247,7 @@ func TestCheckEnvPermissions(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			wantWarnings: 0,
+			wantFindings: 0,
 		},
 		{
 			name: "skips subdirectories",
@@ -256,7 +256,7 @@ func TestCheckEnvPermissions(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			wantWarnings: 0,
+			wantFindings: 0,
 		},
 		{
 			name: "warns only for loose files in mixed set",
@@ -264,7 +264,7 @@ func TestCheckEnvPermissions(t *testing.T) {
 				createEnvFile(t, envDir, "global", utils.SecretPer, "OK=value")
 				createEnvFile(t, envDir, "leaky", 0o644, "LEAKED=yes")
 			},
-			wantWarnings: 1,
+			wantFindings: 1,
 			wantContains: "leaky",
 		},
 		{
@@ -273,14 +273,14 @@ func TestCheckEnvPermissions(t *testing.T) {
 				createEnvFile(t, envDir, "first", 0o644, "A=1")
 				createEnvFile(t, envDir, "second", 0o640, "B=2")
 			},
-			wantWarnings: 2,
+			wantFindings: 2,
 		},
 		{
 			name: "includes chmod fix command",
 			setup: func(t *testing.T, envDir string) {
 				createEnvFile(t, envDir, "global", 0o644, "KEY=val")
 			},
-			wantWarnings: 1,
+			wantFindings: 1,
 			wantContains: "chmod 600",
 		},
 	}
@@ -293,14 +293,14 @@ func TestCheckEnvPermissions(t *testing.T) {
 			restore := chdirTemp(t, tmpDir)
 			defer restore()
 
-			warnings := checkEnvPermissions(envDir)
-			if len(warnings) != tc.wantWarnings {
-				t.Errorf("checkEnvPermissions() returned %d warnings, want %d: %+v",
-					len(warnings), tc.wantWarnings, warnings)
+			findings := checkEnvPermissions(envDir)
+			if len(findings) != tc.wantFindings {
+				t.Errorf("checkEnvPermissions() returned %d findings, want %d: %+v",
+					len(findings), tc.wantFindings, findings)
 			}
-			if tc.wantContains != "" && len(warnings) > 0 &&
-				!warningsContain(warnings, tc.wantContains) {
-				t.Errorf("warnings %+v do not contain %q", warnings, tc.wantContains)
+			if tc.wantContains != "" && len(findings) > 0 &&
+				!findingsContain(findings, tc.wantContains) {
+				t.Errorf("findings %+v do not contain %q", findings, tc.wantContains)
 			}
 		})
 	}
@@ -311,19 +311,19 @@ func TestCheckGitHistory(t *testing.T) {
 		t.Skip("git not available")
 	}
 
-	t.Run("no warnings in non-git directory", func(t *testing.T) {
+	t.Run("no findings in non-git directory", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		createEnvDir(t, tmpDir)
 		restore := chdirTemp(t, tmpDir)
 		defer restore()
 
-		warnings := checkGitHistory()
-		if len(warnings) != 0 {
-			t.Errorf("expected no warnings in non-git dir, got: %+v", warnings)
+		findings := checkGitHistory()
+		if len(findings) != 0 {
+			t.Errorf("expected no findings in non-git dir, got: %+v", findings)
 		}
 	})
 
-	t.Run("no warnings when no env files in history", func(t *testing.T) {
+	t.Run("no findings when no env files in history", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		envDir := createEnvDir(t, tmpDir)
 		restore := chdirTemp(t, tmpDir)
@@ -338,9 +338,9 @@ func TestCheckGitHistory(t *testing.T) {
 		}
 		gitAddCommit(t, "initial commit")
 
-		warnings := checkGitHistory()
-		if len(warnings) != 0 {
-			t.Errorf("expected no warnings, got: %+v", warnings)
+		findings := checkGitHistory()
+		if len(findings) != 0 {
+			t.Errorf("expected no findings, got: %+v", findings)
 		}
 	})
 
@@ -355,53 +355,15 @@ func TestCheckGitHistory(t *testing.T) {
 		createEnvFile(t, envDir, "global", utils.SecretPer, "SECRET=oops")
 		gitAddCommit(t, "add secrets")
 
-		warnings := checkGitHistory()
-		if len(warnings) == 0 {
-			t.Fatal("expected warnings when env files in history, got none")
+		findings := checkGitHistory()
+		if len(findings) == 0 {
+			t.Fatal("expected findings when env files in history, got none")
 		}
-		if !warningsContain(warnings, "git history") {
-			t.Errorf("expected message about git history, got: %+v", warnings)
+		if !findingsContain(findings, "git history") {
+			t.Errorf("expected message about git history, got: %+v", findings)
 		}
-		if !warningsContain(warnings, "filter-repo") {
-			t.Errorf("expected fix mentioning filter-repo, got: %+v", warnings)
-		}
-	})
-}
-
-func TestCollectWarnings(t *testing.T) {
-	t.Run("returns no warnings for healthy project", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		envDir := createEnvDir(t, tmpDir)
-		createEnvFile(t, envDir, "global", utils.SecretPer, "KEY=value")
-
-		content := utils.EnvironmentFolder + "/\n"
-		if err := os.WriteFile(
-			filepath.Join(tmpDir, ".gitignore"), []byte(content), utils.FilePer,
-		); err != nil {
-			t.Fatal(err)
-		}
-
-		restore := chdirTemp(t, tmpDir)
-		defer restore()
-
-		warnings := collectWarnings(envDir)
-		if len(warnings) != 0 {
-			t.Errorf("expected no warnings for healthy project, got: %+v", warnings)
-		}
-	})
-
-	t.Run("aggregates warnings from all checks", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		envDir := createEnvDir(t, tmpDir)
-		createEnvFile(t, envDir, "global", 0o644, "KEY=value")
-
-		restore := chdirTemp(t, tmpDir)
-		defer restore()
-
-		warnings := collectWarnings(envDir)
-		if len(warnings) < 2 {
-			t.Errorf("expected at least 2 warnings (gitignore + permissions), got %d: %+v",
-				len(warnings), warnings)
+		if !findingsContain(findings, "filter-repo") {
+			t.Errorf("expected fix mentioning filter-repo, got: %+v", findings)
 		}
 	})
 }

--- a/pkg/userFlags/doctor_vault_test.go
+++ b/pkg/userFlags/doctor_vault_test.go
@@ -1,0 +1,752 @@
+package userflags
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
+)
+
+// ── test helpers ────────────────────────────────────────────────────────────
+
+// setupDoctorVaultProject creates a minimal vault project in tmpDir with .hulak/
+// marker, store.age, recipients.txt, and identity.txt in a temp config dir.
+// Returns the config dir path so the caller can set XDG_CONFIG_HOME.
+func setupDoctorVaultProject(t *testing.T, tmpDir string) string {
+	t.Helper()
+
+	// Create .hulak/ marker directory
+	hulakDir := filepath.Join(tmpDir, utils.HiddenProjectName)
+	if err := os.MkdirAll(hulakDir, utils.DirPer); err != nil {
+		t.Fatalf("mkdir .hulak: %v", err)
+	}
+
+	// Generate keypair and write identity
+	key, err := vault.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+
+	// Set up config dir for identity
+	configDir := filepath.Join(tmpDir, "config")
+	hulakConfigDir := filepath.Join(configDir, utils.ProjectName)
+	if err := os.MkdirAll(hulakConfigDir, utils.SecretDirPer); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	identityPath := filepath.Join(hulakConfigDir, utils.IdentityFile)
+	if err := os.WriteFile(identityPath, []byte(key.Identity.String()+"\n"), utils.SecretPer); err != nil {
+		t.Fatalf("write identity: %v", err)
+	}
+
+	// Write recipients.txt
+	recipientsContent := fmt.Sprintf("# test\n%s\n", key.Recipient.String())
+	recipientsPath := filepath.Join(hulakDir, utils.RecipientsFile)
+	if err := os.WriteFile(recipientsPath, []byte(recipientsContent), utils.FilePer); err != nil {
+		t.Fatalf("write recipients: %v", err)
+	}
+
+	// Encrypt and write a minimal store
+	store := &vault.Store{Envs: map[string]vault.Env{
+		"global": {"TEST_KEY": "test_value"},
+	}}
+	storeJSON, err := store.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal store: %v", err)
+	}
+	ciphertext, err := vault.EncryptText(storeJSON, key.Recipient)
+	if err != nil {
+		t.Fatalf("encrypt store: %v", err)
+	}
+	storePath := filepath.Join(hulakDir, utils.StoreFile)
+	if err := os.WriteFile(storePath, ciphertext, utils.SecretPer); err != nil {
+		t.Fatalf("write store.age: %v", err)
+	}
+
+	return configDir
+}
+
+// assertFindingSeverity asserts a finding exists with the expected severity.
+func assertFindingSeverity(t *testing.T, f *finding, checkID string, expected severity) {
+	t.Helper()
+	if f == nil {
+		t.Fatalf("finding %q not found", checkID)
+	}
+	if f.severity != expected {
+		t.Errorf("finding %q: got severity %v, want %v (message: %s)",
+			checkID, f.severity, expected, f.message)
+	}
+}
+
+// ── identity checks ────────────────────────────────────────────────────────
+
+func TestCheckIdentityMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission checks not reliable on Windows")
+	}
+
+	t.Run("ok when 0600", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configDir := setupDoctorVaultProject(t, tmpDir)
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+
+		f := checkIdentityMode()
+		assertFindingSeverity(t, &f, "identity-mode", sevOk)
+	})
+
+	t.Run("error when 0640", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configDir := setupDoctorVaultProject(t, tmpDir)
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+
+		identityPath := filepath.Join(configDir, utils.ProjectName, utils.IdentityFile)
+		if err := os.Chmod(identityPath, 0o640); err != nil {
+			t.Fatal(err)
+		}
+
+		f := checkIdentityMode()
+		assertFindingSeverity(t, &f, "identity-mode", sevError)
+		if f.auto == nil {
+			t.Error("expected auto-fixable")
+		}
+	})
+
+	t.Run("auto fix restores 0600", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configDir := setupDoctorVaultProject(t, tmpDir)
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+
+		identityPath := filepath.Join(configDir, utils.ProjectName, utils.IdentityFile)
+		if err := os.Chmod(identityPath, 0o640); err != nil {
+			t.Fatal(err)
+		}
+
+		f := checkIdentityMode()
+		if f.auto == nil {
+			t.Fatal("expected auto-fixable")
+		}
+		if err := f.auto(); err != nil {
+			t.Fatalf("auto fix failed: %v", err)
+		}
+
+		info, err := os.Stat(identityPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != utils.SecretPer {
+			t.Errorf("after fix: mode is %04o, want 0600", info.Mode().Perm())
+		}
+	})
+
+	t.Run("info when identity not present", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "no-config"))
+
+		f := checkIdentityMode()
+		assertFindingSeverity(t, &f, "identity-mode", sevInfo)
+	})
+}
+
+func TestCheckIdentityNotInGit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink tests not reliable on Windows")
+	}
+
+	t.Run("ok when not in git repo", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configDir := setupDoctorVaultProject(t, tmpDir)
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+
+		f := checkIdentityNotInGit()
+		assertFindingSeverity(t, &f, "identity-in-git", sevOk)
+	})
+
+	t.Run("error when identity is inside git repo", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Create a git repo and put identity inside it
+		gitDir := filepath.Join(tmpDir, "dotfiles")
+		if err := os.MkdirAll(filepath.Join(gitDir, ".git"), utils.DirPer); err != nil {
+			t.Fatal(err)
+		}
+
+		configDir := filepath.Join(gitDir, "config")
+		hulakConfigDir := filepath.Join(configDir, utils.ProjectName)
+		if err := os.MkdirAll(hulakConfigDir, utils.SecretDirPer); err != nil {
+			t.Fatal(err)
+		}
+		identityPath := filepath.Join(hulakConfigDir, utils.IdentityFile)
+		if err := os.WriteFile(identityPath, []byte("AGE-SECRET-KEY-test\n"), utils.SecretPer); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+
+		f := checkIdentityNotInGit()
+		assertFindingSeverity(t, &f, "identity-in-git", sevError)
+	})
+
+	t.Run("error when identity is symlinked into git repo", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Create a git repo (simulates dotfiles repo)
+		dotfilesDir := filepath.Join(tmpDir, "dotfiles")
+		if err := os.MkdirAll(filepath.Join(dotfilesDir, ".git"), utils.DirPer); err != nil {
+			t.Fatal(err)
+		}
+
+		// Actual config dir inside dotfiles repo
+		realConfigDir := filepath.Join(dotfilesDir, "config", utils.ProjectName)
+		if err := os.MkdirAll(realConfigDir, utils.SecretDirPer); err != nil {
+			t.Fatal(err)
+		}
+		realIdentityPath := filepath.Join(realConfigDir, utils.IdentityFile)
+		if err := os.WriteFile(realIdentityPath, []byte("AGE-SECRET-KEY-test\n"), utils.SecretPer); err != nil {
+			t.Fatal(err)
+		}
+
+		// Symlink from outside the git repo pointing in
+		symlinkConfigDir := filepath.Join(tmpDir, "symlinked-config", utils.ProjectName)
+		if err := os.MkdirAll(filepath.Dir(symlinkConfigDir), utils.DirPer); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(realConfigDir, symlinkConfigDir); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "symlinked-config"))
+
+		f := checkIdentityNotInGit()
+		assertFindingSeverity(t, &f, "identity-in-git", sevError)
+	})
+}
+
+func TestCheckIdentityLeakedInProject(t *testing.T) {
+	t.Run("ok when no secret keys in project", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configDir := setupDoctorVaultProject(t, tmpDir)
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		f := checkIdentityLeakedInProject()
+		assertFindingSeverity(t, &f, "identity-leaked-in-project", sevOk)
+	})
+
+	t.Run("error when YAML contains secret key", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configDir := setupDoctorVaultProject(t, tmpDir)
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		// Write a file with a secret key
+		leakyContent := "config:\n  key: AGE-SECRET-KEY-1XYZABC123\n"
+		if err := os.WriteFile(
+			filepath.Join(tmpDir, "config.yaml"), []byte(leakyContent), utils.FilePer,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		f := checkIdentityLeakedInProject()
+		assertFindingSeverity(t, &f, "identity-leaked-in-project", sevError)
+		if !strings.Contains(f.message, "config.yaml") {
+			t.Errorf("expected leaked file name in message, got: %s", f.message)
+		}
+	})
+}
+
+// ── config dir check ───────────────────────────────────────────────────────
+
+func TestCheckConfigDirMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission checks not reliable on Windows")
+	}
+
+	t.Run("ok when 0700", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configDir := setupDoctorVaultProject(t, tmpDir)
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+
+		f := checkConfigDirMode()
+		assertFindingSeverity(t, &f, "config-dir-mode", sevOk)
+	})
+
+	t.Run("warn when 0755", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configDir := setupDoctorVaultProject(t, tmpDir)
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+
+		hulakConfigDir := filepath.Join(configDir, utils.ProjectName)
+		if err := os.Chmod(hulakConfigDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		f := checkConfigDirMode()
+		assertFindingSeverity(t, &f, "config-dir-mode", sevWarn)
+		if f.auto == nil {
+			t.Error("expected auto-fixable")
+		}
+	})
+}
+
+// ── store checks ───────────────────────────────────────────────────────────
+
+func TestCheckStoreMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission checks not reliable on Windows")
+	}
+
+	t.Run("ok when 0600", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		f := checkStoreMode()
+		assertFindingSeverity(t, &f, "store-mode", sevOk)
+	})
+
+	t.Run("error when 0644", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		storePath := filepath.Join(tmpDir, utils.HiddenProjectName, utils.StoreFile)
+		if err := os.Chmod(storePath, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		f := checkStoreMode()
+		assertFindingSeverity(t, &f, "store-mode", sevError)
+		if f.auto == nil {
+			t.Error("expected auto-fixable")
+		}
+	})
+}
+
+func TestCheckStoreEncrypted(t *testing.T) {
+	t.Run("ok with valid age header", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		f := checkStoreEncrypted()
+		assertFindingSeverity(t, &f, "store-encrypted", sevOk)
+	})
+
+	t.Run("error when plaintext", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		// Overwrite store.age with plaintext
+		storePath := filepath.Join(tmpDir, utils.HiddenProjectName, utils.StoreFile)
+		if err := os.WriteFile(storePath, []byte(`{"global":{"key":"value"}}`), utils.SecretPer); err != nil {
+			t.Fatal(err)
+		}
+
+		f := checkStoreEncrypted()
+		assertFindingSeverity(t, &f, "store-encrypted", sevError)
+	})
+}
+
+func TestCheckStoreDecrypts(t *testing.T) {
+	t.Run("ok with matching identity", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configDir := setupDoctorVaultProject(t, tmpDir)
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		f := checkStoreDecrypts()
+		assertFindingSeverity(t, &f, "store-decrypts", sevOk)
+	})
+
+	t.Run("error with wrong identity", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configDir := setupDoctorVaultProject(t, tmpDir)
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		// Generate a different key and overwrite identity
+		wrongKey, err := vault.GenerateKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
+		identityPath := filepath.Join(configDir, utils.ProjectName, utils.IdentityFile)
+		if err := os.WriteFile(identityPath, []byte(wrongKey.Identity.String()+"\n"), utils.SecretPer); err != nil {
+			t.Fatal(err)
+		}
+
+		f := checkStoreDecrypts()
+		assertFindingSeverity(t, &f, "store-decrypts", sevError)
+	})
+}
+
+// ── recipients checks ──────────────────────────────────────────────────────
+
+func TestCheckRecipientsExist(t *testing.T) {
+	t.Run("ok when exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		f := checkRecipientsExist()
+		assertFindingSeverity(t, &f, "recipients-exist", sevOk)
+	})
+
+	t.Run("error when missing", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		recipientsPath := filepath.Join(tmpDir, utils.HiddenProjectName, utils.RecipientsFile)
+		os.Remove(recipientsPath)
+
+		f := checkRecipientsExist()
+		assertFindingSeverity(t, &f, "recipients-exist", sevError)
+	})
+}
+
+func TestCheckRecipientsValid(t *testing.T) {
+	t.Run("ok with valid entries", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		f := checkRecipientsValid()
+		assertFindingSeverity(t, &f, "recipients-valid", sevOk)
+	})
+
+	t.Run("error when all comments", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		recipientsPath := filepath.Join(tmpDir, utils.HiddenProjectName, utils.RecipientsFile)
+		if err := os.WriteFile(recipientsPath, []byte("# just a comment\n\n"), utils.FilePer); err != nil {
+			t.Fatal(err)
+		}
+
+		f := checkRecipientsValid()
+		assertFindingSeverity(t, &f, "recipients-valid", sevError)
+	})
+}
+
+func TestCheckRecipientsMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission checks not reliable on Windows")
+	}
+
+	t.Run("ok when 0644", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		f := checkRecipientsMode()
+		assertFindingSeverity(t, &f, "recipients-mode", sevOk)
+	})
+
+	t.Run("warn when 0600", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		recipientsPath := filepath.Join(tmpDir, utils.HiddenProjectName, utils.RecipientsFile)
+		if err := os.Chmod(recipientsPath, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		f := checkRecipientsMode()
+		assertFindingSeverity(t, &f, "recipients-mode", sevWarn)
+		if f.auto == nil {
+			t.Error("expected auto-fixable")
+		}
+	})
+}
+
+// ── drift check ────────────────────────────────────────────────────────────
+
+func TestCheckRecipientDrift(t *testing.T) {
+	t.Run("ok when counts match", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		f := checkRecipientDrift()
+		assertFindingSeverity(t, &f, "recipient-drift", sevOk)
+	})
+
+	t.Run("warn when recipients added but store not re-encrypted", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		// Add a second recipient to recipients.txt without re-encrypting
+		key2, err := vault.GenerateKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		recipientsPath := filepath.Join(tmpDir, utils.HiddenProjectName, utils.RecipientsFile)
+		data, err := os.ReadFile(recipientsPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		newData := string(data) + fmt.Sprintf("# extra\n%s\n", key2.Recipient.String())
+		if err := os.WriteFile(recipientsPath, []byte(newData), utils.FilePer); err != nil {
+			t.Fatal(err)
+		}
+
+		f := checkRecipientDrift()
+		assertFindingSeverity(t, &f, "recipient-drift", sevWarn)
+		if !strings.Contains(f.message, "2 entries") {
+			t.Errorf("expected mention of 2 entries, got: %s", f.message)
+		}
+	})
+}
+
+func TestCountStanzas(t *testing.T) {
+	t.Run("counts single recipient", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+
+		storePath := filepath.Join(tmpDir, utils.HiddenProjectName, utils.StoreFile)
+		count, err := countStanzas(storePath)
+		if err != nil {
+			t.Fatalf("countStanzas: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("expected 1 stanza, got %d", count)
+		}
+	})
+
+	t.Run("counts multi-recipient", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		hulakDir := filepath.Join(tmpDir, utils.HiddenProjectName)
+		if err := os.MkdirAll(hulakDir, utils.DirPer); err != nil {
+			t.Fatal(err)
+		}
+
+		key1, _ := vault.GenerateKeyPair()
+		key2, _ := vault.GenerateKeyPair()
+
+		store := &vault.Store{Envs: map[string]vault.Env{
+			"global": {"KEY": "val"},
+		}}
+		storeJSON, _ := store.MarshalJSON()
+		ciphertext, err := vault.EncryptText(storeJSON, key1.Recipient, key2.Recipient)
+		if err != nil {
+			t.Fatalf("encrypt: %v", err)
+		}
+		storePath := filepath.Join(hulakDir, utils.StoreFile)
+		if err := os.WriteFile(storePath, ciphertext, utils.SecretPer); err != nil {
+			t.Fatal(err)
+		}
+
+		count, err := countStanzas(storePath)
+		if err != nil {
+			t.Fatalf("countStanzas: %v", err)
+		}
+		if count != 2 {
+			t.Errorf("expected 2 stanzas, got %d", count)
+		}
+	})
+
+	t.Run("errors on armored format", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		armoredPath := filepath.Join(tmpDir, "armored.age")
+		content := "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24=\n-----END AGE ENCRYPTED FILE-----\n"
+		if err := os.WriteFile(armoredPath, []byte(content), utils.SecretPer); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := countStanzas(armoredPath)
+		if err == nil {
+			t.Error("expected error for armored format")
+		}
+	})
+
+	t.Run("errors on non-age file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		junkPath := filepath.Join(tmpDir, "junk.age")
+		if err := os.WriteFile(junkPath, []byte("not an age file"), utils.SecretPer); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := countStanzas(junkPath)
+		if err == nil {
+			t.Error("expected error for non-age file")
+		}
+	})
+}
+
+// ── remaining checks ───────────────────────────────────────────────────────
+
+func TestCheckLegacyKeyPub(t *testing.T) {
+	t.Run("ok when no key.pub", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		f := checkLegacyKeyPub()
+		assertFindingSeverity(t, &f, "legacy-key-pub", sevOk)
+	})
+
+	t.Run("info when key.pub exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		keyPubPath := filepath.Join(tmpDir, utils.HiddenProjectName, "key.pub")
+		if err := os.WriteFile(keyPubPath, []byte("age1..."), utils.FilePer); err != nil {
+			t.Fatal(err)
+		}
+
+		f := checkLegacyKeyPub()
+		assertFindingSeverity(t, &f, "legacy-key-pub", sevInfo)
+	})
+}
+
+func TestCheckDualBackend(t *testing.T) {
+	t.Run("ok when only vault", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		f := checkDualBackend()
+		assertFindingSeverity(t, &f, "dual-backend", sevOk)
+	})
+
+	t.Run("error when both env/ and store.age", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		// Create env/ alongside .hulak/
+		createEnvDir(t, tmpDir)
+
+		f := checkDualBackend()
+		assertFindingSeverity(t, &f, "dual-backend", sevError)
+	})
+}
+
+func TestCheckDualIdentity(t *testing.T) {
+	t.Run("ok when only file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configDir := setupDoctorVaultProject(t, tmpDir)
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+		// Make sure HULAK_MASTER_KEY is not set
+		t.Setenv(utils.MasterKey, "")
+
+		f := checkDualIdentity()
+		assertFindingSeverity(t, &f, "dual-identity", sevOk)
+	})
+
+	t.Run("info when both set", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configDir := setupDoctorVaultProject(t, tmpDir)
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+
+		key, _ := vault.GenerateKeyPair()
+		t.Setenv(utils.MasterKey, key.Identity.String())
+
+		f := checkDualIdentity()
+		assertFindingSeverity(t, &f, "dual-identity", sevInfo)
+	})
+}
+
+func TestCheckStoreSize(t *testing.T) {
+	t.Run("ok when small", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupDoctorVaultProject(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		f := checkStoreSize()
+		assertFindingSeverity(t, &f, "store-size", sevOk)
+	})
+
+	// Testing the >1 MiB case would require writing a large file;
+	// skipping to keep tests fast. The logic is a straightforward size comparison.
+}
+
+// ── report and output ──────────────────────────────────────────────────────
+
+func TestDoctorReportSummary(t *testing.T) {
+	r := &doctorReport{
+		findings: []finding{
+			{check: "a", severity: sevOk},
+			{check: "b", severity: sevOk},
+			{check: "c", severity: sevWarn},
+			{check: "d", severity: sevError},
+			{check: "e", severity: sevInfo},
+		},
+	}
+
+	s := r.summary()
+	if s.Ok != 2 || s.Warn != 1 || s.Error != 1 || s.Info != 1 {
+		t.Errorf("summary: got %+v", s)
+	}
+}
+
+func TestDoctorReportExitCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		findings []finding
+		want     int
+	}{
+		{"ok only", []finding{{severity: sevOk}}, 0},
+		{"info only", []finding{{severity: sevInfo}}, 0},
+		{"warn", []finding{{severity: sevOk}, {severity: sevWarn}}, 1},
+		{"error", []finding{{severity: sevOk}, {severity: sevError}}, 2},
+		{"error trumps warn", []finding{{severity: sevWarn}, {severity: sevError}}, 2},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &doctorReport{findings: tc.findings}
+			if got := r.exitCode(); got != tc.want {
+				t.Errorf("exitCode: got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSeverityString(t *testing.T) {
+	tests := []struct {
+		s    severity
+		want string
+	}{
+		{sevInfo, "info"},
+		{sevOk, "ok"},
+		{sevWarn, "warn"},
+		{sevError, "error"},
+	}
+	for _, tc := range tests {
+		if got := tc.s.String(); got != tc.want {
+			t.Errorf("severity(%d).String() = %q, want %q", tc.s, got, tc.want)
+		}
+	}
+}

--- a/pkg/userFlags/doctor_vault_test.go
+++ b/pkg/userFlags/doctor_vault_test.go
@@ -297,40 +297,6 @@ func TestCheckIdentityLeakedInProject(t *testing.T) {
 	})
 }
 
-// ── config dir check ───────────────────────────────────────────────────────
-
-func TestCheckConfigDirMode(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("permission checks not reliable on Windows")
-	}
-
-	t.Run("ok when 0700", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		configDir := setupDoctorVaultProject(t, tmpDir)
-		t.Setenv("XDG_CONFIG_HOME", configDir)
-
-		f := checkConfigDirMode()
-		assertFindingSeverity(t, &f, "config-dir-mode", sevOk)
-	})
-
-	t.Run("warn when 0755", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		configDir := setupDoctorVaultProject(t, tmpDir)
-		t.Setenv("XDG_CONFIG_HOME", configDir)
-
-		hulakConfigDir := filepath.Join(configDir, utils.ProjectName)
-		if err := os.Chmod(hulakConfigDir, 0o755); err != nil {
-			t.Fatal(err)
-		}
-
-		f := checkConfigDirMode()
-		assertFindingSeverity(t, &f, "config-dir-mode", sevWarn)
-		if f.auto == nil {
-			t.Error("expected auto-fixable")
-		}
-	})
-}
-
 // ── store checks ───────────────────────────────────────────────────────────
 
 func TestCheckStoreMode(t *testing.T) {
@@ -480,40 +446,6 @@ func TestCheckRecipientsValid(t *testing.T) {
 
 		f := checkRecipientsValid()
 		assertFindingSeverity(t, &f, "recipients-valid", sevError)
-	})
-}
-
-func TestCheckRecipientsMode(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("permission checks not reliable on Windows")
-	}
-
-	t.Run("ok when 0644", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		setupDoctorVaultProject(t, tmpDir)
-		restore := chdirTemp(t, tmpDir)
-		defer restore()
-
-		f := checkRecipientsMode()
-		assertFindingSeverity(t, &f, "recipients-mode", sevOk)
-	})
-
-	t.Run("warn when 0600", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		setupDoctorVaultProject(t, tmpDir)
-		restore := chdirTemp(t, tmpDir)
-		defer restore()
-
-		recipientsPath := filepath.Join(tmpDir, utils.HiddenProjectName, utils.RecipientsFile)
-		if err := os.Chmod(recipientsPath, 0o600); err != nil {
-			t.Fatal(err)
-		}
-
-		f := checkRecipientsMode()
-		assertFindingSeverity(t, &f, "recipients-mode", sevWarn)
-		if f.auto == nil {
-			t.Error("expected auto-fixable")
-		}
 	})
 }
 

--- a/pkg/userFlags/doctor_vault_test.go
+++ b/pkg/userFlags/doctor_vault_test.go
@@ -1,8 +1,10 @@
 package userflags
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -165,10 +167,10 @@ func TestCheckIdentityNotInGit(t *testing.T) {
 		assertFindingSeverity(t, &f, "identity-in-git", sevOk)
 	})
 
-	t.Run("error when identity is inside git repo", func(t *testing.T) {
+	t.Run("warn when identity is inside git repo but not tracked", func(t *testing.T) {
 		tmpDir := t.TempDir()
 
-		// Create a git repo and put identity inside it
+		// Create a fake git repo dir and put identity inside it
 		gitDir := filepath.Join(tmpDir, "dotfiles")
 		if err := os.MkdirAll(filepath.Join(gitDir, ".git"), utils.DirPer); err != nil {
 			t.Fatal(err)
@@ -187,13 +189,48 @@ func TestCheckIdentityNotInGit(t *testing.T) {
 		t.Setenv("XDG_CONFIG_HOME", configDir)
 
 		f := checkIdentityNotInGit()
-		assertFindingSeverity(t, &f, "identity-in-git", sevError)
+		assertFindingSeverity(t, &f, "identity-in-git", sevWarn)
+		if !strings.Contains(f.message, "not tracked") {
+			t.Errorf("expected 'not tracked' in message, got: %s", f.message)
+		}
 	})
 
-	t.Run("error when identity is symlinked into git repo", func(t *testing.T) {
+	t.Run("error when identity is actually tracked by git", func(t *testing.T) {
+		if _, lookErr := exec.LookPath("git"); lookErr != nil {
+			t.Skip("git not available")
+		}
+
+		tmpDir := t.TempDir()
+		repoDir := filepath.Join(tmpDir, "dotfiles")
+		configDir := filepath.Join(repoDir, "config")
+		hulakConfigDir := filepath.Join(configDir, utils.ProjectName)
+		if err := os.MkdirAll(hulakConfigDir, utils.SecretDirPer); err != nil {
+			t.Fatal(err)
+		}
+		identityPath := filepath.Join(hulakConfigDir, utils.IdentityFile)
+		if err := os.WriteFile(identityPath, []byte("AGE-SECRET-KEY-test\n"), utils.SecretPer); err != nil {
+			t.Fatal(err)
+		}
+
+		// Init real git repo and track the identity file
+		restore := chdirTemp(t, repoDir)
+		gitInit(t)
+		gitAddCommit(t, "track identity")
+		restore()
+
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+
+		f := checkIdentityNotInGit()
+		assertFindingSeverity(t, &f, "identity-in-git", sevError)
+		if !strings.Contains(f.message, "tracked by git") {
+			t.Errorf("expected 'tracked by git' in message, got: %s", f.message)
+		}
+	})
+
+	t.Run("warn when identity is symlinked into git repo but not tracked", func(t *testing.T) {
 		tmpDir := t.TempDir()
 
-		// Create a git repo (simulates dotfiles repo)
+		// Create a fake git repo (simulates dotfiles repo)
 		dotfilesDir := filepath.Join(tmpDir, "dotfiles")
 		if err := os.MkdirAll(filepath.Join(dotfilesDir, ".git"), utils.DirPer); err != nil {
 			t.Fatal(err)
@@ -221,7 +258,7 @@ func TestCheckIdentityNotInGit(t *testing.T) {
 		t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "symlinked-config"))
 
 		f := checkIdentityNotInGit()
-		assertFindingSeverity(t, &f, "identity-in-git", sevError)
+		assertFindingSeverity(t, &f, "identity-in-git", sevWarn)
 	})
 }
 
@@ -749,4 +786,274 @@ func TestSeverityString(t *testing.T) {
 			t.Errorf("severity(%d).String() = %q, want %q", tc.s, got, tc.want)
 		}
 	}
+}
+
+// ── JSON output ─────────────────────────────────────────────────────────
+
+func TestPrintJSON(t *testing.T) {
+	r := &doctorReport{
+		project: "/test/project",
+		backend: "vault (.hulak/store.age)",
+		findings: []finding{
+			{check: "test-ok", severity: sevOk, message: "all good"},
+			{check: "test-warn", severity: sevWarn, message: "fixme", fix: "do X", auto: func() error { return nil }},
+			{check: "test-info", severity: sevInfo, message: "fyi"},
+		},
+	}
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	rp, wp, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = wp
+	r.printJSON()
+	wp.Close()
+	os.Stdout = oldStdout
+
+	var jr jsonReport
+	if err := json.NewDecoder(rp).Decode(&jr); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+
+	if jr.Project != "/test/project" {
+		t.Errorf("project: got %q", jr.Project)
+	}
+	if jr.Backend != "vault (.hulak/store.age)" {
+		t.Errorf("backend: got %q", jr.Backend)
+	}
+	if len(jr.Findings) != 3 {
+		t.Fatalf("findings: got %d, want 3", len(jr.Findings))
+	}
+
+	// Verify check IDs and severity strings
+	if jr.Findings[0].Check != "test-ok" || jr.Findings[0].Severity != "ok" {
+		t.Errorf("finding[0]: %+v", jr.Findings[0])
+	}
+	if jr.Findings[1].Check != "test-warn" || jr.Findings[1].Severity != "warn" {
+		t.Errorf("finding[1]: %+v", jr.Findings[1])
+	}
+	if !jr.Findings[1].AutoFixable {
+		t.Error("finding[1] should be auto_fixable")
+	}
+	if jr.Findings[2].Check != "test-info" || jr.Findings[2].Severity != "info" {
+		t.Errorf("finding[2]: %+v", jr.Findings[2])
+	}
+
+	// Summary
+	if jr.Summary.Ok != 1 || jr.Summary.Warn != 1 || jr.Summary.Info != 1 || jr.Summary.Error != 0 {
+		t.Errorf("summary: %+v", jr.Summary)
+	}
+}
+
+// ── runFixes ────────────────────────────────────────────────────────────
+
+func TestRunFixesWithFailure(t *testing.T) {
+	callCount := 0
+	r := &doctorReport{
+		findings: []finding{
+			{
+				check:    "will-fail",
+				severity: sevWarn,
+				message:  "bad perms",
+				fix:      "chmod 600",
+				auto:     func() error { return fmt.Errorf("permission denied") },
+			},
+			{
+				check:    "will-succeed",
+				severity: sevWarn,
+				message:  "other issue",
+				fix:      "fix it",
+				auto: func() error {
+					callCount++
+					return nil
+				},
+			},
+		},
+	}
+
+	// Run with --yes to skip prompts
+	r.runFixes(true)
+
+	// Failed fix should keep severity
+	if r.findings[0].severity != sevWarn {
+		t.Errorf("failed fix should keep sevWarn, got %v", r.findings[0].severity)
+	}
+	if r.findings[0].auto == nil {
+		t.Error("failed fix should keep auto func")
+	}
+
+	// Successful fix should upgrade to sevOk
+	if r.findings[1].severity != sevOk {
+		t.Errorf("successful fix should be sevOk, got %v", r.findings[1].severity)
+	}
+	if r.findings[1].auto != nil {
+		t.Error("successful fix should clear auto func")
+	}
+	if callCount != 1 {
+		t.Errorf("expected successful auto to be called once, got %d", callCount)
+	}
+}
+
+// ── runDoctor integration ───────────────────────────────────────────────
+
+func TestRunDoctor(t *testing.T) {
+	t.Run("not a hulak project returns 0", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		code := runDoctor(doctorOpts{})
+		if code != 0 {
+			t.Errorf("expected exit code 0 for non-project dir, got %d", code)
+		}
+	})
+
+	t.Run("healthy classic project returns 0", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		envDir := createEnvDir(t, tmpDir)
+		createEnvFile(t, envDir, "global", utils.SecretPer, "KEY=value")
+
+		content := utils.EnvironmentFolder + "/\n"
+		if err := os.WriteFile(
+			filepath.Join(tmpDir, ".gitignore"), []byte(content), utils.FilePer,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		code := runDoctor(doctorOpts{})
+		// Classic always has migrate-suggestion (info), so 0 is expected
+		if code != 0 {
+			t.Errorf("expected exit code 0 for healthy classic project, got %d", code)
+		}
+	})
+
+	t.Run("classic project with warnings returns 1", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		envDir := createEnvDir(t, tmpDir)
+		// Loose permissions → warning
+		createEnvFile(t, envDir, "global", 0o644, "KEY=value")
+
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		code := runDoctor(doctorOpts{})
+		if code != 1 {
+			t.Errorf("expected exit code 1 for classic project with warnings, got %d", code)
+		}
+	})
+
+	t.Run("fix and json are mutually exclusive", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		createEnvDir(t, tmpDir)
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		code := runDoctor(doctorOpts{fix: true, jsonOut: true})
+		if code != 1 {
+			t.Errorf("expected exit code 1 for --fix --json, got %d", code)
+		}
+	})
+
+	t.Run("json output is valid JSON", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		envDir := createEnvDir(t, tmpDir)
+		createEnvFile(t, envDir, "global", utils.SecretPer, "KEY=value")
+		content := utils.EnvironmentFolder + "/\n"
+		if err := os.WriteFile(
+			filepath.Join(tmpDir, ".gitignore"), []byte(content), utils.FilePer,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		restore := chdirTemp(t, tmpDir)
+		defer restore()
+
+		// Capture stdout
+		oldStdout := os.Stdout
+		rp, wp, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		os.Stdout = wp
+		code := runDoctor(doctorOpts{jsonOut: true})
+		wp.Close()
+		os.Stdout = oldStdout
+
+		if code != 0 {
+			t.Errorf("expected exit code 0, got %d", code)
+		}
+
+		var jr jsonReport
+		if err := json.NewDecoder(rp).Decode(&jr); err != nil {
+			t.Fatalf("JSON output is not valid: %v", err)
+		}
+		if jr.Backend != "classic (env/)" {
+			t.Errorf("backend: got %q, want classic", jr.Backend)
+		}
+	})
+}
+
+// ── isFileGitTracked ────────────────────────────────────────────────────
+
+func TestIsFileGitTracked(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	t.Run("tracked file returns true", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "tracked.txt")
+		if err := os.WriteFile(filePath, []byte("data"), utils.FilePer); err != nil {
+			t.Fatal(err)
+		}
+
+		restore := chdirTemp(t, tmpDir)
+		gitInit(t)
+		gitAddCommit(t, "add file")
+		restore()
+
+		if !isFileGitTracked(tmpDir, filePath) {
+			t.Error("expected tracked file to return true")
+		}
+	})
+
+	t.Run("untracked file returns false", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Create a tracked file so git init has something to commit
+		if err := os.WriteFile(filepath.Join(tmpDir, "readme.txt"), []byte("hi"), utils.FilePer); err != nil {
+			t.Fatal(err)
+		}
+		restore := chdirTemp(t, tmpDir)
+		gitInit(t)
+		gitAddCommit(t, "initial")
+		restore()
+
+		// Now add an untracked file
+		untrackedPath := filepath.Join(tmpDir, "untracked.txt")
+		if err := os.WriteFile(untrackedPath, []byte("data"), utils.FilePer); err != nil {
+			t.Fatal(err)
+		}
+
+		if isFileGitTracked(tmpDir, untrackedPath) {
+			t.Error("expected untracked file to return false")
+		}
+	})
+
+	t.Run("non-git dir returns false", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "file.txt")
+		if err := os.WriteFile(filePath, []byte("data"), utils.FilePer); err != nil {
+			t.Fatal(err)
+		}
+
+		if isFileGitTracked(tmpDir, filePath) {
+			t.Error("expected non-git dir to return false")
+		}
+	})
 }

--- a/pkg/userFlags/env_backup.go
+++ b/pkg/userFlags/env_backup.go
@@ -86,6 +86,10 @@ func newEnvBackupListCmd() *command {
 
 // runBackup creates a backup of store.age.
 func runBackup(outPath string, force bool) error {
+	if err := requireVaultProject(); err != nil {
+		return err
+	}
+
 	identity, err := vault.ResolveIdentity()
 	if err != nil {
 		return fmt.Errorf("failed to load identity: %w", err)
@@ -170,6 +174,10 @@ func resolveBackupDest(outPath string, force bool) (string, error) {
 
 // runBackupList prints existing backups from .hulak/backups/.
 func runBackupList() error {
+	if err := requireVaultProject(); err != nil {
+		return err
+	}
+
 	backupsDir, err := vault.BackupsDir()
 	if err != nil {
 		return err
@@ -271,6 +279,10 @@ func newEnvRestoreCmd() *command {
 
 // runRestore restores store.age from a backup.
 func runRestore(backupPath string, force bool) error {
+	if err := requireVaultProject(); err != nil {
+		return err
+	}
+
 	resolvedPath, err := resolveRestorePath(backupPath)
 	if err != nil {
 		return err

--- a/pkg/userFlags/env_crud.go
+++ b/pkg/userFlags/env_crud.go
@@ -72,6 +72,9 @@ func runEnvSet(args []string, envName string, useStdin bool) error {
 	}
 	key := args[0]
 
+	if err := requireVaultProject(); err != nil {
+		return err
+	}
 	if err := utils.ValidateEnvName(envName); err != nil {
 		return err
 	}
@@ -190,6 +193,9 @@ func runEnvGet(args []string, envName string) error {
 	}
 	key := args[0]
 
+	if err := requireVaultProject(); err != nil {
+		return err
+	}
 	if err := utils.ValidateEnvName(envName); err != nil {
 		return err
 	}
@@ -278,6 +284,9 @@ func runEnvDelete(args []string, envName string) error {
 	}
 	key := args[0]
 
+	if err := requireVaultProject(); err != nil {
+		return err
+	}
 	if err := utils.ValidateEnvName(envName); err != nil {
 		return err
 	}

--- a/pkg/userFlags/env_edit.go
+++ b/pkg/userFlags/env_edit.go
@@ -75,6 +75,9 @@ func runEnvEdit(args []string, envName string) error {
 	if len(args) > 0 {
 		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
 	}
+	if err := requireVaultProject(); err != nil {
+		return err
+	}
 
 	if envName == "" {
 		picked, err := envPicker()

--- a/pkg/userFlags/env_list.go
+++ b/pkg/userFlags/env_list.go
@@ -41,6 +41,9 @@ func runEnvList(args []string) error {
 	if len(args) > 0 {
 		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
 	}
+	if err := requireVaultProject(); err != nil {
+		return err
+	}
 
 	identity, err := vault.ResolveIdentity()
 	if err != nil {
@@ -106,6 +109,9 @@ func newEnvKeysCmd() *command {
 func runEnvKeys(args []string, envName, search string, show bool) error {
 	if len(args) > 0 {
 		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
+	}
+	if err := requireVaultProject(); err != nil {
+		return err
 	}
 	if err := utils.ValidateEnvName(envName); err != nil {
 		return err

--- a/pkg/userFlags/env_recipients.go
+++ b/pkg/userFlags/env_recipients.go
@@ -192,6 +192,10 @@ func runAddRecipient(
 	gitHubUser, keyserverURL string,
 	allowRSA bool,
 ) error {
+	if err := requireVaultProject(); err != nil {
+		return err
+	}
+
 	pubKeys, err := resolveRecipientKeys(args, useStdin, gitHubUser, keyserverURL, allowRSA)
 	if err != nil {
 		return err
@@ -304,6 +308,10 @@ func runRemoveRecipient(args []string) error {
 	}
 	query := args[0]
 
+	if err := requireVaultProject(); err != nil {
+		return err
+	}
+
 	return vault.WithStoreLock(func() error {
 		recipPath, err := vault.RecipientsFilePath()
 		if err != nil {
@@ -377,6 +385,9 @@ func newEnvListRecipientsCmd() *command {
 func runListRecipients(args []string) error {
 	if len(args) > 0 {
 		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
+	}
+	if err := requireVaultProject(); err != nil {
+		return err
 	}
 
 	recipPath, err := vault.RecipientsFilePath()

--- a/pkg/userFlags/env_rotate_key.go
+++ b/pkg/userFlags/env_rotate_key.go
@@ -49,6 +49,9 @@ func runRotateKey(args []string) error {
 	if len(args) > 0 {
 		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
 	}
+	if err := requireVaultProject(); err != nil {
+		return err
+	}
 
 	if os.Getenv(utils.MasterKey) != "" {
 		return fmt.Errorf(

--- a/pkg/userFlags/env_sync.go
+++ b/pkg/userFlags/env_sync.go
@@ -37,6 +37,9 @@ func runSync(args []string) error {
 	if len(args) > 0 {
 		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
 	}
+	if err := requireVaultProject(); err != nil {
+		return err
+	}
 
 	return vault.WithStoreLock(func() error {
 		identity, err := vault.ResolveIdentity()

--- a/pkg/userFlags/flags.go
+++ b/pkg/userFlags/flags.go
@@ -3,10 +3,32 @@ package userflags
 
 import (
 	"flag"
+	"fmt"
 	"time"
 
 	"github.com/xaaha/hulak/pkg/utils"
 )
+
+// requireVaultProject returns an error if the current directory is not inside
+// a hulak vault project. Checks that .hulak/ directory actually exists on disk
+// (not just that FindProjectRoot found an env/ marker). The store.age file
+// itself may not exist yet (fresh init, before first `set`).
+func requireVaultProject() error {
+	markerPath, err := utils.GetProjectMarker()
+	if err != nil {
+		return fmt.Errorf(
+			"no vault project found\n\n" +
+				"Run 'hulak init' to create one, or change to a hulak project directory",
+		)
+	}
+	if !utils.DirExists(markerPath) {
+		return fmt.Errorf(
+			"this is a classic (env/) project, not a vault project\n\n" +
+				"Run 'hulak secrets migrate' to upgrade to the encrypted vault",
+		)
+	}
+	return nil
+}
 
 var (
 	flagEnv string

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -102,7 +102,11 @@ func newInitCmd() *command {
 			"Set up a new hulak project in the current directory.\n\n"+
 				"By default, creates an encrypted vault (.hulak/store.age) plus an example '%s'.\n"+
 				"Run 'hulak init classic' (aliases: plain, no-vault) to use the plaintext env/\n"+
-				"layout instead. Use -env to scaffold specific environments.",
+				"layout instead. Use -env to scaffold specific environments.\n\n"+
+				"Init generates an age keypair for encryption. After setup, you can use an SSH\n"+
+				"ed25519 key for vault operations by adding it as a recipient\n"+
+				"('hulak secrets add-recipient \"ssh-ed25519 ...\"') and setting HULAK_SSH_IDENTITY\n"+
+				"or passing --ssh-identity on commands like 'run'.",
 			utils.APIOptions,
 		),
 		Examples: []*utils.CommandHelp{
@@ -113,19 +117,11 @@ func newInitCmd() *command {
 			},
 			{
 				Command:     "hulak init classic",
-				Description: "Use the plaintext env/ layout (global.env + example file)",
-			},
-			{
-				Command:     "hulak init plain",
-				Description: "Same as 'classic' (alias — see also: 'no-vault')",
+				Description: "Use the plaintext env/ layout (aliases: plain, no-vault)",
 			},
 			{
 				Command:     "hulak init classic -env staging prod",
 				Description: "Plaintext layout with extra environments scaffolded",
-			},
-			{
-				Command:     "hulak init classic --help",
-				Description: "Show full help for the classic subcommand",
 			},
 		},
 		Flags: fs,

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -244,12 +244,12 @@ func newDoctorCmd() *command {
 			{Command: "hulak doctor --json", Description: "Output findings as JSON"},
 		},
 		Run: func(_ []string) error {
-			runDoctor(doctorOpts{
+			os.Exit(runDoctor(doctorOpts{
 				fix:     *fixFlag,
 				yes:     *yesFlag,
 				jsonOut: *jsonFlag,
-			})
-			return nil // runDoctor calls os.Exit
+			}))
+			return nil // unreachable
 		},
 	}
 }

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -211,7 +211,9 @@ func newMigrateCmd() *command {
 	return &command{
 		Name:  "migrate",
 		Short: "Migrate Postman collections to hulak format",
-		Long:  "Convert Postman v2.1 environment and collection JSON exports into hulak .hk.yaml and .env files.",
+		Long: "Convert Postman v2.1 environment and collection JSON exports into hulak .hk.yaml and .env files.\n\n" +
+			"Only Postman collections and environments are supported at this time.\n" +
+			"To migrate plaintext env/ files to the encrypted vault, use 'hulak secrets migrate' instead.",
 		Examples: []*utils.CommandHelp{
 			{Command: "hulak migrate collection.json", Description: "Migrate a Postman collection"},
 			{
@@ -227,16 +229,31 @@ func newMigrateCmd() *command {
 }
 
 func newDoctorCmd() *command {
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	fixFlag := fs.Bool("fix", false, "Auto-repair safe issues (chmod, .gitignore)")
+	yesFlag := fs.Bool("yes", false, "Skip confirmation prompts (use with --fix)")
+	jsonFlag := fs.Bool("json", false, "Output findings as JSON to stdout")
+
 	return &command{
 		Name:  "doctor",
 		Short: "Check project health",
-		Long:  "Inspect your hulak project for common issues: missing .gitignore entries,\nloose file permissions on env files, and secrets leaked into git history.",
+		Long: "Inspect your hulak project for common issues.\n\n" +
+			"Vault backend: identity, store, recipients, and drift checks.\n" +
+			"Classic backend: .gitignore, file permissions, git history.",
+		Flags: fs,
 		Examples: []*utils.CommandHelp{
 			{Command: "hulak doctor", Description: "Run all health checks"},
+			{Command: "hulak doctor --fix", Description: "Auto-repair safe issues"},
+			{Command: "hulak doctor --fix --yes", Description: "Auto-repair without prompts"},
+			{Command: "hulak doctor --json", Description: "Output findings as JSON"},
 		},
 		Run: func(_ []string) error {
-			runDoctor()
-			return nil
+			runDoctor(doctorOpts{
+				fix:     *fixFlag,
+				yes:     *yesFlag,
+				jsonOut: *jsonFlag,
+			})
+			return nil // runDoctor calls os.Exit
 		},
 	}
 }

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -96,8 +96,10 @@ const (
 
 // tick mark and x for success and failure
 const (
-	CheckMark           = "\u2714"  // tick
-	CrossMark           = "\u2716"  // x
+	CheckMark           = "\u2714"  // ✔
+	CrossMark           = "\u2716"  // ✖
+	WarningMark         = "\u26a0"  // ⚠
+	InfoMark            = "\u2139"  // ℹ
 	ChevronRight        = "\uf054 " // >
 	ChevronRightCircled = "\uf138"
 	ChevronDownCircled  = "\uf13a"


### PR DESCRIPTION
## Summary

- **16 vault health checks**: identity presence/mode/git-tracking/leak scan, store mode/encryption/decryption, recipients existence/validity/commit status, recipient drift, gitignore for team projects, legacy key.pub detection, dual-backend/dual-identity detection, store size warning
- **Classic backend checks**: .gitignore coverage, env file permissions, git history leak scan — each with distinct check IDs (`classic-gitignore`, `classic-permissions`, `classic-git-history`)
- **`--fix` flag**: auto-repairs safe issues (chmod) with `--yes` for non-interactive use
- **`--json` flag**: machine-readable output to stdout with structured findings and summary
- **`requireVaultProject()` guard**: all vault subcommands now fail early with a clear message when run outside a vault project
- **Exit codes**: 0 (ok/info), 1 (warnings), 2 (errors)
- **Table output**: findings displayed via `PrintTable` to stderr, consistent with runner summary and `secrets list`/`secrets keys`

### Code quality
- `skipFinding`/`okFinding` helpers eliminate boilerplate across 16 check functions
- `checkFileMode` helper centralizes permission checks with auto-fix
- `sevDisplay` table drives colored marks — no switch statement
- Classic checks return `[]finding` directly — removed intermediate `warning` type and `collectWarnings`
- `runDoctor` returns exit code instead of calling `os.Exit` — fully testable
- Removed noise checks: `checkConfigDirMode` (dir perms irrelevant when file is 0600), `checkRecipientsMode` (warned about public key file being too restrictive)
- `checkIdentityNotInGit` uses `git ls-files` to distinguish tracked (error) from in-repo-but-untracked (warn) — avoids false positives with dotfiles managers

## Test plan
- [ ] `go test ./pkg/userFlags/...` passes
- [ ] `hulak doctor` in a vault project shows table output with all checks
- [ ] `hulak doctor` in a classic project shows gitignore/permissions/history checks
- [ ] `hulak doctor --json` produces valid JSON to stdout
- [ ] `hulak doctor --fix --yes` auto-repairs chmod issues
- [ ] `hulak doctor --fix --json` exits with error (mutually exclusive)
- [ ] `hulak secrets set KEY val` outside a vault project shows clear error
- [ ] `hulak doctor` in an empty directory shows "Not a hulak project" message