### PR TITLE
docs: v0.3 documentation pass for encrypted store

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@
   <a href="#documentation">Documentation</a>
 </p>
 
-> **Coming in v0.4:** hulak also becomes a full secrets manager for your dev environment. `hulak secrets exec` runs commands with vault values loaded into the environment, direnv-style. A two-tier user and project vault lets personal and project secrets coexist.
-
 ---
 
 ### Run one request, a whole directory, or stay interactive

--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@
 </p>
 
 <p align="center">
-  Define HTTP requests in YAML. Keep credentials in an age-encrypted vault
-  (<code>.hulak/store.age</code>) that is safe to commit. Share with teammates
-  via age or SSH keys.
+  YAML-defined requests.<br/>
+  Age-encrypted secrets, safe to commit and share.
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 </p>
 
 <h3 align="center">
-  Fast, terminal-native API client with age-encrypted secrets in git.<br/>
-  REST, GraphQL, OAuth.
+  Git-native API client with encrypted secrets.
 </h3>
+
+<p align="center">
+  <sub>REST &middot; GraphQL &middot; OAuth</sub>
+</p>
 
 <p align="center">
   <a href="#quick-start">Quick Start</a> &bull;

--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 </p>
 
 <h3 align="center">
-  A git-native API client for terminal users: no Electron, no login, no lag.<br/>
-  REST, GraphQL, OAuth, encrypted secrets.
+  Fast, file-based API client for the terminal.
 </h3>
+
+<p align="center">
+  REST, GraphQL, OAuth, encrypted secrets.
+</p>
 
 <p align="center">
   Define HTTP requests in YAML. Keep credentials in an age-encrypted vault

--- a/README.md
+++ b/README.md
@@ -3,12 +3,9 @@
 </p>
 
 <h3 align="center">
-  Fast API client for the terminal. Lives in git.
+  Fast, terminal-native API client with age-encrypted secrets in git.<br/>
+  REST, GraphQL, OAuth.
 </h3>
-
-<p align="center">
-  REST &middot; GraphQL &middot; OAuth &middot; age-encrypted secrets.
-</p>
 
 <p align="center">
   <a href="#quick-start">Quick Start</a> &bull;

--- a/README.md
+++ b/README.md
@@ -3,20 +3,24 @@
 </p>
 
 <h3 align="center">
-  API calls with simple YAML. No Electron. No login. No lag.
+  A git-native API client for terminal users: no Electron, no login, no lag.<br/>
+  REST, GraphQL, OAuth, encrypted secrets.
 </h3>
 
 <p align="center">
-  A file-based API client for your terminal. Define requests in YAML, run them instantly, and keep everything in git.
-  <br/>
-  REST, GraphQL, and OAuth 2.0 without GUI overhead.
+  Define HTTP requests in YAML. Keep credentials in an age-encrypted vault
+  (<code>.hulak/store.age</code>) that is safe to commit. Share with teammates
+  via age or SSH keys.
 </p>
 
 <p align="center">
   <a href="#quick-start">Quick Start</a> &bull;
   <a href="#graphql-explorer">GraphQL Explorer</a> &bull;
+  <a href="#project-layout">Project Layout</a> &bull;
   <a href="#documentation">Documentation</a>
 </p>
+
+> **Coming in v0.4:** hulak also becomes a full secrets manager for your dev environment. `hulak secrets exec` runs commands with vault values loaded into the environment, direnv-style. A two-tier user and project vault lets personal and project secrets coexist.
 
 ---
 
@@ -28,13 +32,13 @@
 hulak run ./requests/
 ```
 
-Hulak runs request files directly from your project, supports concurrent directory execution, and falls back to an interactive picker when you simply run `hulak`.
+Hulak runs request files directly from your project. It supports concurrent directory execution. It falls back to an interactive picker when you simply run `hulak`.
 
 ### Dedicated GraphQL Explorer
 
 <img alt="GraphQL Explorer" src="./assets/gql.gif" width="720" />
 
-Browse schemas from multiple endpoints, search operations, build queries interactively, execute inline, and save generated files from the terminal.
+Browse schemas from multiple endpoints. Search operations. Build queries interactively. Execute inline. Save generated files from the terminal.
 
 ## Quick Start
 
@@ -47,47 +51,73 @@ brew install xaaha/tap/hulak
 Other install options:
 
 - `go install github.com/xaaha/hulak@latest`
-- build from source with `go build -o hulak`
+- Build from source with `go build -o hulak`
 
-### Initialize a project
-
-```bash
-mkdir my_apis && cd my_apis
-hulak init
-```
-
-If you want multiple environment files right away:
+### Path A. API client with encrypted secrets (default)
 
 ```bash
-hulak init -env staging prod
+mkdir my-apis && cd my-apis
+hulak init                                            # creates .hulak/store.age + identity
+hulak secrets set Url https://api.example.com/v1 --env prod
 ```
 
-Hulak creates an `env/` directory for secrets used by request files that reference template values like `{{.key}}`.
-
-### Create a request file
+Write a request file:
 
 ```yaml
 # test.hk.yaml
 method: Get
-url: https://jsonplaceholder.typicode.com/todos/1
+url: "{{.Url}}/health"
 ```
 
-### Run it
+Run it:
 
 ```bash
-hulak run test.hk.yaml
-
-# use a specific environment
-hulak run test.hk.yaml --env staging
-
-# run every request in a directory concurrently
-hulak run ./requests/
-
-# or open the interactive picker
-hulak
+hulak run test.hk.yaml --env prod
+hulak run ./requests/                                 # whole directory, concurrent
+hulak                                                 # interactive picker
 ```
 
-If the selected request does not use environment template values, Hulak runs it without requiring `env/` setup.
+See [docs/store.md](./docs/store.md) for the full encryption model.
+
+### Path B. Just the secrets store
+
+If you only want the vault piece, the same `init` command works. Skip writing `.hk.yaml` files:
+
+```bash
+mkdir my-secrets && cd my-secrets
+hulak init
+hulak secrets set DATABASE_URL postgres://... --env prod
+hulak secrets add-recipient --github alice --name Alice   # share with a teammate
+git add .hulak/ && git commit -m "add prod secrets"
+```
+
+### Migrating from an older `env/` setup?
+
+See [docs/migrating-to-vault.md](./docs/migrating-to-vault.md).
+
+### Prefer plaintext `env/` files?
+
+```bash
+hulak init classic
+```
+
+Plaintext mode is fully supported for throwaway projects, or when secrets live entirely outside hulak. See [docs/environment.md](./docs/environment.md).
+
+## Project layout
+
+```text
+my-project/
+├── .hulak/
+│   ├── store.age          # encrypted secrets (safe to commit)
+│   └── recipients.txt     # public keys of recipients (safe to commit)
+├── requests/
+│   ├── create-user.hk.yaml
+│   └── get-user.hk.yaml
+└── (your project files)
+
+~/.config/hulak/
+└── identity.txt           # YOUR private key. NEVER commit. Mode 0600.
+```
 
 ## GraphQL Explorer
 
@@ -106,15 +136,18 @@ Read the full guide in [docs/graphql-explorer.md](./docs/graphql-explorer.md).
 Start here for the full reference:
 
 - [CLI Reference](./docs/cli.md)
+- [Encrypted Store](./docs/store.md). Encryption model, team sharing, CI.
+- [Migrating to the Vault](./docs/migrating-to-vault.md). From `env/` to `.hulak/`.
+- [Versioning Your Vault](./docs/versioning.md). Git workflow for secrets.
+- [Comparison](./docs/comparison.md). Hulak vs SOPS, Bruno, and friends.
 - [Request Body](./docs/body.md)
 - [Actions](./docs/actions.md)
-- [Environment Secrets](./docs/environment.md)
-- [Encrypted Store](./docs/store.md)
+- [Environment Secrets (classic mode)](./docs/environment.md)
 - [Response Files](./docs/response.md)
 - [GraphQL Explorer](./docs/graphql-explorer.md)
-- [Auth2.0](./docs/auth20.md)
+- [Auth 2.0](./docs/auth20.md)
 
-If you want the full list of commands, flags, and subcommands, use [docs/cli.md](./docs/cli.md) or run:
+For the live command surface, run:
 
 ```bash
 hulak help

