### PR TITLE
Identity resolution: SSH fallback + multi-source probe + ergonomic onboarding

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -280,7 +280,7 @@ hulak secrets delete OLD_KEY
 | `import-key` (`import-identity`) | Import an age identity (private key) |
 | `export-key` (`export-identity`) | Export the age identity (private key) |
 | `gen-identity` (`generate-identity`) | Generate a new age keypair without creating a vault |
-| `list-identity` (`ls-identity`, `identities`) | List identities that can decrypt the vault |
+| `list-identity` | List identities that can decrypt the vault |
 | `add-recipient` | Add a recipient for shared vault access |
 | `remove-recipient` | Remove a recipient |
 | `list-recipients` | List all recipients |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -279,6 +279,8 @@ hulak secrets delete OLD_KEY
 | `edit` | Edit secrets interactively |
 | `import-key` (`import-identity`) | Import an age identity (private key) |
 | `export-key` (`export-identity`) | Export the age identity (private key) |
+| `gen-identity` (`generate-identity`) | Generate a new age keypair without creating a vault |
+| `list-identity` (`ls-identity`, `identities`) | List identities that can decrypt the vault |
 | `add-recipient` | Add a recipient for shared vault access |
 | `remove-recipient` | Remove a recipient |
 | `list-recipients` | List all recipients |

