### PR TITLE
fix(envparser): handle json.Number in prepareMap

### DIFF
--- a/pkg/envparser/replaceVars.go
+++ b/pkg/envparser/replaceVars.go
@@ -3,6 +3,7 @@ package envparser
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -106,7 +107,7 @@ func prepareMap(secretsMap map[string]any) (map[string]any, error) {
 				return nil, err
 			}
 			updatedMap[key] = changedValue
-		case bool, int, float64, nil:
+		case json.Number, bool, int, float64, nil:
 			updatedMap[key] = v
 		default:
 			return nil, fmt.Errorf("unsupported type for key '%s': %T", key, val)

--- a/pkg/envparser/replaceVars_test.go
+++ b/pkg/envparser/replaceVars_test.go
@@ -1,11 +1,31 @@
 package envparser
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"strings"
 	"testing"
 )
+
+// TestSubstituteVariablesWithJSONNumber guards against a regression where the
+// vault decoded numbers as json.Number (to preserve int/float distinction) but
+// prepareMap rejected the type with "unsupported type for key '...': json.Number".
+// Real projects hit this on every gql/run call when any numeric secret was set.
+func TestSubstituteVariablesWithJSONNumber(t *testing.T) {
+	secretsMap := map[string]any{
+		"application_id": json.Number("12345"),
+		"url":            "https://api.example.com/apps/{{.application_id}}",
+	}
+	got, err := SubstituteVariables("{{.url}}", secretsMap)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "https://api.example.com/apps/12345"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
 
 func TestHandleEnvVarValue(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
## Summary
- Vault decodes numbers as `json.Number` to preserve int/float distinction (`pkg/vault/store.go:114`).
- `prepareMap` in `pkg/envparser/replaceVars.go` only allowed `bool, int, float64, nil`, so any numeric secret broke `hulak run` and `hulak gql` with `unsupported type for key '<k>': json.Number`.
- Added `json.Number` to the passthrough case. `json.Number` is `type Number string`, so `text/template` renders it correctly with no conversion.
- Added regression test `TestSubstituteVariablesWithJSONNumber` covering the resolution path.

## Test plan
- [x] `go test ./pkg/envparser/...` passes
- [ ] `hulak gql . -env staging` against a real project that has a numeric secret no longer errors