--- a/README.md
+++ b/README.md
@@ -3,16 +3,11 @@
 </p>
 
 <h3 align="center">
-  Fast, file-based API client for the terminal.
+  Fast API client for the terminal. Lives in git.
 </h3>
 
 <p align="center">
-  REST, GraphQL, OAuth, encrypted secrets.
-</p>
-
-<p align="center">
-  YAML-defined requests.<br/>
-  Age-encrypted secrets, safe to commit and share.
+  REST &middot; GraphQL &middot; OAuth &middot; age-encrypted secrets.
 </p>
 
 <p align="center">

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -1,39 +1,37 @@
 # How to access variables?
 
-## 1. Acccessing secrets from `.env` file
+## 1. Accessing secrets from the vault
 
-Hulak uses go's templating to access variables from `.env` files. For example, to access a `Url` value use `"{{.Url}}"`
+Hulak resolves `{{.key}}` template values from the encrypted vault (`.hulak/store.age`). Set a secret once with `hulak secrets set`. Then reference it in your request files.
+
+```bash
+# Set once, per environment
+hulak secrets set Url https://example.com         --env prod
+hulak secrets set Url https://test.example.com    --env staging
+```
+
+Reference it in a request file:
 
 ```yaml
-#test.yaml
-Method: post
+# test.hk.yaml
+method: post
 url: "{{.Url}}"
 # other body items
 ```
 
-So, if `Url` is present in `prod.env` file as
-
-```env
-Url = https://example.com
-```
-
-and is present in `staging.env` file as
-
-```env
-Url = https://test.example.com
-```
-
-When running the `test.yaml` file, hulak picks up the `Url` value depending on the value of `-env` flag. For example,
+Pick the environment at run time:
 
 ```bash
-hulak -env prod -f test # picks up the value from `prod.env` file,
-hulak -env staging -f test # picks up the value from `staging.env` file
+hulak run test.hk.yaml --env prod      # uses prod Url
+hulak run test.hk.yaml --env staging   # uses staging Url
 ```
 
 > [!Note]
 >
-> - If the call is made with `-env prod`, then `Key` should be defined in either `global` or `prod` file. Similarly, if the call is made with `-env staging`, then the `Key` should be present in either `global` or `staging` file. If the `Key` is defined in both files, `global` is ignored.
-> - `Key` is case sensitive. So, `{{.Url}}` and `{{.url}}` are two different values.
+> - If the call is made with `--env prod`, then the key should be defined in either the `global` or the `prod` environment. The same rule applies to other environments. If the key is in both, `global` is ignored.
+> - Keys are case sensitive. So `{{.Url}}` and `{{.url}}` are two different values.
+
+> Using the classic plaintext `env/` backend? See [environment.md](./environment.md).
 
 ## 2. Using `getValueOf`
 
@@ -139,16 +137,15 @@ headers:
   Authorization: '{{basicAuth "admin" "secret123"}}'
 ```
 
-This produces `Basic YWRtaW46c2VjcmV0MTIz` — no manual base64 encoding needed.
+This produces `Basic YWRtaW46c2VjcmV0MTIz`. No manual base64 encoding needed.
 
 ### Using with environment variables
 
-Store credentials in your `.env` file and reference them with template vars:
+Store credentials in the vault and reference them with template vars:
 
-```env
-# env/prod.env
-apiUser = admin
-apiPassword = secret123
+```bash
+hulak secrets set apiUser admin       --env prod
+hulak secrets set apiPassword secret123 --env prod
 ```
 
 ```yaml
@@ -160,14 +157,16 @@ headers:
 ```
 
 ```bash
-hulak -env prod -f request
+hulak run request.hk.yaml --env prod
 ```
 
 This works the same as `curl -u admin:secret123 https://api.example.com/protected`.
 
+> Classic env/ users: put the keys in `env/prod.env` as `apiUser = admin` and `apiPassword = secret123` instead. See [environment.md](./environment.md).
+
 ## 4. Using `os`
 
-Reads an OS environment variable at template execution time. Takes a single argument — the variable name — and returns its value, or an empty string if unset.
+Reads an OS environment variable at template execution time. Takes a single argument, the variable name, and returns its value. Returns an empty string if unset.
 
 ```yaml
 # request.hk.yaml
@@ -182,7 +181,7 @@ export GITHUB_TOKEN=ghp_abc123
 hulak -f request
 ```
 
-This is useful for secrets that live in your shell environment (CI tokens, credentials injected by your platform) rather than in `.env` files or the vault store.
+This is useful for secrets that live in your shell environment. CI tokens or credentials injected by your platform are common examples. The vault store and `env/` files are the other two places hulak looks for values.
 
 ### Combining with store variables
 
@@ -194,6 +193,6 @@ url: '{{.BASE_URL}}/callback?token={{os "SESSION_TOKEN"}}'
 
 ### Behaviour notes
 
-- Variable names are **case sensitive** — `{{os "path"}}` and `{{os "PATH"}}` are different
+- Variable names are **case sensitive**. `{{os "path"}}` and `{{os "PATH"}}` are different
 - Returns an **empty string** if the variable is not set (no error)
-- Does **not** trigger env file loading — it reads directly from the OS environment
+- Does **not** trigger env file loading. It reads directly from the OS environment.