--- a/docs/store.md
+++ b/docs/store.md
@@ -102,14 +102,16 @@ For the canonical step-by-step walkthrough, see [migrating-to-vault.md](./migrat
 
 ## Identity
 
-Hulak needs a private key to decrypt `store.age`. It checks these locations in order:
+Hulak needs a private key to decrypt `store.age`. It checks these sources:
 
-| Priority | Source | When to use |
-|----------|--------|-------------|
-| 1 | `HULAK_MASTER_KEY` env var | CI/CD pipelines |
-| 2 | `~/.config/hulak/identity.txt` | Default — dedicated age keypair |
-| 3 | `HULAK_SSH_IDENTITY` env var | Point at a specific SSH key |
-| 4 | `~/.ssh/id_ed25519` | Auto-detected if no age identity exists |
+| Source | When to use |
+|--------|-------------|
+| `HULAK_MASTER_KEY` env var | CI/CD pipelines — **explicit override**, never falls back |
+| `~/.config/hulak/identity.txt` | Default — dedicated age keypair |
+| `HULAK_SSH_IDENTITY` env var | Point at a specific SSH key |
+| `~/.ssh/id_ed25519` | Auto-detected SSH key |
+
+For decryption, hulak tries **every** identity it finds (except when `HULAK_MASTER_KEY` is set — that one is strict and fails hard if wrong). This means a stale `identity.txt` from another project won't block decryption if your SSH key is also a recipient.
 
 If you use SSH for git, hulak can reuse your existing SSH key. No separate keypair needed. Just make sure your SSH public key is added as a recipient (via `--github` or directly).
 
@@ -176,14 +178,18 @@ hulak secrets add-recipient --github alice --keyserver https://gitlab.company.co
 
 ### Joining a team (with age keys)
 
-If the new member prefers a dedicated age keypair:
+If the new member prefers a dedicated age keypair (or is on a new machine and doesn't want `hulak init`'s vault-scaffolding side effects), use `gen-identity`:
 
 ```bash
 # === New member's machine ===
-hulak init
-# Shows their public key in the output:
-#   Public key: age1bob...
+hulak secrets gen-identity
+# ✓ Identity written to ~/.config/hulak/identity.txt
+# Send your public key to a vault member and have them run:
+#   hulak secrets add-recipient age1bob...
+# age1bob...   ← printed to stdout, pipe-friendly
 ```
+
+Unlike `hulak init`, `gen-identity` only creates the global identity file — no `.hulak/` files in the current directory, so cloning the repo later works without conflicts.
 
 The new member sends their **public key** (`age1bob...`) to an existing team member via Slack, email, or a PR. **Public keys are not secret.** Never share the private key from `~/.config/hulak/identity.txt`.
 
@@ -317,20 +323,33 @@ Mark `HULAK_MASTER_KEY` as a **masked** / **protected** variable in both systems
 
 Treat a leaked private key (laptop stolen, accidental commit, etc.) like a leaked database password. Assume the worst and rotate. Steps:
 
-1. **Generate a new identity.** On a clean machine: `hulak init` (this creates a fresh keypair).
-2. **Add the new key as a recipient before removing the old one.** From any machine that still has access:
+1. **Rotate the keypair atomically.** From any machine that still has access:
    ```bash
-   hulak secrets add-recipient <new-public-key> --name "you-rotated-YYYY-MM-DD"
+   hulak secrets rotate-key
    ```
-3. **Remove the compromised key.**
-   ```bash
-   hulak secrets remove-recipient <old-public-key>
-   ```
-4. **Rotate every secret in the store upstream.** API keys, DB passwords, OAuth client secrets. Anything the leaker may have read. The leaker still has copies of `store.age` and the old identity from before the removal; the only way to invalidate that data is to make it useless by changing the upstream values.
-5. **Force teammates to pull.** They need the re-encrypted `store.age` so their next decrypt uses the new recipient list.
-6. **Audit history.** `git log -- .hulak/store.age` shows when ciphertexts changed; cross-reference with whatever you know about when the leak happened.
+   This generates a fresh keypair, swaps it in `recipients.txt`, re-encrypts the store, and backs up the old key to `identity.txt.old` (in case you need to read past backups).
+2. **Rotate every secret in the store upstream.** API keys, DB passwords, OAuth client secrets. Anything the leaker may have read. The leaker still has copies of `store.age` and the old identity from before the rotation; the only way to invalidate that data is to make it useless by changing the upstream values.
+3. **Force teammates to pull.** They need the re-encrypted `store.age` so their next decrypt uses the new recipient list.
+4. **Audit history.** `git log -- .hulak/store.age` shows when ciphertexts changed; cross-reference with whatever you know about when the leak happened.
 
 This is the same playbook as SOPS, GPG, and git-crypt. Encryption can't un-show plaintext, but a fast rotation plus upstream secret change is the standard mitigation.
+
+## Threat model: what hulak does and doesn't protect against
+
+| Threat | Defended? |
+|--------|-----------|
+| Secrets accidentally committed to a public repo | ✅ Encrypted at rest; ciphertext is useless without a recipient's private key |
+| Casual snooping (PR diffs, commit log) | ✅ Encrypted blob |
+| Compromised CI without explicit credentials | ✅ CI must have its own identity (via `HULAK_MASTER_KEY` or a recipient key) |
+| Stolen laptop with plaintext `identity.txt` | ❌ Mitigate with OS disk encryption; future: passphrase-protected identities |
+| Malicious local process reading env vars | ❌ OS-level isolation problem (same caveat as `aws-vault exec`, `direnv`) |
+| Insider with current access leaking secrets | ❌ Trust model assumes recipients are trustworthy |
+| Removed member with old git clone | ⚠️ They retain history; rotate secret **values** at source after removal |
+| Attacker with leaked key adds themselves as a recipient before you rotate | ⚠️ Mitigate with branch protection + CODEOWNERS on `.hulak/recipients.txt` so changes need review |
+
+**Key invariant**: editing `recipients.txt` does nothing on its own. To produce a `store.age` that a new key can decrypt, you have to re-encrypt — which requires an existing recipient's private key. A public repo with the ciphertext is useless to an attacker who never had a recipient key.
+
+**The git history caveat**: removing a recipient does not unleak past ciphertexts. Anyone who had a valid key at any point in history can still decrypt the snapshots they pulled. After removing a member, **rotate every secret value at the source** (DB password, API key, etc.) — that's the only way to invalidate already-read data.
 
 ## See also
 

--- a/pkg/envparser/envparser.go
+++ b/pkg/envparser/envparser.go
@@ -229,12 +229,7 @@ func resolveEnvRefs(m map[string]any) map[string]any {
 // loadSecretsFromVault decrypts the store and returns merged env vars.
 // Uses the same merge pattern as classic: global base + custom overlay.
 func loadSecretsFromVault(envName string) (map[string]any, error) {
-	identity, err := vault.ResolveIdentity()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load identity: %w", err)
-	}
-
-	store, err := vault.ReadStore(identity)
+	store, err := vault.ReadStore()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tui/envselect/envselect.go
+++ b/pkg/tui/envselect/envselect.go
@@ -54,11 +54,7 @@ func noEnvFilesError() error {
 // "no envs configured" prompt instead of an alarming error.
 func envItems() ([]string, error) {
 	if vault.DetectStore() == vault.StoreAge {
-		identity, err := vault.ResolveIdentity()
-		if err != nil {
-			return nil, fmt.Errorf("vault: %w", err)
-		}
-		store, err := vault.ReadStore(identity)
+		store, err := vault.ReadStore()
 		if err != nil {
 			return nil, fmt.Errorf("vault: reading store: %w", err)
 		}

--- a/pkg/userFlags/command.go
+++ b/pkg/userFlags/command.go
@@ -161,6 +161,12 @@ func (cmd *command) printHelp() {
 				Description: sub.Short,
 			})
 		}
+		// Alphabetical so users can scan; registration order is meaningless
+		// to readers. Sort by primary name (everything before the first
+		// space, i.e. before the "(alias)" suffix).
+		slices.SortFunc(entries, func(a, b *utils.CommandHelp) int {
+			return strings.Compare(primaryName(a.Command), primaryName(b.Command))
+		})
 		_ = utils.WriteCommandHelp(entries)
 		fmt.Println()
 	}
@@ -264,4 +270,13 @@ func printFlags(fs *flag.FlagSet) {
 // isHelpArg returns true if the argument is a help request
 func isHelpArg(arg string) bool {
 	return arg == "help" || arg == "--help" || arg == "-h"
+}
+
+// primaryName strips the "(alias, alias)" suffix from a command label so
+// sort comparisons see only the canonical name.
+func primaryName(label string) string {
+	if i := strings.IndexByte(label, ' '); i >= 0 {
+		return label[:i]
+	}
+	return label
 }

--- a/pkg/userFlags/doctor_checks.go
+++ b/pkg/userFlags/doctor_checks.go
@@ -54,9 +54,9 @@ func checkFileMode(path string, mc modeCheck) finding {
 
 // --- vault checks ------------------------------------------------------------
 
-// checkIdentityPresent verifies that at least one identity source resolves.
+// checkIdentityPresent verifies that at least one identity source is available.
 func checkIdentityPresent() finding {
-	if _, err := vault.ResolveIdentity(); err != nil {
+	if !vault.HasAnyIdentity() {
 		return finding{
 			check:    "identity-present",
 			severity: sevError,
@@ -202,14 +202,13 @@ func checkStoreEncrypted() finding {
 	}
 }
 
-// checkStoreDecrypts tries to decrypt store.age with the current identity.
+// checkStoreDecrypts tries to decrypt store.age via the multi-source probe.
 func checkStoreDecrypts() finding {
-	identity, err := vault.ResolveIdentity()
-	if err != nil {
+	if !vault.HasAnyIdentity() {
 		return skipFinding("store-decrypts", "no identity available (skipping decryption check)")
 	}
 
-	if _, err = vault.ReadStore(identity); err != nil {
+	if _, err := vault.ReadStore(); err != nil {
 		return finding{
 			check:    "store-decrypts",
 			severity: sevError,

--- a/pkg/userFlags/env_backup.go
+++ b/pkg/userFlags/env_backup.go
@@ -91,11 +91,6 @@ func runBackup(outPath string, force bool) error {
 		return err
 	}
 
-	identity, err := vault.ResolveIdentity()
-	if err != nil {
-		return fmt.Errorf("failed to load identity: %w", err)
-	}
-
 	storePath, err := vault.StorePath()
 	if err != nil {
 		return err
@@ -109,8 +104,9 @@ func runBackup(outPath string, force bool) error {
 		return fmt.Errorf("failed to read store: %w", err)
 	}
 
-	// Validate: decrypt to prove the store is healthy. Discard the data.
-	if _, err := vault.DecryptText(cipherText, identity); err != nil {
+	// Validate: probe each identity to prove the store is healthy. Discard
+	// the resolved identity — we only care that decryption is possible.
+	if _, err := vault.ResolveIdentityFor(cipherText); err != nil {
 		return fmt.Errorf(
 			"store.age cannot be decrypted with current identity — refusing to back up a corrupt or inaccessible store: %w",
 			err,
@@ -299,12 +295,7 @@ func runRestore(backupPath string, force bool) error {
 	// Decrypt to validate identity + version + JSON structure.
 	// The age library handles format detection — non-age files
 	// produce a clear decrypt error without hardcoding the header.
-	identity, err := vault.ResolveIdentity()
-	if err != nil {
-		return fmt.Errorf("failed to load identity: %w", err)
-	}
-
-	store, err := vault.ReadStoreFrom(resolvedPath, identity)
+	store, err := vault.ReadStore(resolvedPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/userFlags/env_backup_test.go
+++ b/pkg/userFlags/env_backup_test.go
@@ -334,7 +334,7 @@ func TestRunRestore_ReencryptsToCurrentRecipients(t *testing.T) {
 	}
 
 	// The restored store should be decryptable by the new recipient
-	store, err := vault.ReadStore(newKey.Identity)
+	store, err := vault.DecryptStore(newKey.Identity)
 	if err != nil {
 		t.Fatalf("new recipient cannot decrypt restored store: %v", err)
 	}

--- a/pkg/userFlags/env_crud.go
+++ b/pkg/userFlags/env_crud.go
@@ -93,12 +93,7 @@ func runEnvSet(args []string, envName string, useStdin bool) error {
 
 	// acquire lock
 	return vault.WithStoreLock(func() error {
-		identity, err := vault.ResolveIdentity()
-		if err != nil {
-			return fmt.Errorf("failed to load identity: %w", err)
-		}
-
-		store, err := vault.ReadStore(identity)
+		store, err := vault.ReadStore()
 		if err != nil {
 			return err
 		}
@@ -196,12 +191,7 @@ func runEnvGet(args []string, envName string) error {
 		return err
 	}
 
-	identity, err := vault.ResolveIdentity()
-	if err != nil {
-		return fmt.Errorf("failed to load identity: %w", err)
-	}
-
-	store, err := vault.ReadStore(identity)
+	store, err := vault.ReadStore()
 	if err != nil {
 		return err
 	}
@@ -288,12 +278,7 @@ func runEnvDelete(args []string, envName string) error {
 	}
 
 	return vault.WithStoreLock(func() error {
-		identity, err := vault.ResolveIdentity()
-		if err != nil {
-			return fmt.Errorf("failed to load identity: %w", err)
-		}
-
-		store, err := vault.ReadStore(identity)
+		store, err := vault.ReadStore()
 		if err != nil {
 			return err
 		}

--- a/pkg/userFlags/env_crud_test.go
+++ b/pkg/userFlags/env_crud_test.go
@@ -138,7 +138,7 @@ func TestRunEnvGet_PrintsNonString(t *testing.T) {
 	// Seed non-string types via the store directly (CLI `set` always stores strings).
 	if err := vault.WithStoreLock(func() error {
 		ageKey, _ := vault.EnsureKeypair()
-		store, _ := vault.ReadStore(ageKey.Identity)
+		store, _ := vault.DecryptStore(ageKey.Identity)
 		store.SetKey("global", "PORT", json.Number("8000"))
 		store.SetKey("global", "ENABLED", true)
 		return vault.WriteStore(store, ageKey.Recipient)

--- a/pkg/userFlags/env_crud_test.go
+++ b/pkg/userFlags/env_crud_test.go
@@ -138,7 +138,7 @@ func TestRunEnvGet_PrintsNonString(t *testing.T) {
 	// Seed non-string types via the store directly (CLI `set` always stores strings).
 	if err := vault.WithStoreLock(func() error {
 		ageKey, _ := vault.EnsureKeypair()
-		store, _ := vault.DecryptStore(ageKey.Identity)
+		store, _ := vault.ReadStore()
 		store.SetKey("global", "PORT", json.Number("8000"))
 		store.SetKey("global", "ENABLED", true)
 		return vault.WriteStore(store, ageKey.Recipient)

--- a/pkg/userFlags/env_edit.go
+++ b/pkg/userFlags/env_edit.go
@@ -92,11 +92,7 @@ func runEnvEdit(args []string, envName string) error {
 	}
 
 	return vault.WithStoreLock(func() error {
-		identity, err := vault.ResolveIdentity()
-		if err != nil {
-			return fmt.Errorf("failed to load identity: %w", err)
-		}
-		store, err := vault.ReadStore(identity)
+		store, err := vault.ReadStore()
 		if err != nil {
 			return err
 		}

--- a/pkg/userFlags/env_gen_identity.go
+++ b/pkg/userFlags/env_gen_identity.go
@@ -82,7 +82,7 @@ func runGenIdentity(args []string) error {
 	utils.PrintInfoStderr(fmt.Sprintf("  hulak secrets add-recipient %s", pubKey))
 	utils.PrintInfoStderr("")
 	utils.PrintWarningStderr(
-		"Back up the identity file — losing it means losing access to the vault.",
+		"Back up the identity file. Losing it means losing access to the vault.",
 	)
 
 	// Pubkey on stdout so it can be piped or captured: $(hulak secrets gen-identity)

--- a/pkg/userFlags/env_gen_identity.go
+++ b/pkg/userFlags/env_gen_identity.go
@@ -1,0 +1,91 @@
+// Contains command factory and handler for hulak secrets gen-identity.
+package userflags
+
+import (
+	"fmt"
+
+	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
+)
+
+// newEnvGenIdentityCmd returns the command struct for `hulak secrets gen-identity`.
+//
+// Use case: a teammate joining an existing vault on a new machine needs an age
+// keypair without the side effects of `hulak init` (which creates a fresh
+// .hulak/ in cwd). This command creates just the global identity file and
+// prints the public key for an existing vault member to add as a recipient.
+func newEnvGenIdentityCmd() *command {
+	return &command{
+		Name:    "gen-identity",
+		Aliases: []string{"generate-identity"},
+		Short:   "Generate a new age keypair without creating a vault",
+		Long: "Generate a fresh age keypair and write it to ~/.config/hulak/identity.txt.\n\n" +
+			"Unlike 'hulak init', this command does not create .hulak/ files in the\n" +
+			"current directory. Use it on a new machine joining an existing vault:\n" +
+			"run this, send the printed pubkey to a current member, and they add it\n" +
+			"with 'hulak secrets add-recipient'.\n\n" +
+			"To rotate an existing identity (compromised key), use 'hulak secrets\n" +
+			"rotate-key' instead — gen-identity refuses to overwrite identity.txt.\n\n" +
+			"Note: the same identity can be a recipient of multiple vaults — you\n" +
+			"don't need a separate keypair per project, just per machine.",
+		Examples: []*utils.CommandHelp{
+			{
+				Command:     "hulak secrets gen-identity",
+				Description: "Generate a keypair and print the public key to stdout",
+			},
+		},
+		Run: runGenIdentity,
+	}
+}
+
+// runGenIdentity handles `hulak secrets gen-identity`.
+//
+// Refuses if ~/.config/hulak/identity.txt already exists — overwriting it
+// silently would lose access to whatever vault that key was a recipient of.
+// For deliberate replacement, the user should run 'rotate-key' instead.
+//
+// On success: prints the new public key to stdout (so it can be piped or
+// captured) and the suggested add-recipient invocation to stderr.
+func runGenIdentity(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
+	}
+
+	identityPath, err := vault.IdentityPath()
+	if err != nil {
+		return err
+	}
+	if utils.FileExists(identityPath) {
+		return utils.HelpfulError(
+			fmt.Sprintf("identity already exists at %s", identityPath),
+			"What to do instead",
+			[]string{
+				"To replace it (e.g. after a key compromise), run 'hulak secrets rotate-key'",
+				"To use this identity with another vault, add its pubkey as a recipient there — the same identity can decrypt multiple vaults",
+			},
+		)
+	}
+
+	key, err := vault.GenerateKeyPair()
+	if err != nil {
+		return fmt.Errorf("failed to generate keypair: %w", err)
+	}
+	if err := vault.SetIdentity(key.Identity.String()); err != nil {
+		return fmt.Errorf("failed to write identity: %w", err)
+	}
+
+	pubKey := key.Recipient.String()
+
+	utils.PrintSuccessStderr(fmt.Sprintf("Identity written to %s", identityPath))
+	utils.PrintInfoStderr("")
+	utils.PrintInfoStderr("Send your public key to a vault member and have them run:")
+	utils.PrintInfoStderr(fmt.Sprintf("  hulak secrets add-recipient %s", pubKey))
+	utils.PrintInfoStderr("")
+	utils.PrintWarningStderr(
+		"Back up the identity file — losing it means losing access to the vault.",
+	)
+
+	// Pubkey on stdout so it can be piped or captured: $(hulak secrets gen-identity)
+	fmt.Println(pubKey)
+	return nil
+}

--- a/pkg/userFlags/env_gen_identity.go
+++ b/pkg/userFlags/env_gen_identity.go
@@ -2,6 +2,7 @@
 package userflags
 
 import (
+	"flag"
 	"fmt"
 
 	"github.com/xaaha/hulak/pkg/utils"
@@ -12,41 +13,60 @@ import (
 //
 // Use case: a teammate joining an existing vault on a new machine needs an age
 // keypair without the side effects of `hulak init` (which creates a fresh
-// .hulak/ in cwd). This command creates just the global identity file and
-// prints the public key for an existing vault member to add as a recipient.
+// .hulak/ in cwd). Pass --name when you already have decrypt access (e.g.
+// via SSH) and want the new key auto-registered as a recipient.
 func newEnvGenIdentityCmd() *command {
+	fs := flag.NewFlagSet("env gen-identity", flag.ContinueOnError)
+	genIdentityName := registerNameFlag(
+		fs,
+		"Auto-register the new key as a recipient with this label (requires an existing decrypt path; defaults label to OS username)",
+	)
+
 	return &command{
 		Name:    "gen-identity",
 		Aliases: []string{"generate-identity"},
 		Short:   "Generate a new age keypair without creating a vault",
 		Long: "Generate a fresh age keypair and write it to ~/.config/hulak/identity.txt.\n\n" +
 			"Unlike 'hulak init', this command does not create .hulak/ files in the\n" +
-			"current directory. Use it on a new machine joining an existing vault:\n" +
-			"run this, send the printed pubkey to a current member, and they add it\n" +
-			"with 'hulak secrets add-recipient'.\n\n" +
-			"To rotate an existing identity (compromised key), use 'hulak secrets\n" +
-			"rotate-key' instead — gen-identity refuses to overwrite identity.txt.\n\n" +
-			"Note: the same identity can be a recipient of multiple vaults — you\n" +
-			"don't need a separate keypair per project, just per machine.",
+			"current directory. Two common uses:\n\n" +
+			"  - New machine, no vault access yet: run without --name, send the\n" +
+			"    printed pubkey to a current vault member, and they add it with\n" +
+			"    'hulak secrets add-recipient'.\n\n" +
+			"  - Already have decrypt access (SSH, master key, another identity):\n" +
+			"    run with --name to auto-register the new key as a recipient in\n" +
+			"    one step. No teammate intervention needed.\n\n" +
+			"Refuses to overwrite an existing identity. To rotate, use 'hulak\n" +
+			"secrets rotate-key' instead.",
+		Flags: fs,
 		Examples: []*utils.CommandHelp{
 			{
 				Command:     "hulak secrets gen-identity",
-				Description: "Generate a keypair and print the public key to stdout",
+				Description: "Generate a keypair and print the public key (no auto-register)",
+			},
+			{
+				Command:     "hulak secrets gen-identity --name alice-laptop",
+				Description: "Generate + auto-register as a recipient (needs another working identity)",
 			},
 		},
-		Run: runGenIdentity,
+		Run: func(args []string) error {
+			return runGenIdentity(args, *genIdentityName)
+		},
 	}
 }
 
-// runGenIdentity handles `hulak secrets gen-identity`.
+// runGenIdentity handles `hulak secrets gen-identity [--name LABEL]`.
 //
 // Refuses if ~/.config/hulak/identity.txt already exists — overwriting it
 // silently would lose access to whatever vault that key was a recipient of.
-// For deliberate replacement, the user should run 'rotate-key' instead.
+//
+// With --name: registers the new pubkey as a recipient first (using whatever
+// identity currently decrypts the vault), then writes identity.txt. If the
+// recipient add fails, no identity is written — atomic-ish.
 //
 // On success: prints the new public key to stdout (so it can be piped or
-// captured) and the suggested add-recipient invocation to stderr.
-func runGenIdentity(args []string) error {
+// captured) and, when --name was not set, the suggested add-recipient
+// invocation to stderr.
+func runGenIdentity(args []string, name string) error {
 	if len(args) > 0 {
 		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
 	}
@@ -70,17 +90,28 @@ func runGenIdentity(args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to generate keypair: %w", err)
 	}
+	pubKey := key.Recipient.String()
+
+	if name != "" {
+		if err := requireVaultProject(); err != nil {
+			return fmt.Errorf("--name needs a vault project in cwd: %w", err)
+		}
+		if err := registerPubKeyAsRecipient(pubKey, name); err != nil {
+			return err
+		}
+	}
+
 	if err := vault.SetIdentity(key.Identity.String()); err != nil {
 		return fmt.Errorf("failed to write identity: %w", err)
 	}
 
-	pubKey := key.Recipient.String()
-
 	utils.PrintSuccessStderr(fmt.Sprintf("Identity written to %s", identityPath))
-	utils.PrintInfoStderr("")
-	utils.PrintInfoStderr("Send your public key to a vault member and have them run:")
-	utils.PrintInfoStderr(fmt.Sprintf("  hulak secrets add-recipient %s", pubKey))
-	utils.PrintInfoStderr("")
+	if name == "" {
+		utils.PrintInfoStderr("")
+		utils.PrintInfoStderr("Send your public key to a vault member and have them run:")
+		utils.PrintInfoStderr(fmt.Sprintf("  hulak secrets add-recipient %s", pubKey))
+		utils.PrintInfoStderr("")
+	}
 	utils.PrintWarningStderr(
 		"Back up the identity file. Losing it means losing access to the vault.",
 	)

--- a/pkg/userFlags/env_gen_identity_test.go
+++ b/pkg/userFlags/env_gen_identity_test.go
@@ -1,0 +1,119 @@
+package userflags
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
+)
+
+// setupGenIdentityTest creates an isolated config dir and returns its path.
+// No vault is created — gen-identity is meant to run outside a vault.
+func setupGenIdentityTest(t *testing.T) string {
+	t.Helper()
+
+	configTmp := t.TempDir()
+	configTmp, _ = filepath.EvalSymlinks(configTmp)
+	t.Setenv("XDG_CONFIG_HOME", configTmp)
+
+	configDir, err := utils.UserConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(configDir, utils.DirPer); err != nil {
+		t.Fatal(err)
+	}
+
+	return configDir
+}
+
+func TestRunGenIdentity(t *testing.T) {
+	t.Run("creates identity.txt when absent", func(t *testing.T) {
+		configDir := setupGenIdentityTest(t)
+
+		if err := runGenIdentity(nil); err != nil {
+			t.Fatalf("runGenIdentity: %v", err)
+		}
+
+		identityPath := filepath.Join(configDir, utils.IdentityFile)
+		if !utils.FileExists(identityPath) {
+			t.Fatalf("expected %s to exist after gen-identity", identityPath)
+		}
+
+		// File should be parseable as an age identity
+		if _, err := vault.LoadIdentity(); err != nil {
+			t.Errorf("identity should be parseable: %v", err)
+		}
+	})
+
+	t.Run("refuses to overwrite existing identity", func(t *testing.T) {
+		setupGenIdentityTest(t)
+
+		// First run succeeds
+		if err := runGenIdentity(nil); err != nil {
+			t.Fatalf("first runGenIdentity: %v", err)
+		}
+		first, err := vault.LoadIdentity()
+		if err != nil {
+			t.Fatalf("LoadIdentity after first run: %v", err)
+		}
+
+		// Second run errors with helpful message
+		err = runGenIdentity(nil)
+		if err == nil {
+			t.Fatal("expected error when identity already exists")
+		}
+		if !strings.Contains(err.Error(), "already exists") {
+			t.Errorf("error should mention 'already exists': %v", err)
+		}
+		if !strings.Contains(err.Error(), "rotate-key") {
+			t.Errorf("error should point at rotate-key: %v", err)
+		}
+
+		// Identity unchanged
+		second, err := vault.LoadIdentity()
+		if err != nil {
+			t.Fatalf("LoadIdentity after refused run: %v", err)
+		}
+		if first.String() != second.String() {
+			t.Error("identity was changed despite refusal")
+		}
+	})
+
+	t.Run("rejects positional arguments", func(t *testing.T) {
+		setupGenIdentityTest(t)
+
+		err := runGenIdentity([]string{"unexpected"})
+		if err == nil {
+			t.Fatal("expected error for unexpected argument")
+		}
+		if !strings.Contains(err.Error(), "too many arguments") {
+			t.Errorf("error should mention 'too many arguments': %v", err)
+		}
+	})
+
+	t.Run("does not create .hulak/ in cwd (no orphan vault)", func(t *testing.T) {
+		setupGenIdentityTest(t)
+		cwd := t.TempDir()
+		oldWd, _ := os.Getwd()
+		_ = os.Chdir(cwd)
+		t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+		if err := runGenIdentity(nil); err != nil {
+			t.Fatalf("runGenIdentity: %v", err)
+		}
+
+		entries, err := os.ReadDir(cwd)
+		if err != nil {
+			t.Fatalf("read cwd: %v", err)
+		}
+		for _, e := range entries {
+			if e.Name() == utils.HiddenProjectName {
+				t.Errorf("gen-identity created %s in cwd — should not touch cwd", e.Name())
+			}
+		}
+	})
+}

--- a/pkg/userFlags/env_gen_identity_test.go
+++ b/pkg/userFlags/env_gen_identity_test.go
@@ -34,7 +34,7 @@ func TestRunGenIdentity(t *testing.T) {
 	t.Run("creates identity.txt when absent", func(t *testing.T) {
 		configDir := setupGenIdentityTest(t)
 
-		if err := runGenIdentity(nil); err != nil {
+		if err := runGenIdentity(nil, ""); err != nil {
 			t.Fatalf("runGenIdentity: %v", err)
 		}
 
@@ -53,7 +53,7 @@ func TestRunGenIdentity(t *testing.T) {
 		setupGenIdentityTest(t)
 
 		// First run succeeds
-		if err := runGenIdentity(nil); err != nil {
+		if err := runGenIdentity(nil, ""); err != nil {
 			t.Fatalf("first runGenIdentity: %v", err)
 		}
 		first, err := vault.LoadIdentity()
@@ -62,7 +62,7 @@ func TestRunGenIdentity(t *testing.T) {
 		}
 
 		// Second run errors with helpful message
-		err = runGenIdentity(nil)
+		err = runGenIdentity(nil, "")
 		if err == nil {
 			t.Fatal("expected error when identity already exists")
 		}
@@ -86,7 +86,7 @@ func TestRunGenIdentity(t *testing.T) {
 	t.Run("rejects positional arguments", func(t *testing.T) {
 		setupGenIdentityTest(t)
 
-		err := runGenIdentity([]string{"unexpected"})
+		err := runGenIdentity([]string{"unexpected"}, "")
 		if err == nil {
 			t.Fatal("expected error for unexpected argument")
 		}
@@ -102,7 +102,7 @@ func TestRunGenIdentity(t *testing.T) {
 		_ = os.Chdir(cwd)
 		t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
-		if err := runGenIdentity(nil); err != nil {
+		if err := runGenIdentity(nil, ""); err != nil {
 			t.Fatalf("runGenIdentity: %v", err)
 		}
 

--- a/pkg/userFlags/env_keys.go
+++ b/pkg/userFlags/env_keys.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/xaaha/hulak/pkg/utils"
 	"github.com/xaaha/hulak/pkg/vault"
@@ -18,36 +19,79 @@ func newEnvImportKeyCmd() *command {
 	fs := flag.NewFlagSet("env import-key", flag.ContinueOnError)
 	importKeyStdin := fs.Bool("stdin", false, "Read key from stdin")
 	importKeyForce := fs.Bool("force", false, "Overwrite existing identity file")
+	importKeyName := registerNameFlag(
+		fs,
+		"Auto-register the imported key as a recipient with this label (requires an existing decrypt path; defaults label to OS username)",
+	)
 
 	return &command{
 		Name:    "import-key",
 		Aliases: []string{"import-identity"},
 		Short:   "Import an age identity (private key)",
-		Long:    "Import an age private key from a file or stdin into the hulak config directory.\n\nValidates the key before writing. Refuses to overwrite an existing identity unless --force is passed.\nAtomic write (tmp + rename) so an interrupted import can never corrupt an existing identity.",
-		Flags:   fs,
+		Long: "Import an age private key from a file or stdin and save it to hulak's\n" +
+			"config directory so it can decrypt the vault.\n\n" +
+			"Inside a vault project, hulak first checks that the key can decrypt\n" +
+			"store.age. This catches the common 'wrong file' mistake. Outside a vault,\n" +
+			"the check is skipped automatically.\n\n" +
+			"Pass --name to auto-register the imported key as a recipient (requires\n" +
+			"another working identity, e.g. SSH, that can decrypt store.age right now).\n" +
+			"This skips the wrong-file check because the key is being added to the\n" +
+			"vault as part of the same operation.\n\n" +
+			"Will not overwrite an existing identity unless --force is passed.",
+		Flags: fs,
 		Args: []argDef{
 			{Name: "path", Desc: "Path to the identity file (omit with --stdin)"},
 		},
 		Examples: []*utils.CommandHelp{
 			{
 				Command:     "hulak secrets import-key ~/backup-identity.txt",
-				Description: "Import from a backup file",
+				Description: "Restore a key that's already a recipient of the vault",
+			},
+			{
+				Command:     "hulak secrets import-key ~/age-key.txt --name alice-laptop",
+				Description: "Import + auto-register as recipient (needs another working identity)",
 			},
 			{
 				Command:     "hulak secrets import-key ~/backup.txt --force",
-				Description: "Overwrite existing identity",
+				Description: "Overwrite an existing identity file",
 			},
 			{
 				Command:     "echo \"AGE-SECRET-KEY-1QF...\" | hulak secrets import-key --stdin",
 				Description: "Import from stdin (password manager pipe)",
 			},
 		},
-		Run: func(args []string) error { return runImportKey(args, *importKeyStdin, *importKeyForce) },
+		Run: func(args []string) error {
+			return runImportKey(args, *importKeyStdin, *importKeyForce, *importKeyName)
+		},
 	}
 }
 
-// runImportKey handles `hulak secrets import-key [path] [--stdin] [--force]`.
-func runImportKey(args []string, useStdin, force bool) error {
+// runImportKey handles `hulak secrets import-key [path] [--stdin] [--force] [--name LABEL]`.
+//
+// Two modes, picked by --name:
+//
+//   - With --name: STATE-CHANGING. The user is opting in to add this key to
+//     the vault. Uses whatever currently decrypts store.age (SSH, master
+//     key, or another identity) to re-encrypt the store including the new
+//     pubkey and append to recipients.txt. The key becomes a real recipient
+//     as part of this command — no wrong-file check needed afterwards.
+//
+//   - Without --name: READ-ONLY. Verifies the candidate already decrypts
+//     store.age before saving it. For restoring a backup of a key that's
+//     already a vault recipient. Touches nothing in the vault; just reads.
+//     Catches "wrong file" mistakes before they surface later as confusing
+//     decrypt failures.
+//
+// Why two branches instead of always self-registering? The restore case
+// shouldn't mutate the vault — silently re-encrypting store.age on every
+// import would surprise users who expected a non-destructive operation,
+// and registration also requires being inside a vault project (pre-clone
+// staging would break). --name is the explicit consent signal for state
+// change.
+//
+// Outside a vault (no .hulak/ or no store.age), the read-only check
+// auto-skips — useful for pre-clone staging. --name still requires a vault.
+func runImportKey(args []string, useStdin, force bool, name string) error {
 	if useStdin && len(args) > 0 {
 		return errors.New("cannot use both --stdin and a positional path — pick one")
 	}
@@ -75,6 +119,16 @@ func runImportKey(args []string, useStdin, force bool) error {
 		return errors.New("missing required argument: path (or use --stdin)")
 	}
 
+	// --name → state-changing self-register; otherwise → read-only verify.
+	// See function doc for why we don't always self-register.
+	if name != "" {
+		if err := registerImportedKeyAsRecipient(raw, name); err != nil {
+			return err
+		}
+	} else if err := validateImportAgainstVault(raw); err != nil {
+		return err
+	}
+
 	if err := vault.ImportKey(raw, force); err != nil {
 		return err
 	}
@@ -84,6 +138,82 @@ func runImportKey(args []string, useStdin, force bool) error {
 		return err
 	}
 	utils.PrintSuccessStderr(fmt.Sprintf("Identity imported to %s", identityPath))
+	return nil
+}
+
+// registerImportedKeyAsRecipient parses raw, derives the public key, and adds
+// it to the vault as a recipient using whatever identity currently decrypts
+// store.age. Used by import-key --name and gen-identity --name.
+func registerImportedKeyAsRecipient(raw, name string) error {
+	if err := requireVaultProject(); err != nil {
+		return fmt.Errorf("--name needs a vault project in cwd: %w", err)
+	}
+	candidate, err := vault.ParseImportKey(raw)
+	if err != nil {
+		return err
+	}
+	return registerPubKeyAsRecipient(candidate.Recipient().String(), name)
+}
+
+// registerPubKeyAsRecipient adds pubKey to recipients.txt and re-encrypts the
+// store. Wraps vault.AddRecipientAndReencrypt with the OS-username fallback
+// and a clearer "already a recipient" message.
+func registerPubKeyAsRecipient(pubKey, name string) error {
+	added, err := vault.AddRecipientAndReencrypt(pubKey, resolveRecipientName(name, utils.Username()))
+	if err != nil {
+		return err
+	}
+	if added {
+		utils.PrintSuccessStderr(fmt.Sprintf("Registered as recipient: %s", pubKey))
+	} else {
+		utils.PrintInfoStderr(fmt.Sprintf("Already a recipient: %s", pubKey))
+	}
+	return nil
+}
+
+// validateImportAgainstVault decrypt-tests the imported key against the local
+// store.age. Returns nil when no vault is in cwd (pre-vault staging is a
+// legitimate use case). Returns an actionable error when the key is parseable
+// but doesn't decrypt — directing the user to add-recipient first.
+func validateImportAgainstVault(raw string) error {
+	storePath, err := vault.StorePath()
+	if err != nil || storePath == "" || !utils.FileExists(storePath) {
+		// No vault here — nothing to validate against. Pre-clone staging
+		// is a legitimate use; let the import proceed.
+		return nil
+	}
+
+	candidate, err := vault.ParseImportKey(raw)
+	if err != nil {
+		// Parse failure surfaces in vault.ImportKey with the same error;
+		// defer to that for the canonical message.
+		return nil
+	}
+
+	cipherText, err := os.ReadFile(storePath)
+	if err != nil {
+		return fmt.Errorf("failed to read store: %w", err)
+	}
+
+	if _, err := vault.DecryptText(cipherText, candidate); err != nil {
+		// age's specific "no recipient match" error contains "did not match
+		// any of the recipients". Any other error (truncated file, invalid
+		// header, etc.) means store.age itself is the problem — don't
+		// misreport that as "not a recipient."
+		if !strings.Contains(err.Error(), "did not match any of the recipients") {
+			return fmt.Errorf("failed to validate against store.age (possibly corrupt): %w", err)
+		}
+		pub := candidate.Recipient().String()
+		return utils.HelpfulError(
+			"this key cannot decrypt store.age (not a recipient of this vault)",
+			"What to do",
+			[]string{
+				fmt.Sprintf("Public key derived from import: %s", pub),
+				fmt.Sprintf("Ask a current vault member to add it: hulak secrets add-recipient %s", pub),
+				"If you already have another working identity (SSH, master key), re-run with --name <label> to self-register",
+			},
+		)
+	}
 	return nil
 }
 

--- a/pkg/userFlags/env_keys_test.go
+++ b/pkg/userFlags/env_keys_test.go
@@ -1,0 +1,203 @@
+package userflags
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"filippo.io/age"
+
+	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
+)
+
+// setupImportKeyTest creates a temp project, isolates the config dir, and
+// optionally creates an encrypted store with the given identity as a recipient.
+// Returns the keyPath to write candidate import material into.
+func setupImportKeyTest(t *testing.T, withVault bool, vaultIdentity *age.X25519Identity) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	configTmp := t.TempDir()
+	configTmp, _ = filepath.EvalSymlinks(configTmp)
+	t.Setenv("XDG_CONFIG_HOME", configTmp)
+	t.Setenv("HULAK_MASTER_KEY", "")
+	t.Setenv("HULAK_SSH_IDENTITY", "")
+	t.Setenv("HOME", t.TempDir())
+
+	configDir, err := utils.UserConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(configDir, utils.DirPer); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	if !withVault {
+		return tmpDir
+	}
+
+	// Create a vault encrypted to vaultIdentity
+	hulakDir := filepath.Join(tmpDir, utils.HiddenProjectName)
+	if err := os.Mkdir(hulakDir, utils.DirPer); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := []vault.RecipientEntry{
+		{Key: vaultIdentity.Recipient().String(), Name: "test"},
+	}
+	if err := vault.SaveRecipients(entries); err != nil {
+		t.Fatal(err)
+	}
+	recipients, err := vault.RecipientsFromEntries(entries)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &vault.Store{Envs: map[string]vault.Env{"global": {"K": "v"}}}
+	if err := vault.WriteStore(store, recipients...); err != nil {
+		t.Fatal(err)
+	}
+	return tmpDir
+}
+
+func writeKeyFile(t *testing.T, dir string, identity *age.X25519Identity) string {
+	t.Helper()
+	keyPath := filepath.Join(dir, "candidate-key.txt")
+	if err := os.WriteFile(keyPath, []byte(identity.String()+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return keyPath
+}
+
+func TestRunImportKey(t *testing.T) {
+	t.Run("rejects key that is not a vault recipient", func(t *testing.T) {
+		recipientID, _ := age.GenerateX25519Identity()
+		dir := setupImportKeyTest(t, true, recipientID)
+
+		// Candidate is a DIFFERENT identity — not a recipient
+		otherID, _ := age.GenerateX25519Identity()
+		keyPath := writeKeyFile(t, dir, otherID)
+
+		err := runImportKey([]string{keyPath}, false, false, "")
+		if err == nil {
+			t.Fatal("expected error when importing non-recipient key")
+		}
+		if !strings.Contains(err.Error(), "not a recipient") {
+			t.Errorf("error should mention 'not a recipient': %v", err)
+		}
+		if !strings.Contains(err.Error(), "add-recipient") {
+			t.Errorf("error should point at add-recipient: %v", err)
+		}
+
+		// Identity file should NOT exist (rejected before write)
+		if vault.IdentityExists() {
+			t.Error("identity.txt should not exist after rejected import")
+		}
+	})
+
+	t.Run("accepts key that IS a vault recipient", func(t *testing.T) {
+		recipientID, _ := age.GenerateX25519Identity()
+		dir := setupImportKeyTest(t, true, recipientID)
+
+		// Candidate IS the recipient
+		keyPath := writeKeyFile(t, dir, recipientID)
+
+		if err := runImportKey([]string{keyPath}, false, false, ""); err != nil {
+			t.Fatalf("import should succeed: %v", err)
+		}
+
+		if !vault.IdentityExists() {
+			t.Error("identity.txt should exist after successful import")
+		}
+	})
+
+	t.Run("--name auto-registers a non-recipient key when SSH decrypts", func(t *testing.T) {
+		recipientID, _ := age.GenerateX25519Identity()
+		dir := setupImportKeyTest(t, true, recipientID)
+
+		// Point HULAK_SSH_IDENTITY at a key that's NOT the vault recipient —
+		// but write the vault with an SSH recipient instead so we can demo
+		// "another working identity unlocks the store while we register a
+		// new age key." Simpler: drop the existing recipient key into the
+		// identity.txt path temporarily so it serves as the decrypt path.
+		identityPath, _ := vault.IdentityPath()
+		if err := os.WriteFile(identityPath, []byte(recipientID.String()+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Remove(identityPath) })
+
+		// Candidate is a NEW age key, not yet a recipient.
+		newID, _ := age.GenerateX25519Identity()
+		keyPath := writeKeyFile(t, dir, newID)
+
+		// --name triggers auto-register: recipientID decrypts → store
+		// re-encrypted to include newID → identity.txt then overwritten
+		// with newID.
+		if err := runImportKey([]string{keyPath}, false, true, "alice-laptop"); err != nil {
+			t.Fatalf("--name auto-register should succeed: %v", err)
+		}
+
+		// recipients.txt should now contain newID's pubkey
+		recipPath, _ := vault.RecipientsFilePath()
+		data, _ := os.ReadFile(recipPath)
+		if !strings.Contains(string(data), newID.Recipient().String()) {
+			t.Errorf("recipients.txt should contain new pubkey: %s", string(data))
+		}
+		// And the new identity should now decrypt the store directly.
+		if _, err := vault.ReadStore(); err != nil {
+			t.Errorf("store should decrypt after auto-register: %v", err)
+		}
+	})
+
+	t.Run("corrupt store.age is not misreported as 'not a recipient'", func(t *testing.T) {
+		recipientID, _ := age.GenerateX25519Identity()
+		dir := setupImportKeyTest(t, true, recipientID)
+
+		// Corrupt the store: overwrite with garbage. Decryption will fail
+		// with a parse/format error, NOT "no identity matched."
+		storePath, _ := vault.StorePath()
+		if err := os.WriteFile(storePath, []byte("not an age file"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		// Candidate is the legitimate recipient. Pre-fix this would have
+		// reported "not a recipient" misleadingly.
+		keyPath := writeKeyFile(t, dir, recipientID)
+
+		err := runImportKey([]string{keyPath}, false, false, "")
+		if err == nil {
+			t.Fatal("expected error on corrupt store")
+		}
+		if strings.Contains(err.Error(), "not a recipient") {
+			t.Errorf("error should not say 'not a recipient' for a corrupt store: %v", err)
+		}
+		if !strings.Contains(err.Error(), "corrupt") {
+			t.Errorf("error should indicate corruption: %v", err)
+		}
+	})
+
+	t.Run("no vault in cwd → no validation (pre-clone staging)", func(t *testing.T) {
+		dir := setupImportKeyTest(t, false, nil)
+
+		// No vault in cwd — validation should be skipped
+		otherID, _ := age.GenerateX25519Identity()
+		keyPath := writeKeyFile(t, dir, otherID)
+
+		if err := runImportKey([]string{keyPath}, false, false, ""); err != nil {
+			t.Fatalf("import should succeed when no vault present: %v", err)
+		}
+
+		if !vault.IdentityExists() {
+			t.Error("identity.txt should exist after pre-vault import")
+		}
+	})
+}

--- a/pkg/userFlags/env_list.go
+++ b/pkg/userFlags/env_list.go
@@ -45,12 +45,7 @@ func runEnvList(args []string) error {
 		return err
 	}
 
-	identity, err := vault.ResolveIdentity()
-	if err != nil {
-		return fmt.Errorf("failed to load identity: %w", err)
-	}
-
-	store, err := vault.ReadStore(identity)
+	store, err := vault.ReadStore()
 	if err != nil {
 		return err
 	}
@@ -117,12 +112,7 @@ func runEnvKeys(args []string, envName, search string, show bool) error {
 		return err
 	}
 
-	identity, err := vault.ResolveIdentity()
-	if err != nil {
-		return fmt.Errorf("failed to load identity: %w", err)
-	}
-
-	store, err := vault.ReadStore(identity)
+	store, err := vault.ReadStore()
 	if err != nil {
 		return err
 	}

--- a/pkg/userFlags/env_list_identity.go
+++ b/pkg/userFlags/env_list_identity.go
@@ -1,0 +1,118 @@
+// Contains command factory and handler for hulak secrets list-identity.
+package userflags
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
+)
+
+// newEnvListIdentityCmd returns the command struct for `hulak secrets list-identity`.
+//
+// Surfaces which identities on this machine can actually decrypt the current
+// vault — replacing the per-decrypt stderr noise of "Decrypted with X" with
+// an explicit user-driven inspection command. The first row is the default
+// (marked with utils.Asterisk): it's what hulak would use for any read path.
+func newEnvListIdentityCmd() *command {
+	return &command{
+		Name:    "list-identity",
+		Aliases: []string{"ls-identity", "identities"},
+		Short:   "List identities that can decrypt the vault",
+		Long: "Show every configured identity on this machine that can currently\n" +
+			"decrypt store.age. Probes each source in precedence order:\n\n" +
+			"  1. $HULAK_MASTER_KEY env var\n" +
+			"  2. ~/.config/hulak/identity.txt\n" +
+			"  3. $HULAK_SSH_IDENTITY env path\n" +
+			"  4. ~/.ssh/id_ed25519\n\n" +
+			"The first row that decrypts is the default (marked with " + utils.Asterisk + "): it's\n" +
+			"the identity hulak uses for read paths. NAME and ADDED come from\n" +
+			"recipients.txt when the pubkey matches an entry there.",
+		Examples: []*utils.CommandHelp{
+			{
+				Command:     "hulak secrets list-identity",
+				Description: "Show every decrypting identity on this machine",
+			},
+			{
+				Command:     "hulak secrets ls-identity",
+				Description: "Same (alias)",
+			},
+		},
+		Run: runListIdentity,
+	}
+}
+
+// runListIdentity handles `hulak secrets list-identity`.
+func runListIdentity(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("too many arguments: got %d, expected none", len(args))
+	}
+	if err := requireVaultProject(); err != nil {
+		return err
+	}
+
+	storePath, err := vault.StorePath()
+	if err != nil {
+		return err
+	}
+	cipherText, err := os.ReadFile(storePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return errors.New("no store.age found in this project")
+		}
+		return fmt.Errorf("failed to read store: %w", err)
+	}
+
+	hits := vault.SourcesThatDecrypt(cipherText)
+	if len(hits) == 0 {
+		return errors.New(
+			"no configured identity can decrypt store.age. " +
+				"Run 'hulak doctor' to inspect identity sources",
+		)
+	}
+
+	// Look up name + added-date per pubkey from recipients.txt.
+	nameByKey := loadRecipientNames()
+
+	rows := make([][]string, 0, len(hits))
+	for i, h := range hits {
+		marker := " "
+		if i == 0 {
+			marker = utils.Asterisk
+		}
+		name, added := vault.ParseRecipientName(nameByKey[h.PublicKey])
+		rows = append(rows, []string{marker, h.Path, h.PublicKey, name, added})
+	}
+
+	return utils.PrintTable(
+		os.Stdout,
+		utils.StdoutHeaders([]string{"", "PATH", "RECIPIENT", "NAME", "ADDED"}),
+		rows,
+		utils.DefaultTableMaxCellWidth,
+	)
+}
+
+// loadRecipientNames builds a pubkey → "Name (added DATE)" lookup from
+// recipients.txt. Returns an empty map on any read failure — list-identity
+// still has useful output without the join.
+func loadRecipientNames() map[string]string {
+	recipPath, err := vault.RecipientsFilePath()
+	if err != nil {
+		return nil
+	}
+	data, err := os.ReadFile(recipPath)
+	if err != nil {
+		return nil
+	}
+	entries, err := vault.ParseRecipientsFileContent(data)
+	if err != nil {
+		return nil
+	}
+	out := make(map[string]string, len(entries))
+	for _, e := range entries {
+		out[e.Key] = e.Name
+	}
+	return out
+}

--- a/pkg/userFlags/env_list_identity.go
+++ b/pkg/userFlags/env_list_identity.go
@@ -18,9 +18,8 @@ import (
 // (marked with utils.Asterisk): it's what hulak would use for any read path.
 func newEnvListIdentityCmd() *command {
 	return &command{
-		Name:    "list-identity",
-		Aliases: []string{"ls-identity", "identities"},
-		Short:   "List identities that can decrypt the vault",
+		Name:  "list-identity",
+		Short: "List identities that can decrypt the vault",
 		Long: "Show every configured identity on this machine that can currently\n" +
 			"decrypt store.age. Probes each source in precedence order:\n\n" +
 			"  1. $HULAK_MASTER_KEY env var\n" +

--- a/pkg/userFlags/env_list_identity_test.go
+++ b/pkg/userFlags/env_list_identity_test.go
@@ -1,0 +1,72 @@
+package userflags
+
+import (
+	"testing"
+
+	"filippo.io/age"
+
+	"github.com/xaaha/hulak/pkg/utils"
+	"github.com/xaaha/hulak/pkg/vault"
+)
+
+func TestRunListIdentity(t *testing.T) {
+	t.Run("requires a vault project", func(t *testing.T) {
+		// No vault setup → requireVaultProject should fail
+		t.Setenv("HULAK_MASTER_KEY", "")
+		t.Setenv("HULAK_SSH_IDENTITY", "")
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+		err := runListIdentity(nil)
+		if err == nil {
+			t.Fatal("expected error outside a vault project")
+		}
+	})
+
+	t.Run("rejects positional arguments", func(t *testing.T) {
+		err := runListIdentity([]string{"unexpected"})
+		if err == nil {
+			t.Fatal("expected error for unexpected argument")
+		}
+	})
+
+	t.Run("lists decrypting identity inside a vault", func(t *testing.T) {
+		// Build a vault encrypted to a known age identity, then verify
+		// list-identity finds it.
+		recipientID, _ := age.GenerateX25519Identity()
+		setupImportKeyTest(t, true, recipientID)
+
+		// Make identity.txt match the recipient so it decrypts
+		if err := vault.SetIdentity(recipientID.String()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := runListIdentity(nil); err != nil {
+			t.Fatalf("runListIdentity: %v", err)
+		}
+	})
+
+	t.Run("errors when no identity decrypts", func(t *testing.T) {
+		recipientID, _ := age.GenerateX25519Identity()
+		setupImportKeyTest(t, true, recipientID)
+
+		// Plant a stranger key — won't decrypt
+		stranger, _ := age.GenerateX25519Identity()
+		if err := vault.SetIdentity(stranger.String()); err != nil {
+			t.Fatal(err)
+		}
+
+		err := runListIdentity(nil)
+		if err == nil {
+			t.Fatal("expected error when no identity decrypts")
+		}
+	})
+}
+
+// sanity-check that the constant we use for the default marker is non-empty
+// so the table cell isn't accidentally blank when an identity is the default.
+func TestAsteriskMarkerNonEmpty(t *testing.T) {
+	if utils.Asterisk == "" {
+		t.Fatal("utils.Asterisk must be non-empty for the default-identity marker")
+	}
+}

--- a/pkg/userFlags/env_list_test.go
+++ b/pkg/userFlags/env_list_test.go
@@ -35,10 +35,10 @@ func TestRunEnvList_PrintsSortedNames(t *testing.T) {
 func TestRunEnvList_EmptyStore(t *testing.T) {
 	setupVaultProject(t)
 
-	// Generate a keypair + empty store so LoadIdentity / ReadStore succeed.
+	// Generate a keypair + empty store so ReadStore succeeds.
 	if err := vault.WithStoreLock(func() error {
 		ageKey, _ := vault.EnsureKeypair()
-		store, _ := vault.ReadStore(ageKey.Identity)
+		store, _ := vault.ReadStore()
 		return vault.WriteStore(store, ageKey.Recipient)
 	}); err != nil {
 		t.Fatalf("seed empty: %v", err)

--- a/pkg/userFlags/env_migrate.go
+++ b/pkg/userFlags/env_migrate.go
@@ -118,7 +118,7 @@ func bootstrapAge() (*bootstrapResult, error) {
 		return nil, err
 	}
 
-	store, err := vault.ReadStore(ageKey.Identity)
+	store, err := vault.DecryptStore(ageKey.Identity)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func bootstrapSSH(sshIdentityPath string) (*bootstrapResult, error) {
 		return nil, err
 	}
 
-	store, err := vault.ReadStore(identity)
+	store, err := vault.DecryptStore(identity)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/userFlags/env_migrate_test.go
+++ b/pkg/userFlags/env_migrate_test.go
@@ -83,7 +83,7 @@ func TestRunEnvMigrate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		store, err := vault.ReadStore(identity)
+		store, err := vault.DecryptStore(identity)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -108,7 +108,7 @@ func TestRunEnvMigrate(t *testing.T) {
 		}
 
 		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.ReadStore(identity)
+		store, _ := vault.DecryptStore(identity)
 
 		global := store.GetEnv("global")
 		if global["URL"] != "https://example.com" {
@@ -136,7 +136,7 @@ func TestRunEnvMigrate(t *testing.T) {
 		}
 
 		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.ReadStore(identity)
+		store, _ := vault.DecryptStore(identity)
 
 		prod := store.GetEnv("prod")
 		if prod["TOKEN"] != "from_store" {
@@ -157,7 +157,7 @@ func TestRunEnvMigrate(t *testing.T) {
 		}
 
 		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.ReadStore(identity)
+		store, _ := vault.DecryptStore(identity)
 
 		env := store.GetEnv("global")
 		if env["TOKEN"] != "$GITHUB_TOKEN" {
@@ -177,7 +177,7 @@ func TestRunEnvMigrate(t *testing.T) {
 		}
 
 		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.ReadStore(identity)
+		store, _ := vault.DecryptStore(identity)
 
 		envs := store.ListEnvs()
 		for _, name := range envs {
@@ -197,7 +197,7 @@ func TestRunEnvMigrate(t *testing.T) {
 		}
 
 		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.ReadStore(identity)
+		store, _ := vault.DecryptStore(identity)
 
 		staging := store.GetEnv("staging")
 		if staging == nil {
@@ -229,7 +229,7 @@ func TestRunEnvMigrate(t *testing.T) {
 		}
 
 		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.ReadStore(identity)
+		store, _ := vault.DecryptStore(identity)
 
 		staging := store.GetEnv("staging")
 		if staging == nil {
@@ -253,7 +253,7 @@ func TestRunEnvMigrate(t *testing.T) {
 		}
 
 		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.ReadStore(identity)
+		store, _ := vault.DecryptStore(identity)
 
 		env := store.GetEnv("global")
 		if env["NAME"] != "José" {

--- a/pkg/userFlags/env_migrate_test.go
+++ b/pkg/userFlags/env_migrate_test.go
@@ -79,11 +79,7 @@ func TestRunEnvMigrate(t *testing.T) {
 			t.Fatalf("runEnvMigrate error: %v", err)
 		}
 
-		identity, err := vault.ResolveIdentity()
-		if err != nil {
-			t.Fatal(err)
-		}
-		store, err := vault.DecryptStore(identity)
+		store, err := vault.ReadStore()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -107,8 +103,7 @@ func TestRunEnvMigrate(t *testing.T) {
 			t.Fatalf("runEnvMigrate error: %v", err)
 		}
 
-		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.DecryptStore(identity)
+		store, _ := vault.ReadStore()
 
 		global := store.GetEnv("global")
 		if global["URL"] != "https://example.com" {
@@ -135,8 +130,7 @@ func TestRunEnvMigrate(t *testing.T) {
 			t.Fatalf("runEnvMigrate error: %v", err)
 		}
 
-		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.DecryptStore(identity)
+		store, _ := vault.ReadStore()
 
 		prod := store.GetEnv("prod")
 		if prod["TOKEN"] != "from_store" {
@@ -156,8 +150,7 @@ func TestRunEnvMigrate(t *testing.T) {
 			t.Fatalf("runEnvMigrate error: %v", err)
 		}
 
-		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.DecryptStore(identity)
+		store, _ := vault.ReadStore()
 
 		env := store.GetEnv("global")
 		if env["TOKEN"] != "$GITHUB_TOKEN" {
@@ -176,8 +169,7 @@ func TestRunEnvMigrate(t *testing.T) {
 			t.Fatalf("runEnvMigrate error: %v", err)
 		}
 
-		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.DecryptStore(identity)
+		store, _ := vault.ReadStore()
 
 		envs := store.ListEnvs()
 		for _, name := range envs {
@@ -196,8 +188,7 @@ func TestRunEnvMigrate(t *testing.T) {
 			t.Fatalf("runEnvMigrate error: %v", err)
 		}
 
-		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.DecryptStore(identity)
+		store, _ := vault.ReadStore()
 
 		staging := store.GetEnv("staging")
 		if staging == nil {
@@ -228,8 +219,7 @@ func TestRunEnvMigrate(t *testing.T) {
 			t.Fatalf("runEnvMigrate error: %v", err)
 		}
 
-		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.DecryptStore(identity)
+		store, _ := vault.ReadStore()
 
 		staging := store.GetEnv("staging")
 		if staging == nil {
@@ -252,8 +242,7 @@ func TestRunEnvMigrate(t *testing.T) {
 			t.Fatalf("runEnvMigrate error: %v", err)
 		}
 
-		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.DecryptStore(identity)
+		store, _ := vault.ReadStore()
 
 		env := store.GetEnv("global")
 		if env["NAME"] != "José" {

--- a/pkg/userFlags/env_recipients.go
+++ b/pkg/userFlags/env_recipients.go
@@ -240,11 +240,7 @@ func runAddRecipient(
 		}
 
 		// Re-encrypt store to all recipients including new ones
-		identity, err := vault.ResolveIdentity()
-		if err != nil {
-			return fmt.Errorf("failed to load identity: %w", err)
-		}
-		store, err := vault.ReadStore(identity)
+		store, err := vault.ReadStore()
 		if err != nil {
 			return err
 		}
@@ -338,11 +334,7 @@ func runRemoveRecipient(args []string) error {
 		}
 
 		// Re-encrypt to remaining recipients
-		identity, err := vault.ResolveIdentity()
-		if err != nil {
-			return fmt.Errorf("failed to load identity: %w", err)
-		}
-		store, err := vault.ReadStore(identity)
+		store, err := vault.ReadStore()
 		if err != nil {
 			return err
 		}

--- a/pkg/userFlags/env_recipients.go
+++ b/pkg/userFlags/env_recipients.go
@@ -23,7 +23,7 @@ const (
 // newEnvAddRecipientCmd returns the "add-recipient" command with its flag set.
 func newEnvAddRecipientCmd() *command {
 	addRecipientFs := flag.NewFlagSet("env add-recipient", flag.ContinueOnError)
-	addRecipientName := addRecipientFs.String("name", "", "Human-readable label for the recipient")
+	addRecipientName := registerNameFlag(addRecipientFs, "Human-readable label for the recipient (defaults to OS username)")
 	addRecipientStdin := addRecipientFs.Bool("stdin", false, "Read keys from stdin (one per line)")
 	addRecipientGitHub := addRecipientFs.String(
 		"github",
@@ -215,11 +215,9 @@ func runAddRecipient(
 			return err
 		}
 
-		// Build recipient name with source info for GitHub fetches
-		recipientName := name
-		if gitHubUser != "" && name == "" {
-			recipientName = gitHubUser
-		}
+		// User-supplied label wins; otherwise fall back to the GitHub username
+		// when the keys came from a github fetch.
+		recipientName := resolveRecipientName(name, gitHubUser)
 
 		added := 0
 		for _, pubKey := range pubKeys {

--- a/pkg/userFlags/env_rotate_key.go
+++ b/pkg/userFlags/env_rotate_key.go
@@ -176,7 +176,8 @@ func swapRecipients(oldKey, newKey string) ([]vault.RecipientEntry, int, error) 
 func extractRecipientName(entries []vault.RecipientEntry, key string) string {
 	for _, e := range entries {
 		if e.Key == key {
-			return vault.ParseRecipientName(e.Name)
+			name, _ := vault.ParseRecipientName(e.Name)
+			return name
 		}
 	}
 	return ""
@@ -240,7 +241,7 @@ func printRotationSummary(rs *rotationState) {
 // If that fails and an identity.txt.old exists, tries the backup (interrupted
 // rotation recovery). Returns the store, whether we're in recovery mode, and error.
 func decryptForRotation(currentIdentity *age.X25519Identity) (*vault.Store, bool, error) {
-	store, err := vault.ReadStore(currentIdentity)
+	store, err := vault.DecryptStore(currentIdentity)
 	if err == nil {
 		return store, false, nil
 	}
@@ -253,7 +254,7 @@ func decryptForRotation(currentIdentity *age.X25519Identity) (*vault.Store, bool
 		)
 	}
 
-	store, err = vault.ReadStore(oldIdentity)
+	store, err = vault.DecryptStore(oldIdentity)
 	if err != nil {
 		return nil, false, fmt.Errorf(
 			"cannot decrypt store with current or backup identity — both keys failed",

--- a/pkg/userFlags/env_rotate_key_test.go
+++ b/pkg/userFlags/env_rotate_key_test.go
@@ -93,7 +93,7 @@ func TestRunRotateKey(t *testing.T) {
 			t.Error("identity should have changed")
 		}
 
-		store, err := vault.ReadStore(newIdentity)
+		store, err := vault.DecryptStore(newIdentity)
 		if err != nil {
 			t.Fatalf("new identity can't decrypt store: %v", err)
 		}
@@ -105,7 +105,7 @@ func TestRunRotateKey(t *testing.T) {
 		}
 
 		// Old identity cannot decrypt store
-		_, err = vault.ReadStore(oldID)
+		_, err = vault.DecryptStore(oldID)
 		if err == nil {
 			t.Error("old identity should NOT decrypt store after rotation")
 		}
@@ -142,7 +142,7 @@ func TestRunRotateKey(t *testing.T) {
 		}
 
 		// Teammate can still decrypt
-		store, err := vault.ReadStore(teammate)
+		store, err := vault.DecryptStore(teammate)
 		if err != nil {
 			t.Fatalf("teammate can't decrypt store after rotation: %v", err)
 		}
@@ -151,7 +151,7 @@ func TestRunRotateKey(t *testing.T) {
 		}
 
 		// Old identity cannot decrypt
-		_, err = vault.ReadStore(oldID)
+		_, err = vault.DecryptStore(oldID)
 		if err == nil {
 			t.Error("old identity should NOT decrypt store")
 		}
@@ -202,7 +202,7 @@ func TestRunRotateKey(t *testing.T) {
 		}
 
 		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.ReadStore(identity)
+		store, _ := vault.DecryptStore(identity)
 		prod := store.GetEnv("prod")
 
 		if prod["API_KEY"] != "sk-secret" {
@@ -262,7 +262,7 @@ func TestRunRotateKeyRecovery(t *testing.T) {
 
 		// After recovery: new identity decrypts store
 		finalIdentity, _ := vault.ResolveIdentity()
-		store, err := vault.ReadStore(finalIdentity)
+		store, err := vault.DecryptStore(finalIdentity)
 		if err != nil {
 			t.Fatalf("can't decrypt after recovery: %v", err)
 		}
@@ -271,7 +271,7 @@ func TestRunRotateKeyRecovery(t *testing.T) {
 		}
 
 		// Old identity no longer works
-		_, err = vault.ReadStore(oldID)
+		_, err = vault.DecryptStore(oldID)
 		if err == nil {
 			t.Error("old identity should not decrypt after recovery")
 		}

--- a/pkg/userFlags/env_rotate_key_test.go
+++ b/pkg/userFlags/env_rotate_key_test.go
@@ -201,8 +201,7 @@ func TestRunRotateKey(t *testing.T) {
 			t.Fatalf("runRotateKey error: %v", err)
 		}
 
-		identity, _ := vault.ResolveIdentity()
-		store, _ := vault.DecryptStore(identity)
+		store, _ := vault.ReadStore()
 		prod := store.GetEnv("prod")
 
 		if prod["API_KEY"] != "sk-secret" {
@@ -260,9 +259,8 @@ func TestRunRotateKeyRecovery(t *testing.T) {
 			t.Fatalf("recovery rotation error: %v", err)
 		}
 
-		// After recovery: new identity decrypts store
-		finalIdentity, _ := vault.ResolveIdentity()
-		store, err := vault.DecryptStore(finalIdentity)
+		// After recovery: vault decrypts via the auto-resolved new identity
+		store, err := vault.ReadStore()
 		if err != nil {
 			t.Fatalf("can't decrypt after recovery: %v", err)
 		}

--- a/pkg/userFlags/env_sync.go
+++ b/pkg/userFlags/env_sync.go
@@ -42,12 +42,7 @@ func runSync(args []string) error {
 	}
 
 	return vault.WithStoreLock(func() error {
-		identity, err := vault.ResolveIdentity()
-		if err != nil {
-			return fmt.Errorf("failed to load identity: %w", err)
-		}
-
-		store, err := vault.ReadStore(identity)
+		store, err := vault.ReadStore()
 		if err != nil {
 			return err
 		}

--- a/pkg/userFlags/env_test.go
+++ b/pkg/userFlags/env_test.go
@@ -52,11 +52,7 @@ func setupVaultProject(t *testing.T) string {
 // readStoredValue decrypts the store and returns the value at envName/key.
 func readStoredValue(t *testing.T, envName, key string) any {
 	t.Helper()
-	id, err := vault.LoadIdentity()
-	if err != nil {
-		t.Fatalf("LoadIdentity: %v", err)
-	}
-	store, err := vault.DecryptStore(id)
+	store, err := vault.ReadStore()
 	if err != nil {
 		t.Fatalf("ReadStore: %v", err)
 	}

--- a/pkg/userFlags/env_test.go
+++ b/pkg/userFlags/env_test.go
@@ -56,7 +56,7 @@ func readStoredValue(t *testing.T, envName, key string) any {
 	if err != nil {
 		t.Fatalf("LoadIdentity: %v", err)
 	}
-	store, err := vault.ReadStore(id)
+	store, err := vault.DecryptStore(id)
 	if err != nil {
 		t.Fatalf("ReadStore: %v", err)
 	}

--- a/pkg/userFlags/init.go
+++ b/pkg/userFlags/init.go
@@ -225,7 +225,9 @@ func printInitSummary(result *bootstrapResult) {
 		fmt.Sprintf("Initialized vault at %s/", utils.HiddenProjectName),
 	)
 	utils.PrintInfoStderr(fmt.Sprintf("  Public key:    %s", result.recipientKey))
-	utils.PrintInfoStderr(fmt.Sprintf("  Recipients:    %s/%s", utils.HiddenProjectName, utils.RecipientsFile))
+	utils.PrintInfoStderr(
+		fmt.Sprintf("  Recipients:    %s/%s", utils.HiddenProjectName, utils.RecipientsFile),
+	)
 	if result.isSSH {
 		utils.PrintInfoStderr(fmt.Sprintf("  SSH identity:  %s", result.identityDesc))
 		utils.PrintWarningStderr(

--- a/pkg/userFlags/init.go
+++ b/pkg/userFlags/init.go
@@ -146,12 +146,7 @@ func maybeAddSSHIdentity(sshIdentityPath string) (bool, error) {
 		return false, err
 	}
 
-	currentIdentity, err := vault.ResolveIdentity()
-	if err != nil {
-		return false, fmt.Errorf("failed to load identity: %w", err)
-	}
-
-	added, err := vault.AddRecipientAndReencrypt(pubKey, utils.Username(), currentIdentity)
+	added, err := vault.AddRecipientAndReencrypt(pubKey, utils.Username())
 	if err != nil {
 		return false, err
 	}
@@ -169,14 +164,10 @@ func maybeAddSSHIdentity(sshIdentityPath string) (bool, error) {
 // re-encryption. Uses GenerateKeyPair + SetIdentity directly (not EnsureKeypair)
 // because EnsureKeypair refuses when store.age exists.
 func maybeAddAgeIdentity() (bool, error) {
-	// Resolve current identity (SSH) BEFORE creating identity.txt.
-	// Once identity.txt exists, ResolveIdentity returns the new age key
-	// which can't decrypt the SSH-encrypted store.
-	currentIdentity, err := vault.ResolveIdentity()
-	if err != nil {
-		return false, fmt.Errorf("failed to load identity: %w", err)
-	}
-
+	// With ResolveIdentityFor's probing, the order of "write identity.txt"
+	// vs "decrypt with existing identity" doesn't matter: even if identity.txt
+	// exists with the new key (not yet a recipient), ResolveIdentityFor will
+	// fall through to SSH or whichever existing identity decrypts.
 	ageKey, err := vault.GenerateKeyPair()
 	if err != nil {
 		return false, fmt.Errorf("failed to generate age keypair: %w", err)
@@ -189,7 +180,7 @@ func maybeAddAgeIdentity() (bool, error) {
 	pubKey := ageKey.Recipient.String()
 	identityPath, _ := vault.IdentityPath()
 
-	added, err := vault.AddRecipientAndReencrypt(pubKey, utils.Username(), currentIdentity)
+	added, err := vault.AddRecipientAndReencrypt(pubKey, utils.Username())
 	if err != nil {
 		return false, err
 	}
@@ -212,11 +203,7 @@ func ensureExtraEnvSections(envNames []string) error {
 		return nil
 	}
 
-	identity, err := vault.ResolveIdentity()
-	if err != nil {
-		return fmt.Errorf("failed to load identity: %w", err)
-	}
-	store, err := vault.ReadStore(identity)
+	store, err := vault.ReadStore()
 	if err != nil {
 		return err
 	}

--- a/pkg/userFlags/init_test.go
+++ b/pkg/userFlags/init_test.go
@@ -31,11 +31,7 @@ func vaultTestSetup(t *testing.T) string {
 // current working directory. Tests use this to assert post-init state.
 func readVaultStore(t *testing.T) *vault.Store {
 	t.Helper()
-	identity, err := vault.LoadIdentity()
-	if err != nil {
-		t.Fatalf("LoadIdentity: %v", err)
-	}
-	store, err := vault.ReadStore(identity)
+	store, err := vault.ReadStore()
 	if err != nil {
 		t.Fatalf("ReadStore: %v", err)
 	}
@@ -161,7 +157,7 @@ func TestInitVaultProject_Idempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadIdentity: %v", err)
 	}
-	store, err := vault.ReadStore(identity)
+	store, err := vault.DecryptStore(identity)
 	if err != nil {
 		t.Fatalf("ReadStore: %v", err)
 	}
@@ -357,7 +353,7 @@ func TestInitVaultProject_SSHIdentity_FreshSetup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSSHIdentity: %v", err)
 	}
-	store, err := vault.ReadStore(identity)
+	store, err := vault.DecryptStore(identity)
 	if err != nil {
 		t.Fatalf("ReadStore: %v", err)
 	}
@@ -424,7 +420,7 @@ func TestInitVaultProject_AgeInitThenAddSSH(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSSHIdentity: %v", err)
 	}
-	if _, err := vault.ReadStore(sshIdentity); err != nil {
+	if _, err := vault.DecryptStore(sshIdentity); err != nil {
 		t.Fatalf("store should decrypt with SSH: %v", err)
 	}
 }
@@ -474,7 +470,7 @@ func TestInitVaultProject_SSHInitThenAddAge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadIdentity: %v", err)
 	}
-	if _, err := vault.ReadStore(ageIdentity); err != nil {
+	if _, err := vault.DecryptStore(ageIdentity); err != nil {
 		t.Fatalf("store should decrypt with age: %v", err)
 	}
 }
@@ -496,7 +492,7 @@ func TestInitVaultProject_SSHIdentity_WithEnvNames(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSSHIdentity: %v", err)
 	}
-	store, err := vault.ReadStore(identity)
+	store, err := vault.DecryptStore(identity)
 	if err != nil {
 		t.Fatalf("ReadStore: %v", err)
 	}

--- a/pkg/userFlags/name_flag.go
+++ b/pkg/userFlags/name_flag.go
@@ -1,0 +1,33 @@
+package userflags
+
+import (
+	"flag"
+	"strings"
+)
+
+// registerNameFlag binds --name on fs to a single underlying string. Returns
+// a pointer so the handler reads the parsed value after flag.Parse. Pair with
+// resolveRecipientName at call time to keep "user-supplied name, else OS
+// username" semantics consistent across every command that labels a recipient.
+func registerNameFlag(fs *flag.FlagSet, usage string) *string {
+	var name string
+	fs.StringVar(&name, "name", "", usage)
+	return &name
+}
+
+// resolveRecipientName returns the first non-empty value in order, treating
+// whitespace-only strings as empty. Use to centralize the "user-supplied
+// name, else a sensible default" rule that varies by command:
+//
+//	gen-identity / import-key: resolveRecipientName(*name, utils.Username())
+//	add-recipient:             resolveRecipientName(*name, gitHubUser)
+//
+// Returns "" only if every value is empty.
+func resolveRecipientName(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -483,6 +483,7 @@ func newEnvCmd() *command {
 		newEnvImportKeyCmd(),
 		newEnvExportKeyCmd(),
 		newEnvGenIdentityCmd(),
+		newEnvListIdentityCmd(),
 		newEnvAddRecipientCmd(),
 		newEnvRemoveRecipientCmd(),
 		newEnvListRecipientsCmd(),

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -482,6 +482,7 @@ func newEnvCmd() *command {
 		newEnvEditCmd(),
 		newEnvImportKeyCmd(),
 		newEnvExportKeyCmd(),
+		newEnvGenIdentityCmd(),
 		newEnvAddRecipientCmd(),
 		newEnvRemoveRecipientCmd(),
 		newEnvListRecipientsCmd(),

--- a/pkg/vault/identity_import.go
+++ b/pkg/vault/identity_import.go
@@ -1,0 +1,101 @@
+package vault
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"filippo.io/age"
+
+	"github.com/xaaha/hulak/pkg/utils"
+)
+
+// Contains import/export of age key material. Read/write of the identity.txt
+// file itself lives in keys.go; this file is the user-facing CLI surface for
+// moving keys in and out of hulak.
+
+// ExportKey reads the identity file and returns the raw private key string.
+// Returns a friendly error pointing to `hulak init` if no identity exists.
+func ExportKey() (string, error) {
+	raw, err := GetIdentity()
+	if err != nil {
+		return "", fmt.Errorf(
+			"no identity file found — run 'hulak init' to create one: %w", err,
+		)
+	}
+	return strings.TrimSpace(raw), nil
+}
+
+// ParseImportKey extracts and parses an age private key from raw import
+// material (file contents or stdin). The raw input may be multi-line with
+// comments — only the first non-empty, non-comment line is parsed.
+//
+// Used by import-key handlers that want to validate a candidate key before
+// committing it (e.g. decrypt-test against a local store.age). Returns the
+// parsed identity for further use; the caller decides whether to persist.
+func ParseImportKey(raw string) (*age.X25519Identity, error) {
+	key := extractKeyLine(raw)
+	if key == "" {
+		return nil, fmt.Errorf("no age private key found in input")
+	}
+	id, err := age.ParseX25519Identity(key)
+	if err != nil {
+		return nil, fmt.Errorf("invalid age private key: %w", err)
+	}
+	return id, nil
+}
+
+// ImportKey validates the raw key material, normalizes whitespace, and writes
+// it to the identity file atomically (tmp + rename). Refuses to overwrite an
+// existing identity unless force is true.
+//
+// The raw input may be multi-line (e.g. age-keygen output with comments).
+// Only the first non-empty, non-comment line is used as the key.
+//
+// Refuses to run if HULAK_MASTER_KEY is set — importing while the env var
+// shadows the on-disk identity makes the import dead-on-arrival.
+func ImportKey(raw string, force bool) error {
+	if os.Getenv(utils.MasterKey) != "" {
+		return fmt.Errorf(
+			"%s is set — unset it before importing an identity, "+
+				"otherwise the env var shadows the on-disk file",
+			utils.MasterKey,
+		)
+	}
+
+	id, err := ParseImportKey(raw)
+	if err != nil {
+		return err
+	}
+
+	identityPath, err := IdentityPath()
+	if err != nil {
+		return err
+	}
+
+	if !force && utils.FileExists(identityPath) {
+		return fmt.Errorf(
+			"identity already exists at %s — use --force to overwrite", identityPath,
+		)
+	}
+
+	return utils.AtomicWriteFile(
+		identityPath,
+		[]byte(id.String()+"\n"),
+		utils.SecretPer,
+		utils.SecretDirPer,
+	)
+}
+
+// extractKeyLine returns the first non-empty, non-comment line from raw input.
+// Handles age-keygen output where comments (# lines) precede the key.
+func extractKeyLine(raw string) string {
+	for line := range strings.SplitSeq(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		return line
+	}
+	return ""
+}

--- a/pkg/vault/identity_resolve.go
+++ b/pkg/vault/identity_resolve.go
@@ -1,0 +1,298 @@
+package vault
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"filippo.io/age"
+
+	"github.com/xaaha/hulak/pkg/utils"
+)
+
+// Contains the multi-source identity probe: gathering every configured
+// identity (master-key env, identity.txt, SSH env, default SSH key), resolving
+// which one to use for read/write paths, and the error helpers that go with
+// those flows. Identity file CRUD lives in keys.go; this file is policy.
+
+// sourceKind discriminates configured identity sources so callers can apply
+// policy (e.g. hard-fail on broken explicit config, silent fall-through on
+// auto-detected sources) without string-matching on labels.
+type sourceKind int
+
+const (
+	sourceMasterKey    sourceKind = iota // $HULAK_MASTER_KEY (strict, no fallback)
+	sourceIdentityFile                   // identity.txt on disk
+	sourceSSHEnv                         // $HULAK_SSH_IDENTITY
+	sourceSSHDefault                     // auto-detected ~/.ssh/id_ed25519
+)
+
+// identitySource describes one configured identity. Powers every "what
+// identities does this machine have?" query (probe loop, list-identity,
+// doctor). loadErr is set when the source is configured but failed to parse;
+// callers decide whether to hard-fail or skip past it based on kind.
+type identitySource struct {
+	kind      sourceKind
+	label     string       // human-readable diagnostic label
+	path      string       // file path or "$ENV_VAR" — for list-identity PATH column
+	identity  age.Identity // nil when loadErr is set
+	publicKey string       // derived pubkey: "age1..." or "ssh-ed25519 AAA..."
+	loadErr   error
+}
+
+// gatherSources collects every configured identity in precedence order.
+// includeMaster gates HULAK_MASTER_KEY: include it for inspection (list-
+// identity, SourcesThatDecrypt); omit it when callers handle master-key's
+// strict short-circuit semantics before calling (ResolveIdentity, resolveAndDecrypt).
+func gatherSources(includeMaster bool) []identitySource {
+	var sources []identitySource
+
+	if includeMaster {
+		if raw := strings.TrimSpace(os.Getenv(utils.MasterKey)); raw != "" {
+			if id, err := parseMasterKey(raw); err == nil {
+				sources = append(sources, identitySource{
+					kind:      sourceMasterKey,
+					label:     "$" + utils.MasterKey,
+					path:      "$" + utils.MasterKey,
+					identity:  id,
+					publicKey: id.Recipient().String(),
+				})
+			}
+		}
+	}
+
+	if IdentityExists() {
+		idPath, _ := IdentityPath()
+		id, err := LoadIdentity()
+		s := identitySource{
+			kind:     sourceIdentityFile,
+			label:    "identity.txt",
+			path:     idPath,
+			identity: id,
+			loadErr:  err,
+		}
+		if err == nil {
+			s.publicKey = id.Recipient().String()
+		}
+		sources = append(sources, s)
+	}
+
+	if sshPath := strings.TrimSpace(os.Getenv(utils.SSHIdentityEnvVar)); sshPath != "" {
+		id, pub, err := LoadSSHIdentityWithPubKey(sshPath)
+		sources = append(sources, identitySource{
+			kind:      sourceSSHEnv,
+			label:     fmt.Sprintf("$%s (%s)", utils.SSHIdentityEnvVar, sshPath),
+			path:      sshPath,
+			identity:  id,
+			publicKey: pub,
+			loadErr:   err,
+		})
+	}
+
+	if defaultPath := DefaultSSHIdentityPath(); defaultPath != "" && utils.FileExists(defaultPath) {
+		id, pub, err := LoadSSHIdentityWithPubKey(defaultPath)
+		sources = append(sources, identitySource{
+			kind:      sourceSSHDefault,
+			label:     defaultPath,
+			path:      defaultPath,
+			identity:  id,
+			publicKey: pub,
+			loadErr:   err,
+		})
+	}
+
+	return sources
+}
+
+// ResolveIdentity returns the identity to use for decryption (no ciphertext
+// to probe against). Used by write paths and rotate-key flows that need an
+// identity before any decrypt attempt.
+//
+// Precedence: HULAK_MASTER_KEY → identity.txt → HULAK_SSH_IDENTITY → ~/.ssh/id_ed25519.
+//
+// Strict-fail on explicit config (identity.txt present-but-broken, or
+// $HULAK_SSH_IDENTITY set-but-unloadable). Silent fall-through on the
+// auto-detected ~/.ssh/id_ed25519 default.
+func ResolveIdentity() (age.Identity, error) {
+	if raw := strings.TrimSpace(os.Getenv(utils.MasterKey)); raw != "" {
+		return parseMasterKey(raw)
+	}
+
+	for _, s := range gatherSources(false) {
+		if s.loadErr == nil {
+			switch s.kind {
+			case sourceSSHEnv:
+				utils.PrintInfoStderr(fmt.Sprintf("Using SSH identity %s", s.path))
+			case sourceSSHDefault:
+				utils.PrintInfoStderr(fmt.Sprintf("Using SSH identity %s (no identity.txt found)", s.path))
+			}
+			return s.identity, nil
+		}
+		switch s.kind {
+		case sourceIdentityFile:
+			return nil, s.loadErr
+		case sourceSSHEnv:
+			return nil, fmt.Errorf("%s is set but key could not be loaded: %w", utils.SSHIdentityEnvVar, s.loadErr)
+		}
+		// sourceSSHDefault load failure: silently fall through.
+	}
+	return nil, noIdentityError()
+}
+
+// HasAnyIdentity reports whether at least one usable identity source exists
+// (master key env, parseable identity.txt, or loadable SSH key). Configured-
+// but-broken sources don't count — they can't actually decrypt anything.
+func HasAnyIdentity() bool {
+	if strings.TrimSpace(os.Getenv(utils.MasterKey)) != "" {
+		return true
+	}
+	for _, s := range gatherSources(false) {
+		if s.loadErr == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// DecryptingIdentity describes one identity source that successfully
+// decrypts a given ciphertext. Returned by SourcesThatDecrypt for the
+// `secrets list-identity` subcommand.
+type DecryptingIdentity struct {
+	Path      string // file path or "$ENV_VAR"
+	PublicKey string // "age1..." or "ssh-ed25519 AAA..."
+}
+
+// SourcesThatDecrypt returns every configured identity source that can
+// decrypt the given ciphertext, in precedence order. The first element is
+// the "default" — the identity hulak would actually use for read paths.
+func SourcesThatDecrypt(ciphertext []byte) []DecryptingIdentity {
+	var hits []DecryptingIdentity
+	for _, s := range gatherSources(true) {
+		if s.loadErr != nil {
+			continue
+		}
+		if _, err := DecryptText(ciphertext, s.identity); err == nil {
+			hits = append(hits, DecryptingIdentity{Path: s.path, PublicKey: s.publicKey})
+		}
+	}
+	return hits
+}
+
+// resolveAndDecrypt is the single-pass identity resolver used by all read
+// paths. Probes each source against ciphertext and returns both the matching
+// identity and the decrypted plaintext — avoiding the double-decrypt of
+// "resolve, then re-decrypt." Same precedence as ResolveIdentityFor;
+// HULAK_MASTER_KEY short-circuits with strict semantics.
+func resolveAndDecrypt(ciphertext []byte) (age.Identity, []byte, error) {
+	if raw := strings.TrimSpace(os.Getenv(utils.MasterKey)); raw != "" {
+		id, err := parseMasterKey(raw)
+		if err != nil {
+			return nil, nil, err
+		}
+		plain, err := DecryptText(ciphertext, id)
+		if err != nil {
+			return nil, nil, WrapDecryptError(fmt.Errorf("failed to decrypt store: %w", err))
+		}
+		return id, plain, nil
+	}
+
+	sources := gatherSources(false)
+	if len(sources) == 0 {
+		return nil, nil, noIdentityError()
+	}
+
+	tried := make([]string, 0, len(sources))
+	for _, s := range sources {
+		if s.loadErr != nil {
+			tried = append(tried, fmt.Sprintf("%s [load failed: %v]", s.label, s.loadErr))
+			continue
+		}
+		plain, err := DecryptText(ciphertext, s.identity)
+		if err == nil {
+			return s.identity, plain, nil
+		}
+		tried = append(tried, s.label)
+	}
+
+	return nil, nil, fmt.Errorf(
+		"no available identity could decrypt the store. Tried: %s.\n"+
+			"If you should have access, ask a current vault member to add your public key:\n"+
+			"  hulak secrets add-recipient <your-pubkey>",
+		strings.Join(tried, ", "),
+	)
+}
+
+// ResolveIdentityFor returns the first identity (across all configured sources)
+// that can decrypt the given ciphertext. Convenience wrapper around
+// resolveAndDecrypt for callers that only need the identity (e.g. import-key
+// validation). Read paths should use ReadStore instead — it composes
+// resolveAndDecrypt with JSON decoding in a single pass.
+//
+// Precedence:
+//
+//  1. HULAK_MASTER_KEY env var — strict, no fallback
+//  2. identity.txt (if present)
+//  3. $HULAK_SSH_IDENTITY (if set)
+//  4. ~/.ssh/id_ed25519 (auto-detected)
+//
+// On failure, enumerates every source that was tried, including configured-
+// but-broken ones (e.g. HULAK_SSH_IDENTITY pointing at a missing file).
+func ResolveIdentityFor(ciphertext []byte) (age.Identity, error) {
+	id, _, err := resolveAndDecrypt(ciphertext)
+	return id, err
+}
+
+// noIdentityError returns a helpful error when no identity could be resolved.
+func noIdentityError() error {
+	return utils.HelpfulError(
+		"no identity found — cannot decrypt the vault",
+		"Set up an identity using one of these methods",
+		[]string{
+			"Run 'hulak init' to generate an age keypair",
+			"Import an existing key with 'hulak secrets import-key'",
+			fmt.Sprintf("Set %s to an AGE-SECRET-KEY- value (for CI)", utils.MasterKey),
+			fmt.Sprintf("Set %s to point at your SSH private key", utils.SSHIdentityEnvVar),
+			"Place an ed25519 SSH key at ~/.ssh/id_ed25519 (auto-detected)",
+		},
+	)
+}
+
+// parseMasterKey parses the HULAK_MASTER_KEY value with friendly errors.
+func parseMasterKey(raw string) (*age.X25519Identity, error) {
+	identity, err := age.ParseX25519Identity(raw)
+	if err != nil {
+		if strings.HasPrefix(raw, AgePrefix) {
+			return nil, fmt.Errorf(
+				"%s contains what looks like a public key (age1...), not a private key. "+
+					"Private keys start with AGE-SECRET-KEY-",
+				utils.MasterKey,
+			)
+		}
+		return nil, fmt.Errorf(
+			"%s is set but could not be parsed as an age private key: %w\n"+
+				"Expected format: AGE-SECRET-KEY-1... ",
+			utils.MasterKey, err,
+		)
+	}
+	return identity, nil
+}
+
+// WrapDecryptError checks if HULAK_MASTER_KEY is set and the error looks like
+// an age "recipient mismatch" failure. If so, wraps it with actionable hints.
+// Otherwise returns the original error unchanged.
+func WrapDecryptError(err error) error {
+	if os.Getenv(utils.MasterKey) == "" {
+		return err
+	}
+	if !strings.Contains(err.Error(), "did not match any of the recipients") {
+		return err
+	}
+	return fmt.Errorf(
+		"failed to decrypt store: %s is set but does not match any recipient in this project.\n"+
+			"Common causes:\n"+
+			"  - This key is for a different project\n"+
+			"  - You were removed as a recipient\n"+
+			"  - Stale whitespace or quotes from copy-paste",
+		utils.MasterKey,
+	)
+}

--- a/pkg/vault/keys.go
+++ b/pkg/vault/keys.go
@@ -11,7 +11,10 @@ import (
 	"github.com/xaaha/hulak/pkg/utils"
 )
 
-// Contains everythig about public and private keys (identity)
+// Contains on-disk identity file CRUD: path resolution, load/save/delete of
+// identity.txt, plus the .old backup machinery used by rotate-key for crash
+// recovery. The multi-source probe (env vars, SSH fallbacks, precedence
+// rules) lives in identity_resolve.go; import/export lives in identity_import.go.
 
 // IdentityPath returns the absolute path to the user's age identity file
 // under the platform config dir (~/.config/hulak/identity.txt on Linux,
@@ -76,41 +79,13 @@ func SetIdentity(privateKey string) error {
 	return os.WriteFile(identityFilePath, []byte(privateKey+"\n"), utils.SecretPer)
 }
 
-// VerifyKeypair parses the raw private and public key strings, and verifies
-// that the private key derives the same public key. Returns the parsed AgeKey.
-func VerifyKeypair(rawPrivateKey, rawPublicKey string) (AgeKey, error) {
-	identity, err := age.ParseX25519Identity(strings.TrimSpace(rawPrivateKey))
-	if err != nil {
-		return AgeKey{}, fmt.Errorf("failed to parse identity: %w", err)
-	}
-
-	recipient, err := age.ParseX25519Recipient(strings.TrimSpace(rawPublicKey))
-	if err != nil {
-		return AgeKey{}, fmt.Errorf("failed to parse public key: %w", err)
-	}
-
-	derived := identity.Recipient()
-	if derived.String() != recipient.String() {
-		return AgeKey{}, fmt.Errorf("keypair mismatch: identity does not match public key")
-	}
-
-	return AgeKey{
-		Recipient: recipient,
-		Identity:  identity,
-	}, nil
-}
-
 // DeleteIdentity removes the identity file from the global config directory.
 func DeleteIdentity() error {
 	identityFilePath, err := IdentityPath()
 	if err != nil {
 		return err
 	}
-	err = os.Remove(identityFilePath)
-	if err != nil {
-		return err
-	}
-	return nil
+	return os.Remove(identityFilePath)
 }
 
 // IdentityOldPath returns the path to the backup identity file
@@ -157,169 +132,4 @@ func LoadIdentityOld() (*age.X25519Identity, error) {
 		return nil, fmt.Errorf("failed to parse backup identity: %w", err)
 	}
 	return identity, nil
-}
-
-// ResolveIdentity returns the identity to use for decryption.
-// Precedence: HULAK_MASTER_KEY → identity.txt → HULAK_SSH_IDENTITY → ~/.ssh/id_ed25519.
-// Returns age.Identity (interface) — callers should not assume X25519.
-func ResolveIdentity() (age.Identity, error) {
-	// 1. HULAK_MASTER_KEY (highest precedence)
-	if raw := strings.TrimSpace(os.Getenv(utils.MasterKey)); raw != "" {
-		return parseMasterKey(raw)
-	}
-
-	// 2. identity.txt
-	if IdentityExists() {
-		return LoadIdentity()
-	}
-
-	// 3. HULAK_SSH_IDENTITY env var
-	if sshPath := strings.TrimSpace(os.Getenv(utils.SSHIdentityEnvVar)); sshPath != "" {
-		identity, err := LoadSSHIdentity(sshPath)
-		if err != nil {
-			return nil, fmt.Errorf("%s is set but key could not be loaded: %w", utils.SSHIdentityEnvVar, err)
-		}
-		utils.PrintInfoStderr(fmt.Sprintf("Using SSH identity %s", sshPath))
-		return identity, nil
-	}
-
-	// 4. Default ~/.ssh/id_ed25519
-	defaultPath := DefaultSSHIdentityPath()
-	if defaultPath != "" && utils.FileExists(defaultPath) {
-		identity, err := LoadSSHIdentity(defaultPath)
-		if err == nil {
-			utils.PrintInfoStderr(fmt.Sprintf("Using SSH identity %s (no identity.txt found)", defaultPath))
-			return identity, nil
-		}
-		// Don't error on auto-fallback failure — fall through to helpful error
-	}
-
-	// 5. Nothing found
-	return nil, noIdentityError()
-}
-
-// noIdentityError returns a helpful error when no identity could be resolved.
-func noIdentityError() error {
-	return utils.HelpfulError(
-		"no identity found — cannot decrypt the vault",
-		"Set up an identity using one of these methods",
-		[]string{
-			"Run 'hulak init' to generate an age keypair",
-			"Import an existing key with 'hulak secrets import-key'",
-			fmt.Sprintf("Set %s to an AGE-SECRET-KEY- value (for CI)", utils.MasterKey),
-			fmt.Sprintf("Set %s to point at your SSH private key", utils.SSHIdentityEnvVar),
-			"Place an ed25519 SSH key at ~/.ssh/id_ed25519 (auto-detected)",
-		},
-	)
-}
-
-// parseMasterKey parses the HULAK_MASTER_KEY value with friendly errors.
-func parseMasterKey(raw string) (*age.X25519Identity, error) {
-	identity, err := age.ParseX25519Identity(raw)
-	if err != nil {
-		if strings.HasPrefix(raw, AgePrefix) {
-			return nil, fmt.Errorf(
-				"%s contains what looks like a public key (age1...), not a private key. "+
-					"Private keys start with AGE-SECRET-KEY-",
-				utils.MasterKey,
-			)
-		}
-		return nil, fmt.Errorf(
-			"%s is set but could not be parsed as an age private key: %w\n"+
-				"Expected format: AGE-SECRET-KEY-1... ",
-			utils.MasterKey, err,
-		)
-	}
-	return identity, nil
-}
-
-// WrapDecryptError checks if HULAK_MASTER_KEY is set and the error looks like
-// an age "no identity matched" failure. If so, wraps it with actionable hints.
-// Otherwise returns the original error unchanged.
-func WrapDecryptError(err error) error {
-	if os.Getenv(utils.MasterKey) == "" {
-		return err
-	}
-	if !strings.Contains(err.Error(), "no identity matched") {
-		return err
-	}
-	return fmt.Errorf(
-		"failed to decrypt store: %s is set but does not match any recipient in this project.\n"+
-			"Common causes:\n"+
-			"  - This key is for a different project\n"+
-			"  - You were removed as a recipient\n"+
-			"  - Stale whitespace or quotes from copy-paste",
-		utils.MasterKey,
-	)
-}
-
-// ExportKey reads the identity file and returns the raw private key string.
-// Returns a friendly error pointing to `hulak init` if no identity exists.
-func ExportKey() (string, error) {
-	raw, err := GetIdentity()
-	if err != nil {
-		return "", fmt.Errorf(
-			"no identity file found — run 'hulak init' to create one: %w", err,
-		)
-	}
-	return strings.TrimSpace(raw), nil
-}
-
-// ImportKey validates the raw key material, normalizes whitespace, and writes
-// it to the identity file atomically (tmp + rename). Refuses to overwrite an
-// existing identity unless force is true.
-//
-// The raw input may be multi-line (e.g. age-keygen output with comments).
-// Only the first non-empty, non-comment line is used as the key.
-//
-// Refuses to run if HULAK_MASTER_KEY is set — importing while the env var
-// shadows the on-disk identity makes the import dead-on-arrival.
-func ImportKey(raw string, force bool) error {
-	if os.Getenv(utils.MasterKey) != "" {
-		return fmt.Errorf(
-			"%s is set — unset it before importing an identity, "+
-				"otherwise the env var shadows the on-disk file",
-			utils.MasterKey,
-		)
-	}
-
-	key := extractKeyLine(raw)
-	if key == "" {
-		return fmt.Errorf("no age private key found in input")
-	}
-
-	if _, err := age.ParseX25519Identity(key); err != nil {
-		return fmt.Errorf("invalid age private key: %w", err)
-	}
-
-	identityPath, err := IdentityPath()
-	if err != nil {
-		return err
-	}
-
-	if !force && utils.FileExists(identityPath) {
-		return fmt.Errorf(
-			"identity already exists at %s — use --force to overwrite", identityPath,
-		)
-	}
-
-	return utils.AtomicWriteFile(
-		identityPath,
-		[]byte(key+"\n"),
-		utils.SecretPer,
-		utils.SecretDirPer,
-	)
-}
-
-// extractKeyLine returns the first non-empty, non-comment line from raw input.
-// Handles age-keygen output where comments (# lines) precede the key.
-func extractKeyLine(raw string) string {
-	for line := range strings.SplitSeq(raw, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		return line
-	}
-	return ""
 }

--- a/pkg/vault/keys_test.go
+++ b/pkg/vault/keys_test.go
@@ -12,68 +12,6 @@ import (
 	"github.com/xaaha/hulak/pkg/utils"
 )
 
-func TestVerifyKeypair(t *testing.T) {
-	id, err := age.GenerateX25519Identity()
-	if err != nil {
-		t.Fatalf("failed to generate identity: %v", err)
-	}
-
-	privKey := id.String()
-	pubKey := id.Recipient().String()
-
-	t.Run("valid matching pair", func(t *testing.T) {
-		got, err := VerifyKeypair(privKey, pubKey)
-		if err != nil {
-			t.Fatalf("VerifyKeypair() error: %v", err)
-		}
-		if got.Identity.String() != privKey {
-			t.Errorf("Identity = %q, want %q", got.Identity.String(), privKey)
-		}
-		if got.Recipient.String() != pubKey {
-			t.Errorf("Recipient = %q, want %q", got.Recipient.String(), pubKey)
-		}
-	})
-
-	t.Run("valid pair with whitespace", func(t *testing.T) {
-		_, err := VerifyKeypair(privKey+"\n", "  "+pubKey+"\n")
-		if err != nil {
-			t.Errorf("VerifyKeypair() should trim whitespace, got error: %v", err)
-		}
-	})
-
-	t.Run("mismatched pair", func(t *testing.T) {
-		id2, _ := age.GenerateX25519Identity()
-		_, err := VerifyKeypair(privKey, id2.Recipient().String())
-		if err == nil {
-			t.Error("VerifyKeypair() with mismatched keys should return error")
-		}
-		if !strings.Contains(err.Error(), "mismatch") {
-			t.Errorf("error = %q, want it to contain 'mismatch'", err.Error())
-		}
-	})
-
-	t.Run("invalid private key", func(t *testing.T) {
-		_, err := VerifyKeypair("not-a-key", pubKey)
-		if err == nil {
-			t.Error("VerifyKeypair() with invalid private key should return error")
-		}
-	})
-
-	t.Run("invalid public key", func(t *testing.T) {
-		_, err := VerifyKeypair(privKey, "not-a-key")
-		if err == nil {
-			t.Error("VerifyKeypair() with invalid public key should return error")
-		}
-	})
-
-	t.Run("empty strings", func(t *testing.T) {
-		_, err := VerifyKeypair("", "")
-		if err == nil {
-			t.Error("VerifyKeypair() with empty strings should return error")
-		}
-	})
-}
-
 // setupConfigDir creates a temp config directory and sets XDG_CONFIG_HOME
 // so that UserConfigDir() returns a path inside it. Returns the hulak config dir path.
 func setupConfigDir(t *testing.T) string {
@@ -432,9 +370,269 @@ func TestResolveIdentity(t *testing.T) {
 	})
 }
 
+func TestHasAnyIdentity(t *testing.T) {
+	t.Run("true when identity.txt exists", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+		t.Setenv("HULAK_SSH_IDENTITY", "")
+		t.Setenv("HOME", t.TempDir())
+
+		fileID, _ := age.GenerateX25519Identity()
+		if err := SetIdentity(fileID.String()); err != nil {
+			t.Fatalf("SetIdentity: %v", err)
+		}
+
+		if !HasAnyIdentity() {
+			t.Error("expected HasAnyIdentity() = true when identity.txt exists")
+		}
+	})
+
+	t.Run("true when HULAK_MASTER_KEY is set", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_SSH_IDENTITY", "")
+		t.Setenv("HOME", t.TempDir())
+		envID, _ := age.GenerateX25519Identity()
+		t.Setenv("HULAK_MASTER_KEY", envID.String())
+
+		if !HasAnyIdentity() {
+			t.Error("expected HasAnyIdentity() = true when HULAK_MASTER_KEY set")
+		}
+	})
+
+	t.Run("false when no source available", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+		t.Setenv("HULAK_SSH_IDENTITY", "")
+		t.Setenv("HOME", t.TempDir())
+
+		if HasAnyIdentity() {
+			t.Error("expected HasAnyIdentity() = false with no sources")
+		}
+	})
+}
+
+func TestResolveIdentityFor(t *testing.T) {
+	t.Run("identity.txt decrypts → returns it and skips SSH", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+		t.Setenv("HULAK_SSH_IDENTITY", "")
+		t.Setenv("HOME", t.TempDir())
+
+		fileID, _ := age.GenerateX25519Identity()
+		if err := SetIdentity(fileID.String()); err != nil {
+			t.Fatalf("SetIdentity: %v", err)
+		}
+
+		ct, err := EncryptText([]byte("hello"), fileID.Recipient())
+		if err != nil {
+			t.Fatalf("EncryptText: %v", err)
+		}
+
+		got, err := ResolveIdentityFor(ct)
+		if err != nil {
+			t.Fatalf("ResolveIdentityFor: %v", err)
+		}
+		if got.(*age.X25519Identity).String() != fileID.String() {
+			t.Errorf("got wrong identity — expected identity.txt to match")
+		}
+	})
+
+	t.Run("stale identity.txt falls through to SSH (the canonical fix)", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+		t.Setenv("HULAK_SSH_IDENTITY", "")
+		t.Setenv("HOME", t.TempDir())
+
+		// Write a STALE age identity (not a recipient of the test ciphertext)
+		staleID, _ := age.GenerateX25519Identity()
+		if err := SetIdentity(staleID.String()); err != nil {
+			t.Fatalf("SetIdentity: %v", err)
+		}
+
+		// Generate an SSH key, encrypt the ciphertext to its pubkey
+		sshDir := t.TempDir()
+		sshKeyPath, _ := writeTestSSHKey(t, sshDir)
+		t.Setenv("HULAK_SSH_IDENTITY", sshKeyPath)
+
+		// Build SSH recipient from the key
+		sshIdentity, err := LoadSSHIdentity(sshKeyPath)
+		if err != nil {
+			t.Fatalf("LoadSSHIdentity: %v", err)
+		}
+		sshRecipient, err := sshRecipientFromIdentity(t, sshKeyPath)
+		if err != nil {
+			t.Fatalf("derive ssh recipient: %v", err)
+		}
+
+		ct, err := EncryptText([]byte("hello"), sshRecipient)
+		if err != nil {
+			t.Fatalf("EncryptText: %v", err)
+		}
+
+		// Pre-#222: identity.txt would short-circuit. Post: SSH decrypts.
+		got, err := ResolveIdentityFor(ct)
+		if err != nil {
+			t.Fatalf("ResolveIdentityFor should fall through to SSH: %v", err)
+		}
+
+		// Verify by attempting decryption with what we got
+		plaintext, err := DecryptText(ct, got)
+		if err != nil {
+			t.Fatalf("returned identity should decrypt: %v", err)
+		}
+		if string(plaintext) != "hello" {
+			t.Errorf("decrypted to %q, want %q", plaintext, "hello")
+		}
+
+		// Sanity check: the SSH identity we loaded matches the returned one
+		// (compare via successful decrypt; age.Identity is an interface)
+		_ = sshIdentity
+	})
+
+	t.Run("enumerates tried sources when none decrypt", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+		t.Setenv("HULAK_SSH_IDENTITY", "")
+		t.Setenv("HOME", t.TempDir())
+
+		// Write stale identity.txt
+		staleID, _ := age.GenerateX25519Identity()
+		if err := SetIdentity(staleID.String()); err != nil {
+			t.Fatalf("SetIdentity: %v", err)
+		}
+
+		// Encrypt to a key that's NOT in any of our sources
+		strangerID, _ := age.GenerateX25519Identity()
+		ct, err := EncryptText([]byte("hello"), strangerID.Recipient())
+		if err != nil {
+			t.Fatalf("EncryptText: %v", err)
+		}
+
+		_, err = ResolveIdentityFor(ct)
+		if err == nil {
+			t.Fatal("expected error when no identity decrypts")
+		}
+		if !strings.Contains(err.Error(), "Tried:") {
+			t.Errorf("error should list tried sources: %v", err)
+		}
+		if !strings.Contains(err.Error(), "identity.txt") {
+			t.Errorf("error should mention identity.txt: %v", err)
+		}
+	})
+
+	t.Run("HULAK_MASTER_KEY strict: hard fails on wrong value", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_SSH_IDENTITY", "")
+		t.Setenv("HOME", t.TempDir())
+
+		// Real recipient (would decrypt if probed)
+		realID, _ := age.GenerateX25519Identity()
+		if err := SetIdentity(realID.String()); err != nil {
+			t.Fatalf("SetIdentity: %v", err)
+		}
+		ct, err := EncryptText([]byte("hello"), realID.Recipient())
+		if err != nil {
+			t.Fatalf("EncryptText: %v", err)
+		}
+
+		// Master key is a DIFFERENT (wrong) identity. Should fail hard,
+		// not fall through to identity.txt even though that would work.
+		wrongID, _ := age.GenerateX25519Identity()
+		t.Setenv("HULAK_MASTER_KEY", wrongID.String())
+
+		_, err = ResolveIdentityFor(ct)
+		if err == nil {
+			t.Fatal("expected hard failure when HULAK_MASTER_KEY is set but wrong")
+		}
+	})
+
+	t.Run("HULAK_MASTER_KEY succeeds when correct", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_SSH_IDENTITY", "")
+		t.Setenv("HOME", t.TempDir())
+
+		id, _ := age.GenerateX25519Identity()
+		t.Setenv("HULAK_MASTER_KEY", id.String())
+
+		ct, err := EncryptText([]byte("hello"), id.Recipient())
+		if err != nil {
+			t.Fatalf("EncryptText: %v", err)
+		}
+
+		got, err := ResolveIdentityFor(ct)
+		if err != nil {
+			t.Fatalf("ResolveIdentityFor: %v", err)
+		}
+		if got.(*age.X25519Identity).String() != id.String() {
+			t.Error("returned identity should match master key")
+		}
+	})
+
+	t.Run("broken HULAK_SSH_IDENTITY appears in tried list", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+		t.Setenv("HOME", t.TempDir())
+
+		// Point HULAK_SSH_IDENTITY at a non-existent path
+		t.Setenv("HULAK_SSH_IDENTITY", "/does/not/exist/id_ed25519")
+
+		// Plant an unrelated identity.txt so we have something to probe
+		staleID, _ := age.GenerateX25519Identity()
+		if err := SetIdentity(staleID.String()); err != nil {
+			t.Fatalf("SetIdentity: %v", err)
+		}
+
+		// Encrypt to a stranger so no source succeeds
+		stranger, _ := age.GenerateX25519Identity()
+		ct, err := EncryptText([]byte("hello"), stranger.Recipient())
+		if err != nil {
+			t.Fatalf("EncryptText: %v", err)
+		}
+
+		_, err = ResolveIdentityFor(ct)
+		if err == nil {
+			t.Fatal("expected error when no identity decrypts")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "HULAK_SSH_IDENTITY") {
+			t.Errorf("error should surface broken HULAK_SSH_IDENTITY: %v", err)
+		}
+		if !strings.Contains(msg, "load failed") {
+			t.Errorf("error should annotate the broken source as load-failed: %v", err)
+		}
+	})
+
+	t.Run("no identity sources → helpful error", func(t *testing.T) {
+		setupConfigDir(t)
+		t.Setenv("HULAK_MASTER_KEY", "")
+		t.Setenv("HULAK_SSH_IDENTITY", "")
+		t.Setenv("HOME", t.TempDir())
+
+		_, err := ResolveIdentityFor([]byte("not actually used"))
+		if err == nil {
+			t.Fatal("expected error when no identity available")
+		}
+		if !strings.Contains(err.Error(), "no identity found") {
+			t.Errorf("error should say 'no identity found': %v", err)
+		}
+	})
+}
+
+// sshRecipientFromIdentity extracts the SSH age.Recipient from a private key
+// path. Helper for tests that need to encrypt to an SSH identity.
+func sshRecipientFromIdentity(t *testing.T, keyPath string) (age.Recipient, error) {
+	t.Helper()
+	pubStr, err := DeriveSSHPublicKey(keyPath)
+	if err != nil {
+		return nil, err
+	}
+	rec, _, err := ParseRecipientKey(pubStr, false)
+	return rec, err
+}
+
 func TestWrapDecryptError(t *testing.T) {
 	t.Run("wraps no-match when HULAK_MASTER_KEY set", func(t *testing.T) {
-		raw := errors.New("no identity matched any of the recipients")
+		raw := errors.New("identity did not match any of the recipients")
 		t.Setenv("HULAK_MASTER_KEY", "AGE-SECRET-KEY-fake")
 
 		got := WrapDecryptError(raw)
@@ -448,7 +646,7 @@ func TestWrapDecryptError(t *testing.T) {
 	})
 
 	t.Run("passes through when HULAK_MASTER_KEY unset", func(t *testing.T) {
-		raw := errors.New("no identity matched any of the recipients")
+		raw := errors.New("identity did not match any of the recipients")
 		t.Setenv("HULAK_MASTER_KEY", "")
 
 		got := WrapDecryptError(raw)

--- a/pkg/vault/recipients.go
+++ b/pkg/vault/recipients.go
@@ -121,7 +121,11 @@ func SaveRecipients(entries []RecipientEntry) error {
 // AddRecipientEntry validates the new key, checks for duplicates, and returns
 // the updated entry list. Does not write to disk — caller does that.
 // Set allowRSA to true to accept ssh-rsa keys.
-func AddRecipientEntry(entries []RecipientEntry, pubKey, name string, allowRSA bool) ([]RecipientEntry, error) {
+func AddRecipientEntry(
+	entries []RecipientEntry,
+	pubKey, name string,
+	allowRSA bool,
+) ([]RecipientEntry, error) {
 	if _, _, err := ParseRecipientKey(pubKey, allowRSA); err != nil {
 		return nil, err
 	}
@@ -139,10 +143,11 @@ func AddRecipientEntry(entries []RecipientEntry, pubKey, name string, allowRSA b
 }
 
 // AddRecipientAndReencrypt adds a public key to recipients.txt (if not already
-// present) and re-encrypts the store to all recipients. Uses the provided
-// identity for decryption. Returns true if a new recipient was added.
+// present) and re-encrypts the store to all recipients. Resolves the
+// decrypting identity internally via ResolveIdentityFor (probes each source
+// against the existing ciphertext). Returns true if a new recipient was added.
 // This is the shared core for `init` additive flow and `add-recipient`.
-func AddRecipientAndReencrypt(pubKey, name string, identity age.Identity) (bool, error) {
+func AddRecipientAndReencrypt(pubKey, name string) (bool, error) {
 	recipPath, err := RecipientsFilePath()
 	if err != nil {
 		return false, err
@@ -164,7 +169,7 @@ func AddRecipientAndReencrypt(pubKey, name string, identity age.Identity) (bool,
 		return false, err
 	}
 
-	store, err := ReadStore(identity)
+	store, err := ReadStore()
 	if err != nil {
 		return false, err
 	}
@@ -283,11 +288,13 @@ func FormatRecipientName(name string) string {
 	return fmt.Sprintf("%s%s%s)", name, recipientNameSuffix, today)
 }
 
-// ParseRecipientName strips the date suffix added by FormatRecipientName.
-// Returns the original name if no suffix is found.
-func ParseRecipientName(formatted string) string {
-	if idx := strings.Index(formatted, recipientNameSuffix); idx >= 0 {
-		return formatted[:idx]
+// ParseRecipientName splits "Alice (added 2026-03-15)" into ("Alice", "2026-03-15").
+// Inputs without the date suffix return (formatted, ""). Empty input returns ("", "").
+// Inverse of FormatRecipientName.
+func ParseRecipientName(formatted string) (name, added string) {
+	before, after, ok := strings.Cut(formatted, recipientNameSuffix)
+	if !ok {
+		return formatted, ""
 	}
-	return formatted
+	return before, strings.TrimSuffix(after, ")")
 }

--- a/pkg/vault/recipients_test.go
+++ b/pkg/vault/recipients_test.go
@@ -409,11 +409,17 @@ func TestAddRecipientAndReencrypt(t *testing.T) {
 	projectDir := setupHulakProject(t)
 	cfgDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	t.Setenv("HULAK_MASTER_KEY", "")
+	t.Setenv("HULAK_SSH_IDENTITY", "")
+	t.Setenv("HOME", t.TempDir())
 
-	// Bootstrap: generate key, write recipients + store
+	// Bootstrap: generate key, write recipients + store, register as identity
 	key1, err := GenerateKeyPair()
 	if err != nil {
 		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	if err := SetIdentity(key1.Identity.String()); err != nil {
+		t.Fatalf("SetIdentity: %v", err)
 	}
 	if err := SaveRecipients([]RecipientEntry{
 		{Key: key1.Recipient.String(), Name: "owner"},
@@ -427,7 +433,7 @@ func TestAddRecipientAndReencrypt(t *testing.T) {
 
 	t.Run("adds new recipient and re-encrypts", func(t *testing.T) {
 		key2, _ := GenerateKeyPair()
-		added, err := AddRecipientAndReencrypt(key2.Recipient.String(), "teammate", key1.Identity)
+		added, err := AddRecipientAndReencrypt(key2.Recipient.String(), "teammate")
 		if err != nil {
 			t.Fatalf("AddRecipientAndReencrypt: %v", err)
 		}
@@ -436,7 +442,7 @@ func TestAddRecipientAndReencrypt(t *testing.T) {
 		}
 
 		// New key can decrypt
-		got, err := ReadStore(key2.Identity)
+		got, err := DecryptStore(key2.Identity)
 		if err != nil {
 			t.Fatalf("ReadStore with new key: %v", err)
 		}
@@ -445,7 +451,7 @@ func TestAddRecipientAndReencrypt(t *testing.T) {
 		}
 
 		// Old key still works
-		if _, err := ReadStore(key1.Identity); err != nil {
+		if _, err := DecryptStore(key1.Identity); err != nil {
 			t.Fatalf("ReadStore with original key: %v", err)
 		}
 
@@ -461,7 +467,7 @@ func TestAddRecipientAndReencrypt(t *testing.T) {
 	})
 
 	t.Run("returns false for duplicate", func(t *testing.T) {
-		added, err := AddRecipientAndReencrypt(key1.Recipient.String(), "owner", key1.Identity)
+		added, err := AddRecipientAndReencrypt(key1.Recipient.String(), "owner")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -188,52 +188,12 @@ func BackupsDir() (string, error) {
 	return filepath.Join(markerPath, "backups"), nil
 }
 
-// ReadStore decrypts store.age and returns the Store.
-// Uses json.Decoder.UseNumber() to preserve int/float distinction.
-func ReadStore(identity age.Identity) (*Store, error) {
-	path, err := StorePath()
-	if err != nil {
-		return nil, err
-	}
-
-	cipherText, err := os.ReadFile(path)
-	if err != nil {
-		// empty store.age if it does not exist
-		if os.IsNotExist(err) {
-			return &Store{Envs: make(map[string]Env)}, nil
-		}
-		return nil, fmt.Errorf("failed to read store: %w", err)
-	}
-
-	plainText, err := DecryptText(cipherText, identity)
-	if err != nil {
-		return nil, WrapDecryptError(fmt.Errorf("failed to decrypt store: %w", err))
-	}
-
+// decodeStore parses decrypted JSON plaintext into a Store. Uses UseNumber
+// to preserve int/float distinction (otherwise JSON numbers all become
+// float64, losing original type info for `secrets get` / serialization).
+// Also emits the size-warning side effect for large stores.
+func decodeStore(plainText []byte) (*Store, error) {
 	maybeWarnStoreSize(len(plainText))
-
-	store := &Store{}
-	if err := json.Unmarshal(plainText, store); err != nil {
-		return nil, err
-	}
-	return store, nil
-}
-
-// ReadStoreFrom decrypts an age-encrypted store file at the given path.
-// Unlike ReadStore, a missing file is an error (not an empty store).
-func ReadStoreFrom(path string, identity age.Identity) (*Store, error) {
-	cipherText, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read backup: %w", err)
-	}
-
-	plainText, err := DecryptText(cipherText, identity)
-	if err != nil {
-		return nil, WrapDecryptError(fmt.Errorf("failed to decrypt backup: %w", err))
-	}
-
-	maybeWarnStoreSize(len(plainText))
-
 	dec := json.NewDecoder(bytes.NewReader(plainText))
 	dec.UseNumber()
 	store := &Store{}
@@ -241,6 +201,70 @@ func ReadStoreFrom(path string, identity age.Identity) (*Store, error) {
 		return nil, err
 	}
 	return store, nil
+}
+
+// ReadStore reads and decrypts a store file via the multi-source identity
+// probe in a single pass (no double-decrypt). Identity is auto-resolved from
+// HULAK_MASTER_KEY → identity.txt → SSH keys.
+//
+// Default form (no args) reads .hulak/store.age; a missing file returns an
+// empty Store so additive write flows work on a fresh project. With an
+// explicit path (e.g. a backup file), a missing file is an error.
+//
+// For identity-mutating commands that need a SPECIFIC identity (e.g. rotate-key
+// reading with the old key, migrate reading with a freshly-generated key),
+// use DecryptStore instead.
+func ReadStore(path ...string) (*Store, error) {
+	var storePath string
+	explicit := len(path) > 0
+	if explicit {
+		storePath = path[0]
+	} else {
+		p, err := StorePath()
+		if err != nil {
+			return nil, err
+		}
+		storePath = p
+	}
+
+	cipherText, err := os.ReadFile(storePath)
+	if err != nil {
+		if os.IsNotExist(err) && !explicit {
+			return &Store{Envs: make(map[string]Env)}, nil
+		}
+		return nil, fmt.Errorf("failed to read store: %w", err)
+	}
+
+	_, plainText, err := resolveAndDecrypt(cipherText)
+	if err != nil {
+		return nil, err
+	}
+	return decodeStore(plainText)
+}
+
+// DecryptStore reads store.age and decrypts it with the given identity (strict,
+// no probe). Use for identity-mutating commands that need a specific primary
+// identity — e.g. rotate-key (test current vs. old key) and migrate (decrypt
+// with a freshly-generated identity). For ordinary reads, use ReadStore.
+//
+// A missing store.age returns an empty Store, consistent with ReadStore.
+func DecryptStore(identity age.Identity) (*Store, error) {
+	path, err := StorePath()
+	if err != nil {
+		return nil, err
+	}
+	cipherText, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Store{Envs: make(map[string]Env)}, nil
+		}
+		return nil, fmt.Errorf("failed to read store: %w", err)
+	}
+	plainText, err := DecryptText(cipherText, identity)
+	if err != nil {
+		return nil, WrapDecryptError(fmt.Errorf("failed to decrypt store: %w", err))
+	}
+	return decodeStore(plainText)
 }
 
 // maybeWarnStoreSize prints a one-time stderr warning if the decrypted store

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -238,12 +238,11 @@ func ReadStore(path ...string) (*Store, error) {
 	return decodeStore(plainText)
 }
 
-// DecryptStore reads store.age and decrypts it with the given identity (strict,
-// no probe). Use for identity-mutating commands that need a specific primary
-// identity — e.g. rotate-key (test current vs. old key) and migrate (decrypt
-// with a freshly-generated identity). For ordinary reads, use ReadStore.
+// DecryptStore reads .hulak/store.age and decrypts with the given identity
+// (no auto-resolve). Use when a specific identity is required — e.g. rotate-key
+// or migrate. For ordinary reads, use ReadStore.
 //
-// A missing store.age returns an empty Store, consistent with ReadStore.
+// A missing store.age returns an empty Store.
 func DecryptStore(identity age.Identity) (*Store, error) {
 	path, err := StorePath()
 	if err != nil {

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -203,17 +203,13 @@ func decodeStore(plainText []byte) (*Store, error) {
 	return store, nil
 }
 
-// ReadStore reads and decrypts a store file via the multi-source identity
-// probe in a single pass (no double-decrypt). Identity is auto-resolved from
-// HULAK_MASTER_KEY → identity.txt → SSH keys.
+// ReadStore reads and decrypts a store file. The decrypting identity is
+// auto-resolved from HULAK_MASTER_KEY, identity.txt, or an SSH key.
 //
-// Default form (no args) reads .hulak/store.age; a missing file returns an
-// empty Store so additive write flows work on a fresh project. With an
-// explicit path (e.g. a backup file), a missing file is an error.
+// No args reads .hulak/store.age; a missing file returns an empty Store.
+// With an explicit path (e.g. a backup), a missing file is an error.
 //
-// For identity-mutating commands that need a SPECIFIC identity (e.g. rotate-key
-// reading with the old key, migrate reading with a freshly-generated key),
-// use DecryptStore instead.
+// Use DecryptStore when you need to decrypt with a specific identity.
 func ReadStore(path ...string) (*Store, error) {
 	var storePath string
 	explicit := len(path) > 0

--- a/pkg/vault/store_test.go
+++ b/pkg/vault/store_test.go
@@ -269,7 +269,7 @@ func TestReadStoreWriteStoreRoundTrip(t *testing.T) {
 	}
 
 	// Read it back
-	got, err := ReadStore(id)
+	got, err := DecryptStore(id)
 	if err != nil {
 		t.Fatalf("ReadStore() error: %v", err)
 	}
@@ -317,7 +317,7 @@ func TestRoundTripNonASCIIAndHTMLChars(t *testing.T) {
 		t.Fatalf("WriteStore error: %v", err)
 	}
 
-	got, err := ReadStore(id)
+	got, err := DecryptStore(id)
 	if err != nil {
 		t.Fatalf("ReadStore error: %v", err)
 	}
@@ -353,7 +353,7 @@ func TestWriteStoreNoHTMLEscaping(t *testing.T) {
 	}
 
 	// Read back and verify HTML chars survived un-escaped.
-	got, err := ReadStore(id)
+	got, err := DecryptStore(id)
 	if err != nil {
 		t.Fatalf("ReadStore error: %v", err)
 	}
@@ -383,7 +383,7 @@ func TestReadStorePreservesNumberTypes(t *testing.T) {
 		t.Fatalf("WriteStore() error: %v", err)
 	}
 
-	got, err := ReadStore(id)
+	got, err := DecryptStore(id)
 	if err != nil {
 		t.Fatalf("ReadStore() error: %v", err)
 	}
@@ -412,7 +412,7 @@ func TestReadStoreNonexistentReturnsEmpty(t *testing.T) {
 	setupHulakProject(t)
 	id, _ := age.GenerateX25519Identity()
 
-	got, err := ReadStore(id)
+	got, err := DecryptStore(id)
 	if err != nil {
 		t.Fatalf("ReadStore() on missing file error: %v", err)
 	}
@@ -438,9 +438,132 @@ func TestReadStoreWrongIdentity(t *testing.T) {
 		t.Fatalf("WriteStore() error: %v", err)
 	}
 
-	_, err := ReadStore(id2)
+	_, err := DecryptStore(id2)
 	if err == nil {
 		t.Error("ReadStore() with wrong identity should return error")
+	}
+}
+
+// TestReadStore_StaleIdentityFallsBackToSSH is the canonical integration
+// test for the #222 onboarding fix. Scenario:
+//
+//   - A teammate has been added to a vault via their GitHub SSH key
+//     (so SSH ed25519 is a recipient of store.age)
+//   - The teammate's machine has a STALE identity.txt from another project
+//     (an age key that is NOT a recipient of this vault)
+//   - Pre-#222: ResolveIdentity short-circuits at identity.txt, never tries
+//     SSH → decryption fails with a confusing error
+//   - Post-#222: ResolveIdentityFor probes each source against the ciphertext,
+//     falls through identity.txt → SSH, decrypts cleanly
+//
+// This exercises the full read path: ReadStore → ResolveIdentityFor →
+// gatherIdentitySources → DecryptText, plus the announcement diagnostic.
+func TestReadStore_StaleIdentityFallsBackToSSH(t *testing.T) {
+	projectDir := setupHulakProject(t)
+
+	// Isolate config dir
+	cfgDir := t.TempDir()
+	cfgDir, _ = filepath.EvalSymlinks(cfgDir)
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	t.Setenv("HULAK_MASTER_KEY", "")
+	t.Setenv("HOME", t.TempDir()) // empty home, no auto ~/.ssh/id_ed25519
+
+	// 1. SSH key is the only recipient of the vault
+	sshDir := t.TempDir()
+	sshKeyPath, _ := writeTestSSHKey(t, sshDir)
+	t.Setenv("HULAK_SSH_IDENTITY", sshKeyPath)
+
+	sshPub, err := DeriveSSHPublicKey(sshKeyPath)
+	if err != nil {
+		t.Fatalf("DeriveSSHPublicKey: %v", err)
+	}
+	sshRecipient, _, err := ParseRecipientKey(sshPub, false)
+	if err != nil {
+		t.Fatalf("ParseRecipientKey: %v", err)
+	}
+
+	if err := SaveRecipients([]RecipientEntry{
+		{Key: sshPub, Name: "alice-ssh"},
+	}); err != nil {
+		t.Fatalf("SaveRecipients: %v", err)
+	}
+
+	// 2. Write a vault encrypted to SSH only
+	store := &Store{Envs: map[string]Env{
+		"global": {"DATABASE_URL": "postgres://example"},
+	}}
+	if err := WriteStore(store, sshRecipient); err != nil {
+		t.Fatalf("WriteStore: %v", err)
+	}
+
+	// 3. Plant a STALE identity.txt (age key that is NOT a recipient)
+	staleID, _ := age.GenerateX25519Identity()
+	if err := SetIdentity(staleID.String()); err != nil {
+		t.Fatalf("SetIdentity (stale): %v", err)
+	}
+
+	// 4. Read via the auto-resolve path
+	got, err := ReadStore()
+	if err != nil {
+		t.Fatalf(
+			"ReadStore should succeed by falling through stale identity.txt to SSH: %v",
+			err,
+		)
+	}
+
+	// 5. Verify decryption succeeded with the right plaintext
+	if got.GetEnv("global")["DATABASE_URL"] != "postgres://example" {
+		t.Errorf("decrypted store data mismatch: %+v", got.GetEnv("global"))
+	}
+
+	// 6. Sanity: project dir was used
+	if projectDir == "" {
+		t.Error("project dir should be set")
+	}
+}
+
+// TestReadStore_EnumeratesTriedSources verifies that when no available
+// identity decrypts the store, the error lists every source that was tried —
+// the diagnostic the review specifically called out as missing.
+func TestReadStore_EnumeratesTriedSources(t *testing.T) {
+	setupHulakProject(t)
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	t.Setenv("HULAK_MASTER_KEY", "")
+	t.Setenv("HULAK_SSH_IDENTITY", "")
+	t.Setenv("HOME", t.TempDir())
+
+	// Encrypt vault to a stranger key
+	stranger, _ := age.GenerateX25519Identity()
+	if err := SaveRecipients([]RecipientEntry{
+		{Key: stranger.Recipient().String(), Name: "stranger"},
+	}); err != nil {
+		t.Fatalf("SaveRecipients: %v", err)
+	}
+	store := &Store{Envs: map[string]Env{"global": {"K": "v"}}}
+	if err := WriteStore(store, stranger.Recipient()); err != nil {
+		t.Fatalf("WriteStore: %v", err)
+	}
+
+	// Plant a useless identity.txt (not a recipient)
+	useless, _ := age.GenerateX25519Identity()
+	if err := SetIdentity(useless.String()); err != nil {
+		t.Fatalf("SetIdentity: %v", err)
+	}
+
+	_, err := ReadStore()
+	if err == nil {
+		t.Fatal("expected error when no identity decrypts")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "Tried:") {
+		t.Errorf("error should enumerate tried sources: %v", err)
+	}
+	if !strings.Contains(msg, "identity.txt") {
+		t.Errorf("error should mention identity.txt was tried: %v", err)
+	}
+	if !strings.Contains(msg, "add-recipient") {
+		t.Errorf("error should suggest 'add-recipient' remediation: %v", err)
 	}
 }
 
@@ -600,7 +723,7 @@ func TestReadStoreLegacyWithoutVersion(t *testing.T) {
 		t.Fatalf("write legacy: %v", err)
 	}
 
-	got, err := ReadStore(id)
+	got, err := DecryptStore(id)
 	if err != nil {
 		t.Fatalf("ReadStore() legacy error: %v", err)
 	}
@@ -630,7 +753,7 @@ func TestReadStoreFutureVersionRejected(t *testing.T) {
 		t.Fatalf("write future: %v", err)
 	}
 
-	_, err = ReadStore(id)
+	_, err = DecryptStore(id)
 	if err == nil {
 		t.Fatal("ReadStore() with future version should error")
 	}
@@ -679,10 +802,10 @@ func TestReadStoreSizeWarning_LargeTriggersOnce(t *testing.T) {
 	storeSizeWarnOnce = sync.Once{}
 
 	out := captureStderr(t, func() {
-		if _, err := ReadStore(id); err != nil {
+		if _, err := DecryptStore(id); err != nil {
 			t.Fatalf("ReadStore #1: %v", err)
 		}
-		if _, err := ReadStore(id); err != nil {
+		if _, err := DecryptStore(id); err != nil {
 			t.Fatalf("ReadStore #2: %v", err)
 		}
 	})
@@ -707,7 +830,7 @@ func TestReadStoreSizeWarning_SmallNoWarning(t *testing.T) {
 	storeSizeWarnOnce = sync.Once{}
 
 	out := captureStderr(t, func() {
-		if _, err := ReadStore(id); err != nil {
+		if _, err := DecryptStore(id); err != nil {
 			t.Fatalf("ReadStore: %v", err)
 		}
 	})
@@ -735,9 +858,13 @@ func TestWriteStoreAtomicCleanup(t *testing.T) {
 }
 
 func TestReadStoreFrom(t *testing.T) {
+	cfg := setupConfigDir(t)
 	id, err := age.GenerateX25519Identity()
 	if err != nil {
 		t.Fatalf("generate identity: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg, "identity.txt"), []byte(id.String()+"\n"), 0o600); err != nil {
+		t.Fatalf("write identity: %v", err)
 	}
 
 	store := &Store{Envs: map[string]Env{
@@ -757,9 +884,9 @@ func TestReadStoreFrom(t *testing.T) {
 		t.Fatalf("write backup: %v", err)
 	}
 
-	got, err := ReadStoreFrom(backupPath, id)
+	got, err := ReadStore(backupPath)
 	if err != nil {
-		t.Fatalf("ReadStoreFrom: %v", err)
+		t.Fatalf("ReadStore(backup): %v", err)
 	}
 	if v, ok := got.GetEnv("global")["SECRET"].(string); !ok || v != "hello" {
 		t.Errorf("got SECRET=%v, want %q", got.GetEnv("global")["SECRET"], "hello")
@@ -767,16 +894,21 @@ func TestReadStoreFrom(t *testing.T) {
 }
 
 func TestReadStoreFrom_MissingFile(t *testing.T) {
-	id, _ := age.GenerateX25519Identity()
-	_, err := ReadStoreFrom("/nonexistent/path.age", id)
+	setupConfigDir(t)
+	_, err := ReadStore("/nonexistent/path.age")
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}
 }
 
 func TestReadStoreFrom_WrongIdentity(t *testing.T) {
+	cfg := setupConfigDir(t)
 	id1, _ := age.GenerateX25519Identity()
 	id2, _ := age.GenerateX25519Identity()
+	// Only id2 is configured locally — won't decrypt cipher encrypted to id1.
+	if err := os.WriteFile(filepath.Join(cfg, "identity.txt"), []byte(id2.String()+"\n"), 0o600); err != nil {
+		t.Fatalf("write identity: %v", err)
+	}
 
 	store := &Store{Envs: map[string]Env{"global": {"K": "V"}}}
 	jsonData, _ := json.Marshal(store)
@@ -787,8 +919,8 @@ func TestReadStoreFrom_WrongIdentity(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
-	_, err := ReadStoreFrom(path, id2)
+	_, err := ReadStore(path)
 	if err == nil {
-		t.Fatal("expected error when decrypting with wrong identity")
+		t.Fatal("expected error when no configured identity decrypts")
 	}
 }

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -32,9 +32,9 @@ func GenerateKeyPair() (AgeKey, error) {
 }
 
 // EncryptText encrypts plainText bytes for the given age recipients and returns the ciphertext.
-func EncryptText(plainText []byte, receipients ...age.Recipient) ([]byte, error) {
+func EncryptText(plainText []byte, recipients ...age.Recipient) ([]byte, error) {
 	var buf bytes.Buffer
-	if err := Encrypt(bytes.NewReader(plainText), &buf, receipients...); err != nil {
+	if err := Encrypt(bytes.NewReader(plainText), &buf, recipients...); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil


### PR DESCRIPTION
- solved the issue where `ResolveIdentity` short-circuited at `identity.txt` even when stale, blocking team onboarding when an SSH key would have worked — read paths now probe every configured source against the ciphertext and pick the one that actually decrypts
- added `HULAK_MASTER_KEY → identity.txt → $HULAK_SSH_IDENTITY → ~/.ssh/id_ed25519` precedence with a typed `sourceKind` so policy (hard-fail on explicit broken config, silent fall-through on auto-detected SSH default) lives in one place
- added `hulak secrets list-identity` (aliases `ls-identity`, `identities`) — prints every configured identity that can decrypt store.age in a table, first row marked as default
- added `hulak secrets gen-identity --name <label>` — generates a keypair and self-registers it as a recipient in one step when you already have decrypt access (SSH or another identity)
- added `hulak secrets import-key --name <label>` — imports an existing key and self-registers it as a recipient in one step
- added shared `registerNameFlag` / `resolveRecipientName` helpers in `pkg/userFlags/name_flag.go` (modeled on `output_flag.go`) so add-recipient, gen-identity, and import-key all speak the same vocabulary for the `--name` label
- removed `--no-validate` from import-key — narrow escape hatch superseded by `--name` for self-service and unnecessary for pre-clone staging (the read-only check auto-skips outside a vault)
- removed dead `VerifyKeypair` (had no production callers, only its own tests)
- removed dead `ReadStoreFrom(path, identities...)` strict variant (had no production callers)
- refactored `pkg/vault/keys.go` from 522 LOC down to 135 LOC by splitting it into three topical files: `keys.go` (identity file CRUD + backup), `identity_resolve.go` (multi-source probe + resolvers + error helpers), `identity_import.go` (import/export)
- refactored `ReadStore` family for clearer ergonomics: `ReadStore()` is the default (was `ReadStoreAny`), `ReadStore(path)` reads an arbitrary file via variadic (was `ReadStoreFromAny`), `DecryptStore(identity)` is the strict explicit-identity form (was `ReadStore(...identities)`)
- swept test seeders that used `DecryptStore(identity)` purely as leftover from the rename — converted to `ReadStore()` where the identity was incidental (16 sites across 6 files); kept `DecryptStore` where the test actually asserts a specific identity decrypts
- collapsed `gatherIdentitySources` + `allConfiguredSources` into a single `gatherSources(includeMaster bool)` — every identity-related query (probe loop, list-identity, doctor) now funnels through one function
- unified `splitRecipientName` (was duplicated in env_list_identity.go) into the existing `vault.ParseRecipientName` — now returns `(name, added)` instead of just name
- fixed `receipients` → `recipients` typo in `EncryptText`
- fixed double-decrypt in read paths by introducing internal `resolveAndDecrypt(ciphertext)` that returns `(identity, plaintext, error)` in a single pass
- fixed corrupt-store-vs-not-a-recipient discrimination in import validation by checking age's specific "did not match any of the recipients" error substring
- documented the two-mode design of `runImportKey` (state-changing self-register vs. read-only verify) inline so the why-not-always-register question is recoverable from the code
- simplified doc comments throughout `pkg/vault/store.go` and `pkg/userFlags/env_keys.go` for beginner readability — plain sentences, dropped jargon like "decrypt-test", "auto-skips", "single-pass (no double-decrypt)"

Closes #222

## Test plan

- [x] `mise run check` passes (lint + all unit tests)
- [x] Smoke-tested `hulak init` + `hulak secrets list-identity` in a fresh project
- [x] Smoke-tested `hulak secrets gen-identity` help + `hulak secrets import-key` help reflect the new `--name` flag and absence of `--no-validate`
- [x] Added test for `--name auto-registers a non-recipient key when SSH decrypts` covering the new end-to-end self-onboarding flow