### PR TITLE
fix(runner): preserve multi-line error detail in outcome lines

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -410,51 +410,47 @@ func printOutcome(o outcome) {
 	if o.status != "" {
 		bracket = o.status + ", " + dur
 	}
-	headline, hint := splitErrorForOutcome(o.err)
+	headline, detail := splitErrorForOutcome(o.err)
 	utils.PrintErrorStderr(fmt.Sprintf("%s [%s]: %s", name, bracket, headline))
-	if hint != "" {
-		// Two-space indent groups the hint visually under the failure line —
-		// matches the summary's `  ✗ X` indent so the eye reads them as one block.
-		fmt.Fprintf(os.Stderr, "  %s\n", hint)
+	if detail != "" {
+		// Two-space indent groups the detail block visually under the failure
+		// line. Matches the summary's `  ✗ X` indent so the eye reads them as
+		// one unit. Newlines in detail are preserved (YAML decoder context,
+		// remediation steps, etc.) so each gets its own indented line.
+		for line := range strings.SplitSeq(detail, "\n") {
+			fmt.Fprintf(os.Stderr, "  %s\n", line)
+		}
 	}
 }
 
-// splitErrorForOutcome flattens an error chain into one short headline plus
-// an optional hint extracted from the deepest error message. The headline is
-// the full wrapped chain with whitespace and ANSI codes normalized; the hint
-// is the trailing actionable sentence (e.g. "Run 'hulak secrets set ...'") pulled
-// onto its own line so the user's eye lands on it.
+// splitErrorForOutcome splits an error message into a one-line headline plus
+// an optional multi-line detail block. The headline is the first line of the
+// error (after ANSI stripping). The detail is everything after the first
+// newline, with newlines preserved so callers can print the block indented
+// under the headline.
 //
-// Why bother: errors here are wrapped 3-4 deep ("substituting ...:
-// substituting ...: key X not found in environment Y. Add ..."). Printing
-// the whole chain in one line is unreadable; printing only the leaf loses
-// the file/key context. We keep both, just present them tidily.
-func splitErrorForOutcome(err error) (headline, hint string) {
+// Why bother: wrapped errors (envparser missing-key with remediation steps,
+// YAML decoder errors with caret-arrow context, etc.) carry information on
+// multiple lines. Flattening to one line loses the context arrows; printing
+// the whole chain inline makes the outcome row unreadable. Splitting keeps
+// the row scannable and the detail discoverable.
+func splitErrorForOutcome(err error) (headline, detail string) {
 	if err == nil {
 		return "", ""
 	}
 	msg := err.Error()
-	// Collapse any embedded newlines a wrapper may have injected (legacy
-	// ColorError used to do this). Tabs collapse the same way so a stray
-	// indented line doesn't widen the rendered outcome.
-	msg = strings.ReplaceAll(msg, "\n", " ")
-	msg = strings.ReplaceAll(msg, "\t", " ")
-	// Trim any leftover ANSI escape codes from older wrappers.
 	msg = ansiInOutcome.ReplaceAllString(msg, "")
-	msg = strings.TrimSpace(msg)
+	msg = strings.TrimRight(msg, " \n\t")
 
-	// Heuristic split: pull a trailing actionable sentence onto its own line.
-	// Marker is intentionally narrow — `. Add "` (period + space + Add + space
-	// + open quote) only matches the env-key-missing error format from
-	// envparser.formatMissingKeyError, where the quote anchors it to a real
-	// hint rather than free-form prose like "you must Add this header...".
-	// New hint-bearing errors should either use this exact format or, better,
-	// surface a typed hintError that this function can read explicitly.
-	const marker = `. Add "`
-	if i := strings.LastIndex(msg, marker); i >= 0 {
-		return strings.TrimSpace(msg[:i+1]), strings.TrimSpace(msg[i+2:])
+	if first, rest, ok := strings.Cut(msg, "\n"); ok {
+		headline = strings.TrimSpace(first)
+		// Tabs widen unpredictably in terminals; normalize so the indented
+		// detail block lines up regardless of the source error formatting.
+		detail = strings.ReplaceAll(rest, "\t", "  ")
+		detail = strings.TrimRight(detail, " \n\t")
+		return headline, detail
 	}
-	return msg, ""
+	return strings.TrimSpace(msg), ""
 }
 
 // ansiInOutcome strips ANSI SGR escape sequences from error strings.

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -327,63 +327,69 @@ func TestSplitErrorForOutcome(t *testing.T) {
 		name         string
 		err          error
 		wantHeadline string
-		wantHint     string
+		wantDetail   string
 	}{
 		{
 			name:         "nil error returns empty",
 			err:          nil,
 			wantHeadline: "",
-			wantHint:     "",
+			wantDetail:   "",
 		},
 		{
-			name:         "plain error has no hint",
+			name:         "single-line error has no detail",
 			err:          errors.New("something broke"),
 			wantHeadline: "something broke",
-			wantHint:     "",
+			wantDetail:   "",
 		},
 		{
-			name: "env-key-missing hint is split off",
+			name: "multi-line missing-key remediation preserves detail",
 			err: errors.New(
-				`substituting "client_id": key "client_id" not found in environment "global". Add "client_id=<value>" to env/global.env`,
+				"key \"X\" not found in environment \"prod\".\n" +
+					"Run 'hulak secrets set X <value> --env prod' to add it to the encrypted vault.\n" +
+					"For classic env/ mode, add X=<value> to env/prod.env.\n" +
+					"Or use a different environment with the -env flag",
 			),
-			wantHeadline: `substituting "client_id": key "client_id" not found in environment "global".`,
-			wantHint:     `Add "client_id=<value>" to env/global.env`,
+			wantHeadline: `key "X" not found in environment "prod".`,
+			wantDetail: "Run 'hulak secrets set X <value> --env prod' to add it to the encrypted vault.\n" +
+				"For classic env/ mode, add X=<value> to env/prod.env.\n" +
+				"Or use a different environment with the -env flag",
 		},
 		{
-			name:         "marker requires opening quote — false-positive prose stays unsplit",
-			err:          errors.New("you must Add this header before retrying"),
-			wantHeadline: "you must Add this header before retrying",
-			wantHint:     "",
-		},
-		{
-			name:         "embedded newlines collapse to spaces",
-			err:          errors.New("line one\nline two\nline three"),
-			wantHeadline: "line one line two line three",
-			wantHint:     "",
+			name: "yaml decoder context arrows are kept readable",
+			err: errors.New(
+				"decoding foo.gql: [2:1] unexpected key name\n" +
+					"   1 | # comment\n" +
+					">  2 | query Bar(\n" +
+					"       ^\n" +
+					"   3 |   $x: Int!",
+			),
+			wantHeadline: "decoding foo.gql: [2:1] unexpected key name",
+			wantDetail: "   1 | # comment\n" +
+				">  2 | query Bar(\n" +
+				"       ^\n" +
+				"   3 |   $x: Int!",
 		},
 		{
 			name:         "ANSI escape codes are stripped",
 			err:          errors.New("\x1b[31mred error\x1b[0m happened"),
 			wantHeadline: "red error happened",
-			wantHint:     "",
+			wantDetail:   "",
 		},
 		{
-			name: "ANSI + newline + hint together",
-			err: errors.New(
-				"\x1b[31mwrapped\x1b[0m:\nkey \"X\" not found in environment \"prod\". Add \"X=<value>\" to env/prod.env",
-			),
-			wantHeadline: `wrapped: key "X" not found in environment "prod".`,
-			wantHint:     `Add "X=<value>" to env/prod.env`,
+			name:         "tabs in detail normalize to two spaces",
+			err:          errors.New("headline\n\tindented one\n\tindented two"),
+			wantHeadline: "headline",
+			wantDetail:   "  indented one\n  indented two",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			gotHL, gotHint := splitErrorForOutcome(tc.err)
+			gotHL, gotDetail := splitErrorForOutcome(tc.err)
 			if gotHL != tc.wantHeadline {
 				t.Errorf("headline = %q, want %q", gotHL, tc.wantHeadline)
 			}
-			if gotHint != tc.wantHint {
-				t.Errorf("hint = %q, want %q", gotHint, tc.wantHint)
+			if gotDetail != tc.wantDetail {
+				t.Errorf("detail = %q, want %q", gotDetail, tc.wantDetail)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- `splitErrorForOutcome` flattened every `\n` and `\t` to a single space, which destroyed alignment in two common cases:
  - v0.3 envparser missing-key errors carry a four-line remediation block (canonical `hulak secrets set ...` command, classic-mode fallback, env-flag hint). All four lines collapsed into one row.
  - YAML decoder errors include caret-arrow context (numbered source lines plus a `^`). Flattening destroyed the alignment.
- The old hint marker (`. Add \"`) no longer matches the v0.3 envparser format, so missing-key errors also lost their actionable hint extraction.
- Replaced the flattening plus heuristic split with a simple two-part split: first line of the error becomes the headline, everything after the first newline becomes a multi-line detail block. `printOutcome` indents each detail line under the headline.
- Tabs in detail normalize to two spaces. ANSI is still stripped.

## Test plan
- [x] `go test ./pkg/runner/...` passes
- [x] `go test ./...` passes (no regressions)
- [ ] `hulak run foo.gql` shows the YAML decoder error with caret arrows readable
- [ ] `hulak run foo.hk.yaml` with a missing-key reference shows headline + indented remediation block