--- a/docs/body.md
+++ b/docs/body.md
@@ -49,16 +49,16 @@ url: "https://slow.example.com/big-export"
 timeout: 5m
 ```
 
-Accepts any [Go duration string](https://pkg.go.dev/time#ParseDuration): `30s`, `90s`, `5m`, `2m30s`, `1h`. Bare numbers (`60`) are rejected — always include the unit.
+Accepts any [Go duration string](https://pkg.go.dev/time#ParseDuration): `30s`, `90s`, `5m`, `2m30s`, `1h`. Bare numbers (`60`) are rejected. Always include the unit.
 
 #### Precedence
 
 When more than one source could time-out a request, Hulak picks the highest-precedence source that is set:
 
-1. **YAML `timeout:` field** — wins over everything else for this file.
-2. **`--timeout <duration>` flag** — fallback for files with no YAML override. Works on `hulak run`, `hulak -fp`, and `hulak -dir`.
-3. **`HULAK_TIMEOUT` env var** — same scope as the flag, scoped to the shell session. Useful for slow VPNs or one-off runs without retyping.
-4. **60-second default** — when nothing above is set.
+1. **YAML `timeout:` field**. Wins over everything else for this file.
+2. **`--timeout <duration>` flag**. Fallback for files with no YAML override. Works on `hulak run`, `hulak -fp`, and `hulak -dir`.
+3. **`HULAK_TIMEOUT` env var**. Same scope as the flag, scoped to the shell session. Useful for slow VPNs or one-off runs without retyping.
+4. **60-second default**. When nothing above is set.
 
 A non-zero value at any layer overrides every layer below it; an unset / zero layer falls through to the next.
 
@@ -84,7 +84,7 @@ hulak -dir ./requests --timeout 90s        # root-flag form, concurrent
 hulak -dirseq ./requests --timeout 90s     # root-flag form, sequential
 ```
 
-Files in concurrent mode (`-dir` / `hulak run <dir>`) each get their own resolved timeout independently — one slow file does not steal the budget from the next. Sequential mode (`-dirseq` / `--sequential`) applies the same per-file resolution one file at a time.
+Files in concurrent mode (`-dir` / `hulak run <dir>`) each get their own resolved timeout independently. One slow file does not steal the budget from the next. Sequential mode (`-dirseq` / `--sequential`) applies the same per-file resolution one file at a time.
 
 #### Errors
 
@@ -96,7 +96,7 @@ Hulak validates timeouts up front so a typo cannot silently fall back to the def
 
 > [!Note]
 >
-> 1. `timeout: 0s` and negative durations are rejected — there is no "no timeout" mode. Set a value high enough for the slowest request you expect.
+> 1. `timeout: 0s` and negative durations are rejected. There is no "no timeout" mode. Set a value high enough for the slowest request you expect.
 > 2. The timeout covers the whole request (connect + send + read). It is not a connect-only or read-only timeout.
 > 3. Each retry attempt uses the same timeout independently; the value is per-attempt, not a total budget across retries.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,6 +39,9 @@ hulak secrets --help
 
 For command-specific help, prefer `hulak <command> --help`.
 
+> [!Tip]
+> This page documents the current command surface. For the most up to date flags and subcommands, run `hulak <command> --help`. That output is generated from the same source as the binary.
+
 ## Command Index
 
 | Command   | Purpose                                      | Example                               |
@@ -48,8 +51,8 @@ For command-specific help, prefer `hulak <command> --help`.
 | `init` | Initialize a hulak project | `hulak init` |
 | `migrate` | Migrate Postman collections to hulak format | `hulak migrate collection.json` |
 | `doctor` | Check project health | `hulak doctor` |
-| `gql` | Open the GraphQL explorer | `hulak gql .` |
-| `secrets` | Manage encrypted environment secrets | `hulak secrets list` |
+| `gql` (alias: `graphql`) | Open the GraphQL explorer | `hulak gql .` |
+| `secrets` (alias: `env`) | Manage encrypted environment secrets | `hulak secrets list` |
 | `help` | Show help for hulak | `hulak help` |
 
 ## Core Behaviors
@@ -67,7 +70,7 @@ Running `hulak` with no file or directory target opens the interactive picker.
 When `--env` is omitted, behavior depends on the command:
 
 - **`run` and `gql`**: open the interactive picker if the request files reference environment variables (`{{.key}}`). If a request needs no env, no picker.
-- **`hulak secrets edit`**: always opens the picker — no default. Pass `--env <name>` (including for new envs you want to create).
+- **`hulak secrets edit`**: always opens the picker. There is no default. Pass `--env <name>` (including for new envs you want to create).
 - **`hulak secrets set`, `get`, `delete`, `keys`**: default to `global`. These are non-interactive operations on a known env; the default keeps scripts terse.
 - **`hulak secrets list`**: takes no `--env` (it lists envs themselves).
 
@@ -146,7 +149,8 @@ Supported flags:
 
 Notes:
 
-- `hulak init` creates the default setup, including `env/global.env` and the example API options file.
+- `hulak init` creates the default setup. That means an encrypted vault at `.hulak/store.age`, an age keypair at `~/.config/hulak/identity.txt`, and the example API options file.
+- Run `hulak init classic` for the legacy plaintext `env/` layout.
 - On `init`, `-env` is a **boolean setup flag**, not an environment selector. It tells Hulak to create the named env files you pass after it.
 
 ### `migrate`
@@ -211,7 +215,13 @@ Read the full guide in [graphql-explorer.md](./graphql-explorer.md).
 Manage environment secrets stored in the encrypted vault (.hulak/store.age).
 
 Secrets are organized by environment (e.g. global, staging, prod).
-The default environment is "global" unless --env is specified. See [docs/store.md](./store.md) for the full encryption model and team-sharing flows.
+The default environment is "global" unless --env is specified.
+
+'env' is retained as an alias for backward compatibility with pre-0.3 docs. See [docs/store.md](./store.md) for the full encryption model and team-sharing flows.
+
+Aliases:
+
+- `env`
 
 ```bash
 hulak secrets list

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,50 @@
+# Hulak compared to other tools
+
+Hulak overlaps two ecosystems: encrypted secrets management and file-based HTTP clients. This page shows where hulak fits and where each alternative wins. Last reviewed: 2026-05.
+
+## Secrets management
+
+| Tool          | Encrypted at rest  | Multi-recipient |     Git-friendly     | SSH-key support | No external service | GUI required |
+| ------------- | :----------------: | :-------------: | :------------------: | :-------------: | :-----------------: | :----------: |
+| **hulak**     |      ✅ (age)      |       ✅        |   ✅ (binary blob)   |       ✅        |         ✅          |      ❌      |
+| SOPS          | ✅ (age, PGP, KMS) |       ✅        | ✅ (YAML, JSON diff) |     partial     |   optional (KMS)    |      ❌      |
+| age           |         ✅         |       ✅        |       ✅ (CLI)       |       ✅        |         ✅          |      ❌      |
+| git-crypt     |      ✅ (GPG)      |       ✅        |   ✅ (transparent)   |       ❌        |         ✅          |      ❌      |
+| direnv        |   ❌ (plaintext)   |       n/a       |     ✅ (.envrc)      |       n/a       |         ✅          |      ❌      |
+| doppler       |  ✅ (server-side)  |       ✅        |          ❌          |       ❌        |      ❌ (SaaS)      |   ✅ (web)   |
+| 1Password CLI |  ✅ (server-side)  |   ✅ (vaults)   |          ❌          |       ❌        |      ❌ (SaaS)      |   ✅ (app)   |
+
+### When _not_ to choose hulak for secrets
+
+- **Policy-as-code on secret access** (who can read what, audit logs, just-in-time access). Use HashiCorp Vault, or SOPS with KMS.
+- **OS keyring or Touch ID integration.** Use 1Password CLI.
+- **No git workflow at all (server-side dashboard).** Use Doppler or AWS Secrets Manager.
+
+## API clients
+
+| Tool      |      File-based      |     No login     |      GraphQL      | Concurrent run | Vault-integrated |  In terminal  |
+| --------- | :------------------: | :--------------: | :---------------: | :------------: | :--------------: | :-----------: |
+| **hulak** |      ✅ (YAML)       |        ✅        | ✅ (TUI explorer) |       ✅       |  ✅ (built-in)   |      ✅       |
+| Postman   | ❌ (cloud workspace) |        ❌        |        ✅         |    partial     |        ❌        | ❌ (Electron) |
+| Bruno     |   ✅ (collections)   |        ✅        |        ✅         |       ❌       |        ❌        | ❌ (Electron) |
+| Insomnia  |       partial        | ❌ (auth needed) |        ✅         |       ❌       |        ❌        | ❌ (Electron) |
+| HTTPie    |   ❌ (CLI ad-hoc)    |        ✅        |        ❌         |       ❌       |        ❌        |      ✅       |
+| curl      |   ❌ (CLI ad-hoc)    |        ✅        |        ❌         |       ❌       |        ❌        |      ✅       |
+
+### When _not_ to choose hulak as an API client
+
+- **GUI for non-engineers.** Use Bruno or Postman.
+- **API mocking or contract testing.** Use Postman, Prism, or Insomnia.
+- **One-off ad-hoc requests.** Use curl or HTTPie. No project scaffolding needed.
+
+## Why hulak exists
+
+No tool in the secrets list also runs HTTP requests. No tool in the API client list also encrypts and version-controls its own secrets. Hulak exists because keeping these in two tools means glue. You copy `.env` files into Postman. You wrap curl in `sops` invocations. You export env vars via direnv to feed Insomnia. Hulak collapses the seam. Your secrets and your requests live in the same git repo. They share the same `{{.KEY}}` template syntax. They survive `git push` without leaking plaintext.
+
+If you only need one half, that is fine. Hulak works as a pure secrets store or a pure API client. The integration is opt-in, not mandatory.
+
+## What's next
+
+- [docs/store.md](./store.md). Encryption model.
+- [docs/cli.md](./cli.md). Full CLI reference.
+- [docs/migrating-to-vault.md](./migrating-to-vault.md). Switch from `env/`.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,7 +1,11 @@
-# Environment Secrets
+# Environment Secrets (Classic Mode)
 
-> [!Note]
-> This page documents the legacy `env/` backend. For new projects, prefer the encrypted store — see [docs/store.md](./store.md). Hulak supports both; if `.hulak/store.age` exists, it takes priority over `env/`.
+> [!Important]
+> This page documents the **legacy plaintext `env/` backend**. For new projects, use the encrypted vault. See [docs/store.md](./store.md). Existing projects can convert with [docs/migrating-to-vault.md](./migrating-to-vault.md).
+>
+> If `.hulak/store.age` exists, hulak uses the vault and ignores `env/`.
+
+This page is here for projects that have not yet migrated, or that intentionally use plaintext (throwaway scripts, secrets managed entirely outside hulak).
 
 - Environment secrets files (for example `global.env`) live in the `env/` folder at the project root.
 - The `env/` setup is required only for requests that use environment template vars like `{{.key}}`.

--- a/docs/migrating-to-vault.md
+++ b/docs/migrating-to-vault.md
@@ -1,0 +1,139 @@
+# Migrating from `env/` to the encrypted vault
+
+This page walks you through moving an existing classic-mode hulak project (`env/*.env`) into the encrypted vault (`.hulak/store.age`). Read it once. Run the commands. Delete `env/`.
+
+## Why migrate
+
+- **Encrypted at rest.** `store.age` is an age-encrypted blob. Safe to commit. Safe to share via git.
+- **Audit trail.** Every change to a secret shows up in `git log` like any other file.
+- **Team sharing.** Add teammates as recipients with age or SSH keys. They decrypt with their own private key. No more sharing `.env` files in Slack DMs.
+- **CI-friendly.** Set `HULAK_MASTER_KEY` once in CI. The same `hulak run` command works locally and in pipelines.
+
+## Before you start
+
+1. **Commit your current state.** A clean working tree is your rollback safety net.
+   ```bash
+   git status            # should be clean
+   git log -1 --oneline  # remember this SHA
+   ```
+2. **Verify your hulak version.** Migration uses commands added in v0.3.
+   ```bash
+   hulak version
+   ```
+3. **Choose an identity source.** Hulak needs a private key to decrypt the vault. You have three options. Most users want the first.
+   - **Generate a new age keypair** (default). Hulak creates `~/.config/hulak/identity.txt`.
+   - **Use your SSH key.** Run `hulak init --ssh` first to bootstrap with `~/.ssh/id_ed25519`, then migrate.
+   - **Bring your own age key.** Generate it elsewhere, then import with `hulak secrets import-key`.
+
+See [store.md#identity](./store.md#identity) for the full identity priority chain.
+
+## Migrate
+
+```bash
+hulak secrets migrate
+```
+
+The command reads every file in `env/`, encrypts the keys into `.hulak/store.age`, and writes the recipient list. Annotated output looks like this:
+
+```text
+✓ Generated identity at ~/.config/hulak/identity.txt
+✓ Wrote recipients to .hulak/recipients.txt
+✓ Migrated env/global.env  -> store.age[global]  (4 keys)
+✓ Migrated env/prod.env    -> store.age[prod]    (7 keys)
+✓ Migrated env/staging.env -> store.age[staging] (5 keys)
+⚠ Back up ~/.config/hulak/identity.txt now. Losing it locks the vault.
+```
+
+Encoding edge cases like non-ASCII keys are handled per issue [#147](https://github.com/xaaha/hulak/issues/147). If migration warns about a key, the source line is shown. Fix it in `env/<name>.env` and re-run.
+
+## Verify
+
+Three quick checks. Do all three before trusting the migration.
+
+```bash
+# 1. Environments are present
+hulak secrets list
+
+# 2. Keys per environment
+hulak secrets keys --env prod
+
+# 3. End-to-end smoke test (run a real request with the new backend)
+hulak run requests/health.hk.yaml --env prod
+```
+
+If something is off, see the [rollback](#rollback) section. Your `env/` directory is still on disk.
+
+## Commit
+
+```bash
+git add .hulak/store.age .hulak/recipients.txt
+git commit -m "migrate secrets to encrypted vault"
+```
+
+Safe to commit:
+- `store.age`. Encrypted. Only recipients in `recipients.txt` can decrypt it.
+- `recipients.txt`. Public keys only.
+
+**Never commit** `~/.config/hulak/identity.txt`. That is your private key. The file is created with mode `0600` for this reason.
+
+## Back up your identity (do this NOW)
+
+Losing `~/.config/hulak/identity.txt` without a backup means losing access to your vault. Pick one. Preferably do both.
+
+```bash
+# Option A. Export and paste into a password manager.
+hulak secrets export-key
+# AGE-SECRET-KEY-1QF...
+# (paste into 1Password / Bitwarden / etc.)
+
+# Option B. Add a second recipient.
+# Generate a backup keypair on a different machine or USB. Then:
+hulak secrets add-recipient <backup-pubkey> --name "backup-laptop"
+```
+
+See [store.md#identity-backup](./store.md#identity-backup) for details.
+
+## Clean up
+
+Once you have verified end-to-end and backed up the identity, remove the plaintext `env/`:
+
+```bash
+rm -r env/
+git add -A
+git commit -m "remove plaintext env/ (migrated to vault)"
+```
+
+## Rollback
+
+Until `env/` is deleted, classic mode is one rename away.
+
+```bash
+# Move the vault out of the way
+mv .hulak/store.age .hulak/store.age.bak
+
+# Verify hulak falls back to env/
+hulak run requests/health.hk.yaml --env prod
+```
+
+If you have already deleted `env/`, recover it from git:
+
+```bash
+git checkout <pre-migration-sha> -- env/
+```
+
+That is why we wrote down the SHA in "Before you start".
+
+## Troubleshooting
+
+| Symptom | See |
+| ------- | --- |
+| "no identity found" | [store.md#identity](./store.md#identity) |
+| "decryption failed" | [store.md#identity-backup](./store.md#identity-backup) |
+| Non-ASCII or special-character keys | issue [#147](https://github.com/xaaha/hulak/issues/147) |
+| Merge conflicts on `store.age` | [store.md#merge-conflicts-on-recipientstxt-and-storeage](./store.md#merge-conflicts-on-recipientstxt-and-storeage) |
+
+## What's next
+
+- [docs/store.md](./store.md). Full encryption model and team sharing.
+- [docs/versioning.md](./versioning.md). Git-versioned vault patterns.
+- [docs/cli.md#secrets](./cli.md#secrets). Complete `secrets` command reference.

--- a/docs/store.md
+++ b/docs/store.md
@@ -33,11 +33,11 @@ my-project/
 
 ## How encryption works
 
-Hulak uses [age](https://age-encryption.org/) — a modern, file-based encryption tool with simple X25519 keys.
+Hulak uses [age](https://age-encryption.org/). A modern, file-based encryption tool with simple X25519 keys.
 
 - Each user generates an age **keypair** (one public key, one private key)
-- The **public key** can be shared freely — it only encrypts
-- The **private key** decrypts ciphertext encrypted to your public key — keep it secret
+- The **public key** can be shared freely. It only encrypts
+- The **private key** decrypts ciphertext encrypted to your public key. Keep it secret
 - A single `store.age` file can be encrypted to **multiple public keys** at once. Any one of the corresponding private keys can decrypt it. This is what makes team sharing possible.
 
 ## `recipients.txt` format
@@ -54,7 +54,7 @@ ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBobsPublicKeyHere
 age1yr5tpz76yxqeg5ktrp7g2wgkxfmq9rmef0gxhvsky2pyv6lsf8msgmd00n
 ```
 
-- **One public key per line** — both `age1...` and `ssh-ed25519` formats are supported.
+- **One public key per line**. Both `age1...` and `ssh-ed25519` formats are supported.
 - **`#` comments are supported.** Use them to label keys (name, date added, role).
 - **Blank lines are ignored.**
 - `ssh-rsa` keys are accepted with `--allow-rsa` but ed25519 is recommended.
@@ -98,6 +98,8 @@ hulak secrets migrate
 
 The legacy `env/` directory is left in place. Vault takes priority while both exist. Delete `env/` once you're confident.
 
+For the canonical step-by-step walkthrough, see [migrating-to-vault.md](./migrating-to-vault.md).
+
 ## Identity
 
 Hulak needs a private key to decrypt `store.age`. It checks these locations in order:
@@ -109,7 +111,7 @@ Hulak needs a private key to decrypt `store.age`. It checks these locations in o
 | 3 | `HULAK_SSH_IDENTITY` env var | Point at a specific SSH key |
 | 4 | `~/.ssh/id_ed25519` | Auto-detected if no age identity exists |
 
-If you use SSH for git, hulak can reuse your existing SSH key — no separate keypair needed. Just make sure your SSH public key is added as a recipient (via `--github` or directly).
+If you use SSH for git, hulak can reuse your existing SSH key. No separate keypair needed. Just make sure your SSH public key is added as a recipient (via `--github` or directly).
 
 ```bash
 # Use a specific SSH key for this run
@@ -146,7 +148,7 @@ hulak secrets import-key ~/Downloads/identity-backup.txt
 
 A single `store.age` can be encrypted to many recipients. Each teammate has their own private key; any of them can decrypt the shared file.
 
-### Joining a team (with GitHub — recommended)
+### Joining a team (with GitHub. Recommended)
 
 If the new member uses SSH for git, they already have keys published on GitHub. No key exchange needed:
 
@@ -214,7 +216,7 @@ git push
 
 ### Why rotation matters
 
-Removing a recipient prevents them from decrypting **future** versions of `store.age`. They can still decrypt any copy they already have — local clones, old git commits, backups they made.
+Removing a recipient prevents them from decrypting **future** versions of `store.age`. They can still decrypt any copy they already have. Local clones, old git commits, backups they made.
 
 To truly revoke access:
 
@@ -223,11 +225,11 @@ To truly revoke access:
 3. `hulak secrets set <KEY> <new-value>` for each rotated secret
 4. Commit and push
 
-This is a fundamental property of asymmetric encryption — true of age, GPG, SOPS, git-crypt, and every similar tool. There is no scheme that can un-show plaintext.
+This is a fundamental property of asymmetric encryption. True of age, GPG, SOPS, git-crypt, and every similar tool. There is no scheme that can un-show plaintext.
 
 ### Self-removal guard
 
-You cannot remove yourself if you are the only recipient — that would brick the store.
+You cannot remove yourself if you are the only recipient. That would brick the store.
 
 ```bash
 hulak secrets remove-recipient age1ql3z...
@@ -237,20 +239,20 @@ hulak secrets remove-recipient age1ql3z...
 
 ## Commands
 
-For the full command reference — flags, aliases, and examples — see the [`secrets` section in cli.md](./cli.md#secrets).
+For the full command reference. Flags, aliases, and examples. See the [`secrets` section in cli.md](./cli.md#secrets).
 
 > [!Tip]
-> Need a snapshot of `store.age`? Just `cp .hulak/store.age my-backup.age`. The file is already encrypted — copy it anywhere. To restore, copy it back. No dedicated subcommand needed.
+> Need a snapshot of `store.age`? Just `cp .hulak/store.age my-backup.age`. The file is already encrypted. Copy it anywhere. To restore, copy it back. No dedicated subcommand needed.
 
 > [!Note]
-> `hulak secrets edit` opens an interactive picker when `--env` is omitted — the same flow as `hulak run`. There is no silent "global" default for edit. Pass `--env <name>` (including for new envs you want to create).
+> `hulak secrets edit` opens an interactive picker when `--env` is omitted. The same flow as `hulak run`. There is no silent "global" default for edit. Pass `--env <name>` (including for new envs you want to create).
 
 ## Merge conflicts on `recipients.txt` and `store.age`
 
 Two teammates may add or remove recipients on parallel branches. The merge behavior:
 
-- **`recipients.txt` is plain text.** Git merges it like any source file. If both branches added different recipients, you'll get a clean three-way merge. If both added a recipient at the same line, you'll get a textual conflict — resolve by keeping both lines.
-- **`store.age` is a binary blob.** Git can't merge it. Whichever branch's `store.age` you accept will be encrypted to **only that branch's recipient set** — the other branch's added recipient is silently dropped.
+- **`recipients.txt` is plain text.** Git merges it like any source file. If both branches added different recipients, you'll get a clean three-way merge. If both added a recipient at the same line, you'll get a textual conflict. Resolve by keeping both lines.
+- **`store.age` is a binary blob.** Git can't merge it. Whichever branch's `store.age` you accept will be encrypted to **only that branch's recipient set**. The other branch's added recipient is silently dropped.
 
 ### How to resolve
 
@@ -264,7 +266,7 @@ git add .hulak/store.age .hulak/recipients.txt
 git commit
 ```
 
-`hulak secrets rotate` re-encrypts the store to the current `recipients.txt` without changing keys — exactly what you need after a merge.
+`hulak secrets rotate` re-encrypts the store to the current `recipients.txt` without changing keys. Exactly what you need after a merge.
 
 > [!Tip]
 > For frequent recipient churn (large teams), consider squashing multiple `add-recipient` / `remove-recipient` commits into one to reduce merge surface area.
@@ -281,7 +283,7 @@ hulak run requests/create_user.yaml --env prod
 `HULAK_MASTER_KEY` takes precedence over `~/.config/hulak/identity.txt`. Store the value in your CI provider's secret manager (GitHub Actions secrets, GitLab CI variables, etc.).
 
 > [!Caution]
-> Environment variables are visible to other processes running as the same user. On Linux, `ps -e auxe` shows the env table for any process owned by you. In CI this is fine — the runner is single-tenant. On a shared workstation (e.g., a build server with multiple users sharing one account), prefer the file-based identity at `~/.config/hulak/identity.txt` instead of `HULAK_MASTER_KEY`.
+> Environment variables are visible to other processes running as the same user. On Linux, `ps -e auxe` shows the env table for any process owned by you. In CI this is fine. The runner is single-tenant. On a shared workstation (e.g., a build server with multiple users sharing one account), prefer the file-based identity at `~/.config/hulak/identity.txt` instead of `HULAK_MASTER_KEY`.
 
 ### CI templates
 
@@ -313,7 +315,7 @@ Mark `HULAK_MASTER_KEY` as a **masked** / **protected** variable in both systems
 
 ## If your identity is compromised
 
-Treat a leaked private key (laptop stolen, accidental commit, etc.) like a leaked database password — assume the worst and rotate. Steps:
+Treat a leaked private key (laptop stolen, accidental commit, etc.) like a leaked database password. Assume the worst and rotate. Steps:
 
 1. **Generate a new identity.** On a clean machine: `hulak init` (this creates a fresh keypair).
 2. **Add the new key as a recipient before removing the old one.** From any machine that still has access:
@@ -324,15 +326,21 @@ Treat a leaked private key (laptop stolen, accidental commit, etc.) like a leake
    ```bash
    hulak secrets remove-recipient <old-public-key>
    ```
-4. **Rotate every secret in the store upstream.** API keys, DB passwords, OAuth client secrets — anything the leaker may have read. The leaker still has copies of `store.age` and the old identity from before the removal; the only way to invalidate that data is to make it useless by changing the upstream values.
+4. **Rotate every secret in the store upstream.** API keys, DB passwords, OAuth client secrets. Anything the leaker may have read. The leaker still has copies of `store.age` and the old identity from before the removal; the only way to invalidate that data is to make it useless by changing the upstream values.
 5. **Force teammates to pull.** They need the re-encrypted `store.age` so their next decrypt uses the new recipient list.
 6. **Audit history.** `git log -- .hulak/store.age` shows when ciphertexts changed; cross-reference with whatever you know about when the leak happened.
 
-This is the same playbook as SOPS, GPG, and git-crypt. Encryption can't un-show plaintext, but a fast rotation + upstream secret change is the standard mitigation.
+This is the same playbook as SOPS, GPG, and git-crypt. Encryption can't un-show plaintext, but a fast rotation plus upstream secret change is the standard mitigation.
+
+## See also
+
+- [Migrating from `env/` to the vault](./migrating-to-vault.md). Step-by-step walkthrough.
+- [Versioning your vault with git](./versioning.md). Commit workflow.
+- [Hulak vs SOPS, Bruno, and friends](./comparison.md). Positioning.
 
 ## Privacy
 
-hulak makes no network calls except for the HTTP requests you author in your `.hk.yaml` files — that's the whole product. There is no telemetry, no analytics, no version-check ping, no error reporting. The CLI runs entirely against local files and the requests you author. If you observe a network call from hulak outside of running your own request files, that's a bug — please file it.
+hulak makes no network calls except for the HTTP requests you author in your `.hk.yaml` files. That's the whole product. There is no telemetry, no analytics, no version-check ping, no error reporting. The CLI runs entirely against local files and the requests you author. If you observe a network call from hulak outside of running your own request files, that's a bug. Please file it.
 
 ## FAQ
 
@@ -353,7 +361,7 @@ If you have no backup and no second recipient, the data is gone. Mitigations:
 Yes, during migration. Vault takes priority. After verifying everything works, delete `env/`.
 
 **How big can a single value be?**
-Functionally, anything. Practically, hulak warns at 64 KB and recommends `{{getFile "path"}}` for large blobs (certs, JSON fixtures) — those are read from disk on demand instead of decrypted on every invocation.
+Functionally, anything. Practically, hulak warns at 64 KB and recommends `{{getFile "path"}}` for large blobs (certs, JSON fixtures). Those are read from disk on demand instead of decrypted on every invocation.
 
 **Does this work with SSH keys?**
 Yes. Both `ssh-ed25519` public keys (as recipients) and `~/.ssh/id_ed25519` private keys (as identities) are supported. See [Identity](#identity) and [Team sharing](#team-sharing) above. Use `--github <username>` to add teammates directly from their GitHub SSH keys.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,95 @@
+# Versioning your vault with git
+
+The encrypted vault (`.hulak/store.age`) is designed to be committed. This page covers the conventions that make commit history useful when the file in question is opaque ciphertext.
+
+## Why commit `store.age`
+
+- **Encrypted.** Without a private key in `recipients.txt`, the blob is opaque. Safe in public repos.
+- **Audit trail.** Every secret rotation, addition, or removal lands as a git commit. `git log` answers "when did we change this?" for free.
+- **Disaster recovery.** A stale clone is also a backup. No external secrets service required.
+- **PR review for secret changes.** Same workflow as code. Propose, review, merge.
+
+## What to commit, what to ignore
+
+| File | Commit? | Why |
+| ---- | ------- | --- |
+| `.hulak/store.age` | **Yes** | Encrypted. Safe. |
+| `.hulak/recipients.txt` | **Yes** | Public keys only. |
+| `~/.config/hulak/identity.txt` | **No** | Private key. Mode `0600`. |
+| `env/*.env` (classic mode) | **No** | Plaintext secrets. |
+
+Your `.gitignore` should already contain `env/` if you started with classic mode. `hulak doctor --fix` will add it if missing.
+
+## Day-to-day workflow
+
+```bash
+# Edit a secret
+hulak secrets set STRIPE_SECRET_KEY sk_live_new_value --env prod
+
+# Stage and commit
+git add .hulak/store.age
+git commit -m "rotate prod STRIPE_SECRET_KEY (incident #4521)"
+
+# Push
+git push
+```
+
+The commit message is the only narrative. The diff is ciphertext. Write descriptive messages: which key, which env, and why. Future you, reading `git log` six months from now, will thank present you.
+
+## Recovering an old secret value
+
+```bash
+# See every change to the vault
+git log --oneline -- .hulak/store.age
+
+# Restore the vault to a previous revision
+git checkout <sha> -- .hulak/store.age
+
+# Read the value as of that commit
+hulak secrets get STRIPE_SECRET_KEY --env prod
+
+# Put HEAD back
+git checkout HEAD -- .hulak/store.age
+```
+
+This works because age decryption does not depend on git state. Any historical `store.age` you can check out is a valid ciphertext.
+
+## Auditing who changed what
+
+```bash
+git log --follow --pretty=format:"%h %an %ad %s" --date=short -- .hulak/store.age
+```
+
+Author, date, message. The diff itself is opaque. So commit messages do all the work. Pick a convention. Include the env name and either the key name or "(rotation)" in every commit subject.
+
+## Merge conflicts
+
+`store.age` is a binary blob. Git cannot merge it. See [store.md merge conflicts](./store.md#merge-conflicts-on-recipientstxt-and-storeage) for the full flow. Short version:
+
+```bash
+# Resolve recipients.txt by keeping the union of both branches
+git checkout --theirs .hulak/store.age
+hulak secrets rotate                     # re-encrypt to merged recipients
+git add .hulak/store.age .hulak/recipients.txt
+git commit
+```
+
+## Branches and PR review
+
+A PR that touches `store.age` should describe the change in plain English. Reviewers cannot diff ciphertext. Conventions that work:
+
+- Title: `secrets: rotate prod STRIPE_SECRET_KEY` (or similar)
+- Description: which env, which keys, why
+- Optionally: `hulak secrets keys --env <env>` output before and after in the PR description, so reviewers can verify keys-added vs keys-removed without decrypting
+
+## Backup beyond git
+
+- `git push` covers off-site backup for `store.age` if you have a remote. Treat your git remote as the canonical store.
+- `~/.config/hulak/identity.txt` is **not** in git. Back it up separately. See [migrating-to-vault.md](./migrating-to-vault.md#back-up-your-identity-do-this-now).
+- For air-gapped redundancy: `cp .hulak/store.age my-backup.age`. The file is already encrypted. Copy it anywhere.
+
+## What's next
+
+- [docs/store.md](./store.md). Encryption model.
+- [docs/migrating-to-vault.md](./migrating-to-vault.md). Moving from `env/`.
+- [docs/cli.md#secrets](./cli.md#secrets). `secrets` command reference.

--- a/pkg/envparser/replaceVars.go
+++ b/pkg/envparser/replaceVars.go
@@ -44,7 +44,12 @@ func formatMissingKeyError(keyName string) error {
 	}
 
 	return fmt.Errorf(
-		`key "%s" not found in environment "%s". Add "%s=<value>" to env/%s.env or use a different environment with -env flag`,
+		"key %q not found in environment %q.\n"+
+			"Run 'hulak secrets set %s <value> --env %s' to add it to the encrypted vault.\n"+
+			"For classic env/ mode, add %s=<value> to env/%s.env.\n"+
+			"Or use a different environment with the -env flag",
+		keyName,
+		env,
 		keyName,
 		env,
 		keyName,

--- a/pkg/envparser/replaceVars_test.go
+++ b/pkg/envparser/replaceVars_test.go
@@ -327,7 +327,8 @@ func TestFormatMissingKeyError(t *testing.T) {
 			expectedInMsg: []string{
 				`key "graphqlUrl" not found`,
 				`environment "global"`,
-				`Add "graphqlUrl=<value>" to env/global.env`,
+				`hulak secrets set graphqlUrl <value> --env global`,
+				`env/global.env`,
 			},
 		},
 		{
@@ -337,7 +338,8 @@ func TestFormatMissingKeyError(t *testing.T) {
 			expectedInMsg: []string{
 				`key "apiKey" not found`,
 				`environment "prod"`,
-				`Add "apiKey=<value>" to env/prod.env`,
+				`hulak secrets set apiKey <value> --env prod`,
+				`env/prod.env`,
 			},
 		},
 	}
@@ -431,7 +433,7 @@ func TestSubstituteVariablesWithImprovedErrors(t *testing.T) {
 			expectedErrParts: []string{
 				`key "missingKey" not found`,
 				`environment "global"`,
-				`Add "missingKey=<value>"`,
+				`hulak secrets set missingKey <value> --env global`,
 			},
 		},
 		{
@@ -442,7 +444,8 @@ func TestSubstituteVariablesWithImprovedErrors(t *testing.T) {
 			expectedErrParts: []string{
 				`key "endpoint" not found`,
 				`environment "prod"`,
-				`Add "endpoint=<value>" to env/prod.env`,
+				`hulak secrets set endpoint <value> --env prod`,
+				`env/prod.env`,
 			},
 		},
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -422,7 +422,7 @@ func printOutcome(o outcome) {
 // splitErrorForOutcome flattens an error chain into one short headline plus
 // an optional hint extracted from the deepest error message. The headline is
 // the full wrapped chain with whitespace and ANSI codes normalized; the hint
-// is the trailing actionable sentence (e.g. "Add ... to env/X.env") pulled
+// is the trailing actionable sentence (e.g. "Run 'hulak secrets set ...'") pulled
 // onto its own line so the user's eye lands on it.
 //
 // Why bother: errors here are wrapped 3-4 deep ("substituting ...:

--- a/pkg/userFlags/cli_contract_test.go
+++ b/pkg/userFlags/cli_contract_test.go
@@ -493,7 +493,8 @@ func TestEnvSubCommandsHaveRunHandlers(t *testing.T) {
 
 // TestEnvFlagDoesNotConflictWithSecretsSubcommand verifies that the -env global
 // flag and the secrets subcommand coexist. The flag is prefixed with "-" so the
-// router dispatches them to different paths.
+// router dispatches them to different paths. The "env" alias on the secrets
+// command is preserved per #201.
 func TestEnvFlagDoesNotConflictWithSecretsSubcommand(t *testing.T) {
 	root := subCommands()
 
@@ -502,14 +503,28 @@ func TestEnvFlagDoesNotConflictWithSecretsSubcommand(t *testing.T) {
 		t.Error("expected 'secrets' to resolve as a subcommand")
 	}
 
-	// "env" should NOT resolve as a subcommand (no longer aliased)
-	if root.findSub("env") != nil {
-		t.Error("'env' should not resolve as a subcommand — alias was removed")
+	// "env" should resolve as an alias of "secrets" (#201)
+	if root.findSub("env") == nil {
+		t.Error("expected 'env' to resolve as an alias of 'secrets'")
 	}
 
 	// "-env" should NOT resolve as a subcommand (it's a flag)
 	if root.findSub("-env") != nil {
 		t.Error("'-env' should not resolve as a subcommand")
+	}
+}
+
+// TestSecretsHasEnvAlias verifies that legacy `hulak env ...` invocations
+// resolve to the renamed `secrets` command. The alias was promised in #201
+// to keep older docs and muscle memory working.
+func TestSecretsHasEnvAlias(t *testing.T) {
+	root := subCommands()
+	envResolved := root.findSub("env")
+	if envResolved == nil {
+		t.Fatal("expected 'env' to resolve to 'secrets' command")
+	}
+	if envResolved != root.findSub("secrets") {
+		t.Fatal("'env' should resolve to the same command as 'secrets'")
 	}
 }
 

--- a/pkg/userFlags/gendocs.go
+++ b/pkg/userFlags/gendocs.go
@@ -337,6 +337,9 @@ func generateCLIMarkdown(w io.Writer) {
 	p("")
 	p("For command-specific help, prefer `hulak <command> --help`.")
 	p("")
+	p("> [!Tip]")
+	p("> This page documents the current command surface. For the most up to date flags and subcommands, run `hulak <command> --help`. That output is generated from the same source as the binary.")
+	p("")
 
 	// Command Index
 	p("## Command Index")
@@ -351,7 +354,11 @@ func generateCLIMarkdown(w io.Writer) {
 		if len(sub.Examples) > 0 {
 			example = sub.Examples[0].Command
 		}
-		p("| `%s` | %s | `%s` |", sub.Name, sub.Short, example)
+		nameCell := fmt.Sprintf("`%s`", sub.Name)
+		if len(sub.Aliases) > 0 {
+			nameCell = fmt.Sprintf("`%s` (alias: `%s`)", sub.Name, strings.Join(sub.Aliases, "`, `"))
+		}
+		p("| %s | %s | `%s` |", nameCell, sub.Short, example)
 	}
 	p("")
 
@@ -371,7 +378,7 @@ func generateCLIMarkdown(w io.Writer) {
 	p("When `--env` is omitted, behavior depends on the command:")
 	p("")
 	p("- **`run` and `gql`**: open the interactive picker if the request files reference environment variables (`{{.key}}`). If a request needs no env, no picker.")
-	p("- **`hulak secrets edit`**: always opens the picker — no default. Pass `--env <name>` (including for new envs you want to create).")
+	p("- **`hulak secrets edit`**: always opens the picker. There is no default. Pass `--env <name>` (including for new envs you want to create).")
 	p("- **`hulak secrets set`, `get`, `delete`, `keys`**: default to `global`. These are non-interactive operations on a known env; the default keeps scripts terse.")
 	p("- **`hulak secrets list`**: takes no `--env` (it lists envs themselves).")
 	p("")
@@ -471,7 +478,8 @@ func mdWriteCommand(w io.Writer, cmd *command) {
 	case "init":
 		p("Notes:")
 		p("")
-		p("- `hulak init` creates the default setup, including `env/global.env` and the example API options file.")
+		p("- `hulak init` creates the default setup. That means an encrypted vault at `.hulak/store.age`, an age keypair at `~/.config/hulak/identity.txt`, and the example API options file.")
+		p("- Run `hulak init classic` for the legacy plaintext `env/` layout.")
 		p("- On `init`, `-env` is a **boolean setup flag**, not an environment selector. It tells Hulak to create the named env files you pass after it.")
 		p("")
 	case "gql":

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -442,11 +442,13 @@ func parseRunArgs(
 
 func newEnvCmd() *command {
 	envCmd := &command{
-		Name:  "secrets",
-		Short: "Manage encrypted environment secrets",
+		Name:    "secrets",
+		Aliases: []string{"env"},
+		Short:   "Manage encrypted environment secrets",
 		Long: "Manage environment secrets stored in the encrypted vault (.hulak/store.age).\n\n" +
 			"Secrets are organized by environment (e.g. global, staging, prod).\n" +
-			"The default environment is \"global\" unless --env is specified.",
+			"The default environment is \"global\" unless --env is specified.\n\n" +
+			"'env' is retained as an alias for backward compatibility with pre-0.3 docs.",
 		Examples: []*utils.CommandHelp{
 			{
 				Command:     "hulak secrets list",


### PR DESCRIPTION
Closes #133.

## Summary
- New pages: `docs/migrating-to-vault.md`, `docs/versioning.md`, `docs/comparison.md`.
- README rewrite around the encrypted-vault story plus a `Path A` (API client) and `Path B` (secrets only) Quickstart.
- `secrets` command now re-aliases `env` per #201, with a contract test.
- `pkg/envparser/replaceVars.go` error message points to `hulak secrets set ...` and satisfies staticcheck ST1005.
- `gendocs` regenerates `docs/cli.md` and `man/hulak.1` with the alias surfaced and a live-help callout.

## Test plan
- [ ] `go test ./...` passes locally (already green on this branch)
- [ ] `hulak env list` resolves to `hulak secrets list`
- [ ] README renders on GitHub: logo, `<sub>` subtitle, two Quickstart paths, project-layout tree
- [ ] Skim new docs in GitHub preview for link integrity