### PR TITLE
fix gql bug and support types

### DIFF
--- a/pkg/userFlags/command.go
+++ b/pkg/userFlags/command.go
@@ -22,6 +22,7 @@ var flagAliases = map[string]string{
 	"help":        "h",
 	"quiet":       "q",
 	"sequential":  "seq",
+	"type":        "t",
 }
 
 // hiddenFlags are omitted from help output entirely (utility flags

--- a/pkg/userFlags/env_backup_test.go
+++ b/pkg/userFlags/env_backup_test.go
@@ -13,7 +13,7 @@ import (
 func TestRunBackup_DefaultPath(t *testing.T) {
 	setupVaultProject(t)
 
-	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false, ""); err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
 
@@ -45,7 +45,7 @@ func TestRunBackup_DefaultPath(t *testing.T) {
 func TestRunBackup_OutPath(t *testing.T) {
 	setupVaultProject(t)
 
-	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false, ""); err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
 
@@ -62,7 +62,7 @@ func TestRunBackup_OutPath(t *testing.T) {
 func TestRunBackup_OutExistingNoForce(t *testing.T) {
 	setupVaultProject(t)
 
-	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false, ""); err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
 
@@ -83,7 +83,7 @@ func TestRunBackup_OutExistingNoForce(t *testing.T) {
 func TestRunBackup_OutExistingForce(t *testing.T) {
 	setupVaultProject(t)
 
-	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false, ""); err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
 
@@ -105,7 +105,7 @@ func TestRunBackup_OutExistingForce(t *testing.T) {
 func TestRunBackup_SameSecondCollision(t *testing.T) {
 	setupVaultProject(t)
 
-	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false, ""); err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
 
@@ -157,7 +157,7 @@ func TestRunBackupList_Empty(t *testing.T) {
 func TestRunBackupList_WithBackups(t *testing.T) {
 	setupVaultProject(t)
 
-	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false, ""); err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
 	if err := runBackup("", false); err != nil {
@@ -172,7 +172,7 @@ func TestRunBackupList_WithBackups(t *testing.T) {
 func TestRunBackup_GitignoreUpdated(t *testing.T) {
 	setupVaultProject(t)
 
-	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false, ""); err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
 	if err := runBackup("", false); err != nil {
@@ -193,7 +193,7 @@ func TestRunBackup_GitignoreUpdated(t *testing.T) {
 func TestRunRestore_LatestBackup(t *testing.T) {
 	setupVaultProject(t)
 
-	if err := runEnvSet([]string{"KEY", "original"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"KEY", "original"}, "global", false, ""); err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
 
@@ -201,7 +201,7 @@ func TestRunRestore_LatestBackup(t *testing.T) {
 		t.Fatalf("backup: %v", err)
 	}
 
-	if err := runEnvSet([]string{"KEY", "mutated"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"KEY", "mutated"}, "global", false, ""); err != nil {
 		t.Fatalf("mutate store: %v", err)
 	}
 	if got := readStoredValue(t, "global", "KEY"); got != "mutated" {
@@ -220,7 +220,7 @@ func TestRunRestore_LatestBackup(t *testing.T) {
 func TestRunRestore_SpecificPath(t *testing.T) {
 	setupVaultProject(t)
 
-	if err := runEnvSet([]string{"KEY", "original"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"KEY", "original"}, "global", false, ""); err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
 
@@ -229,7 +229,7 @@ func TestRunRestore_SpecificPath(t *testing.T) {
 		t.Fatalf("backup: %v", err)
 	}
 
-	if err := runEnvSet([]string{"KEY", "changed"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"KEY", "changed"}, "global", false, ""); err != nil {
 		t.Fatalf("mutate: %v", err)
 	}
 
@@ -286,7 +286,7 @@ func TestRunRestore_PlaintextFile(t *testing.T) {
 func TestRunRestore_WrongIdentity(t *testing.T) {
 	setupVaultProject(t)
 
-	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false, ""); err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
 
@@ -313,7 +313,7 @@ func TestRunRestore_WrongIdentity(t *testing.T) {
 func TestRunRestore_ReencryptsToCurrentRecipients(t *testing.T) {
 	setupVaultProject(t)
 
-	if err := runEnvSet([]string{"KEY", "val"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"KEY", "val"}, "global", false, ""); err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
 
@@ -346,7 +346,7 @@ func TestRunRestore_ReencryptsToCurrentRecipients(t *testing.T) {
 func TestRunRestore_CancelledPrompt(t *testing.T) {
 	setupVaultProject(t)
 
-	if err := runEnvSet([]string{"KEY", "original"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"KEY", "original"}, "global", false, ""); err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
 
@@ -355,7 +355,7 @@ func TestRunRestore_CancelledPrompt(t *testing.T) {
 		t.Fatalf("backup: %v", err)
 	}
 
-	if err := runEnvSet([]string{"KEY", "mutated"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"KEY", "mutated"}, "global", false, ""); err != nil {
 		t.Fatalf("mutate: %v", err)
 	}
 

--- a/pkg/userFlags/env_crud.go
+++ b/pkg/userFlags/env_crud.go
@@ -21,8 +21,9 @@ import (
 const MaxValueSizeWarnBytes = 64 << 10 // 64 KiB
 
 // validSetTypes lists the type names accepted by `secrets set --type`.
-// Kept as a slice (not a map) so error messages can present them in a stable
-// order and the default ("string") is first. Items available in json type
+// Kept as a fixed-size array (not a map) so error messages can present them
+// in a stable order, the default ("string") stays first, and adding a value
+// fails the compiler if the size constant is not updated to match.
 var validSetTypes = [5]string{"string", "int", "float", "bool", "json"}
 
 // parseTypedValue converts the raw string value read from the CLI into the

--- a/pkg/userFlags/env_crud.go
+++ b/pkg/userFlags/env_crud.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/xaaha/hulak/pkg/utils"
@@ -18,6 +19,59 @@ import (
 // Above this, the user is warned and pointed at {{getFile "path"}} for blobs.
 // Not a hard limit — the value is still written.
 const MaxValueSizeWarnBytes = 64 << 10 // 64 KiB
+
+// validSetTypes lists the type names accepted by `secrets set --type`.
+// Kept as a slice (not a map) so error messages can present them in a stable
+// order and the default ("string") is first. Items available in json type
+var validSetTypes = [5]string{"string", "int", "float", "bool", "json"}
+
+// parseTypedValue converts the raw string value read from the CLI into the
+// typed any that gets stored in the vault. Empty typeName defaults to
+// "string" so callers that don't pass --type keep current behavior.
+//
+// int and float are returned as json.Number to match the shape the vault
+// decoder emits on read (UseNumber). That keeps write-then-read a no-op and
+// lets downstream JSON marshalling emit numbers as raw numbers rather than
+// quoted strings.
+func parseTypedValue(raw, typeName string) (any, error) {
+	if typeName == "" {
+		typeName = "string"
+	}
+	switch typeName {
+	case "string":
+		return raw, nil
+	case "int":
+		if _, err := strconv.ParseInt(raw, 10, 64); err != nil {
+			return nil, fmt.Errorf("invalid int value %q: %w", raw, err)
+		}
+		return json.Number(raw), nil
+	case "float":
+		if _, err := strconv.ParseFloat(raw, 64); err != nil {
+			return nil, fmt.Errorf("invalid float value %q: %w", raw, err)
+		}
+		return json.Number(raw), nil
+	case "bool":
+		b, err := strconv.ParseBool(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid bool value %q: %w", raw, err)
+		}
+		return b, nil
+	case "json":
+		dec := json.NewDecoder(strings.NewReader(raw))
+		dec.UseNumber()
+		var v any
+		if err := dec.Decode(&v); err != nil {
+			return nil, fmt.Errorf("invalid json value: %w", err)
+		}
+		return v, nil
+	default:
+		return nil, fmt.Errorf(
+			"unknown type %q: must be one of %s",
+			typeName,
+			strings.Join(validSetTypes[:], ", "),
+		)
+	}
+}
 
 // newEnvSetCmd returns the command struct for `hulak secrets set`.
 func newEnvSetCmd() *command {

--- a/pkg/userFlags/env_crud.go
+++ b/pkg/userFlags/env_crud.go
@@ -78,12 +78,16 @@ func newEnvSetCmd() *command {
 	setFs := flag.NewFlagSet("env set", flag.ContinueOnError)
 	setEnv := registerEnvFlag(setFs, utils.DefaultEnvVal, "Environment to operate on")
 	setStdin := setFs.Bool("stdin", false, "Read value from stdin")
+	var setType string
+	typeUsage := "Value type: " + strings.Join(validSetTypes[:], "|")
+	setFs.StringVar(&setType, "type", "string", typeUsage)
+	setFs.StringVar(&setType, "t", "string", typeUsage)
 
 	return &command{
 		Name:    "set",
 		Aliases: []string{"add"},
 		Short:   "Set a key-value pair",
-		Long:    "Store a secret in the encrypted vault.\n\nIf VALUE is omitted, you'll be prompted to enter it (no echo, no shell history).\nUse --stdin to pipe the value from standard input (useful for scripts).",
+		Long:    "Store a secret in the encrypted vault.\n\nIf VALUE is omitted, you'll be prompted to enter it (no echo, no shell history).\nUse --stdin to pipe the value from standard input (useful for scripts).\nUse --type to store numbers, booleans, or JSON instead of strings.",
 		Flags:   setFs,
 		Args: []argDef{
 			{Name: "key", Required: true, Desc: "Secret key name"},
@@ -106,8 +110,20 @@ func newEnvSetCmd() *command {
 				Command:     "hulak secrets set FEATURE_FLAG true --env staging",
 				Description: "Set a value in a specific environment",
 			},
+			{
+				Command:     "hulak secrets set userAge 3939 --type int",
+				Description: "Store as an integer (preserved through to GraphQL/JSON bodies)",
+			},
+			{
+				Command:     "hulak secrets set ENABLED true --type bool",
+				Description: "Store as a boolean",
+			},
+			{
+				Command:     "hulak secrets set config '{\"a\":1}' --type json",
+				Description: "Store an arbitrary JSON value (object, array, number, etc.)",
+			},
 		},
-		Run: func(args []string) error { return runEnvSet(args, *setEnv, *setStdin) },
+		Run: func(args []string) error { return runEnvSet(args, *setEnv, *setStdin, setType) },
 	}
 }
 
@@ -118,9 +134,14 @@ func newEnvSetCmd() *command {
 //  2. positional VALUE → use as-is
 //  3. interactive prompt with no echo (only if stdin is a TTY)
 //
+// typeName is the --type flag value; "" or "string" stores the raw string.
+// int/float/bool/json are parsed by parseTypedValue and the typed result is
+// what lands in the vault. Parse failure aborts before the store lock so a
+// bad type/value never opens or mutates the store.
+//
 // The read-modify-write of store.age is wrapped in WithStoreLock so concurrent
 // `hulak secrets set` invocations cannot lose each other's edits.
-func runEnvSet(args []string, envName string, useStdin bool) error {
+func runEnvSet(args []string, envName string, useStdin bool, typeName string) error {
 	if len(args) == 0 {
 		return errors.New("missing required argument: KEY")
 	}
@@ -133,16 +154,21 @@ func runEnvSet(args []string, envName string, useStdin bool) error {
 		return err
 	}
 
-	value, err := resolveSetValue(args, useStdin, key)
+	rawValue, err := resolveSetValue(args, useStdin, key)
 	if err != nil {
 		return err
 	}
 
-	if len(value) > MaxValueSizeWarnBytes {
+	if len(rawValue) > MaxValueSizeWarnBytes {
 		utils.PrintWarningStderr(fmt.Sprintf(
 			"value for %q is %.1f KB — consider {{getFile \"path\"}} for large blobs",
-			key, float64(len(value))/1024,
+			key, float64(len(rawValue))/1024,
 		))
+	}
+
+	typedValue, err := parseTypedValue(rawValue, typeName)
+	if err != nil {
+		return err
 	}
 
 	// acquire lock
@@ -152,7 +178,7 @@ func runEnvSet(args []string, envName string, useStdin bool) error {
 			return err
 		}
 
-		store.SetKey(envName, key, value)
+		store.SetKey(envName, key, typedValue)
 
 		if err := vault.WriteStoreToRecipients(store); err != nil {
 			return err

--- a/pkg/userFlags/env_crud.go
+++ b/pkg/userFlags/env_crud.go
@@ -63,6 +63,12 @@ func parseTypedValue(raw, typeName string) (any, error) {
 		if err := dec.Decode(&v); err != nil {
 			return nil, fmt.Errorf("invalid json value: %w", err)
 		}
+		// Reject trailing tokens like `{"a":1}garbage` so silent truncation
+		// can't happen. Trailing whitespace is fine — Decode consumes it on
+		// the next call only if non-whitespace remains.
+		if err := dec.Decode(new(any)); err != io.EOF {
+			return nil, fmt.Errorf("invalid json value: unexpected data after value")
+		}
 		return v, nil
 	default:
 		return nil, fmt.Errorf(

--- a/pkg/userFlags/env_crud_test.go
+++ b/pkg/userFlags/env_crud_test.go
@@ -351,3 +351,173 @@ func TestRunEnvSet_LargeValueWarning(t *testing.T) {
 		t.Error("large value should still be written")
 	}
 }
+
+func TestParseTypedValue_String(t *testing.T) {
+	got, err := parseTypedValue("hello world", "string")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "hello world" {
+		t.Errorf("got %v (%T), want %q (string)", got, got, "hello world")
+	}
+}
+
+func TestParseTypedValue_StringDefault(t *testing.T) {
+	got, err := parseTypedValue("anything", "")
+	if err != nil {
+		t.Fatalf("empty type should default to string, got error: %v", err)
+	}
+	if got != "anything" {
+		t.Errorf("got %v, want %q", got, "anything")
+	}
+}
+
+func TestParseTypedValue_Int(t *testing.T) {
+	got, err := parseTypedValue("3939", "int")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	num, ok := got.(json.Number)
+	if !ok {
+		t.Fatalf("got %v (%T), want json.Number", got, got)
+	}
+	if num.String() != "3939" {
+		t.Errorf("got %q, want %q", num.String(), "3939")
+	}
+}
+
+func TestParseTypedValue_IntNegative(t *testing.T) {
+	got, err := parseTypedValue("-42", "int")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	num, ok := got.(json.Number)
+	if !ok || num.String() != "-42" {
+		t.Errorf("got %v, want json.Number(\"-42\")", got)
+	}
+}
+
+func TestParseTypedValue_IntInvalid(t *testing.T) {
+	cases := []string{"3.5", "abc", "", "1e3"}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := parseTypedValue(raw, "int"); err == nil {
+				t.Errorf("expected error for int %q, got nil", raw)
+			}
+		})
+	}
+}
+
+func TestParseTypedValue_Float(t *testing.T) {
+	got, err := parseTypedValue("3.14", "float")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	num, ok := got.(json.Number)
+	if !ok || num.String() != "3.14" {
+		t.Errorf("got %v, want json.Number(\"3.14\")", got)
+	}
+}
+
+func TestParseTypedValue_FloatInvalid(t *testing.T) {
+	if _, err := parseTypedValue("not-a-number", "float"); err == nil {
+		t.Error("expected error for invalid float, got nil")
+	}
+}
+
+func TestParseTypedValue_Bool(t *testing.T) {
+	cases := map[string]bool{
+		"true":  true,
+		"false": false,
+		"1":     true,
+		"0":     false,
+		"T":     true,
+		"F":     false,
+	}
+	for raw, want := range cases {
+		t.Run(raw, func(t *testing.T) {
+			got, err := parseTypedValue(raw, "bool")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			b, ok := got.(bool)
+			if !ok {
+				t.Fatalf("got %v (%T), want bool", got, got)
+			}
+			if b != want {
+				t.Errorf("got %v, want %v", b, want)
+			}
+		})
+	}
+}
+
+func TestParseTypedValue_BoolInvalid(t *testing.T) {
+	cases := []string{"yes", "no", "TRUE!", "", "2"}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := parseTypedValue(raw, "bool"); err == nil {
+				t.Errorf("expected error for bool %q, got nil", raw)
+			}
+		})
+	}
+}
+
+func TestParseTypedValue_JSONObject(t *testing.T) {
+	got, err := parseTypedValue(`{"a":1,"b":"x"}`, "json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("got %T, want map[string]any", got)
+	}
+	num, ok := m["a"].(json.Number)
+	if !ok || num.String() != "1" {
+		t.Errorf("m[a] = %v (%T), want json.Number(\"1\")", m["a"], m["a"])
+	}
+	if m["b"] != "x" {
+		t.Errorf("m[b] = %v, want %q", m["b"], "x")
+	}
+}
+
+func TestParseTypedValue_JSONArray(t *testing.T) {
+	got, err := parseTypedValue(`[1,2,3]`, "json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	arr, ok := got.([]any)
+	if !ok {
+		t.Fatalf("got %T, want []any", got)
+	}
+	if len(arr) != 3 {
+		t.Fatalf("len=%d, want 3", len(arr))
+	}
+	num, ok := arr[0].(json.Number)
+	if !ok || num.String() != "1" {
+		t.Errorf("arr[0] = %v, want json.Number(\"1\")", arr[0])
+	}
+}
+
+func TestParseTypedValue_JSONInvalid(t *testing.T) {
+	cases := []string{`{`, `not json`, ``, `{"a":}`}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := parseTypedValue(raw, "json"); err == nil {
+				t.Errorf("expected error for json %q, got nil", raw)
+			}
+		})
+	}
+}
+
+func TestParseTypedValue_UnknownType(t *testing.T) {
+	_, err := parseTypedValue("v", "integer")
+	if err == nil {
+		t.Fatal("expected error for unknown type, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"string", "int", "float", "bool", "json"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q should list valid type %q", msg, want)
+		}
+	}
+}

--- a/pkg/userFlags/env_crud_test.go
+++ b/pkg/userFlags/env_crud_test.go
@@ -682,3 +682,41 @@ func TestRunEnvSet_DefaultTypeIsString(t *testing.T) {
 		t.Errorf("stored = %v (%T), want \"3939\" (string)", got, got)
 	}
 }
+
+// TestEnvSetCmd_FlagWiring exercises the full newEnvSetCmd() path: build the
+// command, parse flag args through the FlagSet, then invoke Run. This is the
+// only test that catches a regression in the `-t`/`--type` alias wiring or
+// the StringVar pair pointing to the same variable (a bug here would have
+// integration tests still pass because they bypass flag parsing).
+func TestEnvSetCmd_FlagWiring(t *testing.T) {
+	testCases := []struct {
+		name string
+		args []string // full args after `secrets set`
+		key  string
+	}{
+		{"long flag --type int", []string{"--type", "int", "longInt", "100"}, "longInt"},
+		{"short flag -t int", []string{"-t", "int", "shortInt", "200"}, "shortInt"},
+		{"long flag --type bool", []string{"--type", "bool", "longBool", "true"}, "longBool"},
+		{"short flag -t bool", []string{"-t", "bool", "shortBool", "false"}, "shortBool"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setupVaultProject(t)
+			cmd := newEnvSetCmd()
+			if err := cmd.Flags.Parse(tc.args); err != nil {
+				t.Fatalf("Flags.Parse(%v): %v", tc.args, err)
+			}
+			if err := cmd.Run(cmd.Flags.Args()); err != nil {
+				t.Fatalf("cmd.Run: %v", err)
+			}
+
+			got := readStoredValue(t, "global", tc.key)
+			// Stored value should NOT be the raw string. Any non-string type
+			// proves --type was honored end-to-end via the flag binding.
+			if s, ok := got.(string); ok {
+				t.Errorf("stored as string %q — flag binding did not honor --type", s)
+			}
+		})
+	}
+}

--- a/pkg/userFlags/env_crud_test.go
+++ b/pkg/userFlags/env_crud_test.go
@@ -510,6 +510,38 @@ func TestParseTypedValue_JSONInvalid(t *testing.T) {
 	}
 }
 
+func TestParseTypedValue_JSONRejectsTrailingData(t *testing.T) {
+	cases := []string{
+		`{"a":1}garbage`,
+		`[1,2] extra`,
+		`42 99`,
+		`"hello" world`,
+	}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			_, err := parseTypedValue(raw, "json")
+			if err == nil {
+				t.Errorf("expected error for trailing data in %q, got nil", raw)
+			}
+		})
+	}
+}
+
+func TestParseTypedValue_JSONAcceptsTrailingWhitespace(t *testing.T) {
+	cases := []string{
+		`{"a":1}` + "\n",
+		`[1,2]  `,
+		"  42  \n\t",
+	}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := parseTypedValue(raw, "json"); err != nil {
+				t.Errorf("trailing whitespace should be allowed, got error for %q: %v", raw, err)
+			}
+		})
+	}
+}
+
 func TestParseTypedValue_UnknownType(t *testing.T) {
 	_, err := parseTypedValue("v", "integer")
 	if err == nil {

--- a/pkg/userFlags/env_crud_test.go
+++ b/pkg/userFlags/env_crud_test.go
@@ -14,7 +14,7 @@ import (
 func TestRunEnvSet_PositionalValue(t *testing.T) {
 	setupVaultProject(t)
 
-	if err := runEnvSet([]string{"API_KEY", "sk-123"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"API_KEY", "sk-123"}, "global", false, ""); err != nil {
 		t.Fatalf("runEnvSet: %v", err)
 	}
 
@@ -39,7 +39,7 @@ func TestRunEnvSet_StdinValue(t *testing.T) {
 	os.Stdin = r
 	t.Cleanup(func() { os.Stdin = orig })
 
-	if err := runEnvSet([]string{"TOKEN"}, "global", true); err != nil {
+	if err := runEnvSet([]string{"TOKEN"}, "global", true, ""); err != nil {
 		t.Fatalf("runEnvSet: %v", err)
 	}
 
@@ -55,7 +55,7 @@ func TestRunEnvSet_StdinValue(t *testing.T) {
 func TestRunEnvSet_CustomEnv(t *testing.T) {
 	setupVaultProject(t)
 
-	if err := runEnvSet([]string{"DB_URL", "postgres://x"}, "prod", false); err != nil {
+	if err := runEnvSet([]string{"DB_URL", "postgres://x"}, "prod", false, ""); err != nil {
 		t.Fatalf("runEnvSet: %v", err)
 	}
 
@@ -67,10 +67,10 @@ func TestRunEnvSet_CustomEnv(t *testing.T) {
 func TestRunEnvSet_Upsert(t *testing.T) {
 	setupVaultProject(t)
 
-	if err := runEnvSet([]string{"K", "v1"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"K", "v1"}, "global", false, ""); err != nil {
 		t.Fatalf("set v1: %v", err)
 	}
-	if err := runEnvSet([]string{"K", "v2"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"K", "v2"}, "global", false, ""); err != nil {
 		t.Fatalf("set v2: %v", err)
 	}
 
@@ -103,7 +103,7 @@ func TestRunEnvSet_Errors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			setupVaultProject(t)
-			err := runEnvSet(tc.args, tc.envName, tc.stdin)
+			err := runEnvSet(tc.args, tc.envName, tc.stdin, "")
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -116,7 +116,7 @@ func TestRunEnvSet_Errors(t *testing.T) {
 
 func TestRunEnvGet_PrintsString(t *testing.T) {
 	setupVaultProject(t)
-	if err := runEnvSet([]string{"FOO", "bar"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"FOO", "bar"}, "global", false, ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
@@ -171,7 +171,7 @@ func TestRunEnvGet_PrintsNonString(t *testing.T) {
 
 func TestRunEnvGet_FromCustomEnv(t *testing.T) {
 	setupVaultProject(t)
-	if err := runEnvSet([]string{"DB_URL", "postgres"}, "prod", false); err != nil {
+	if err := runEnvSet([]string{"DB_URL", "postgres"}, "prod", false, ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
@@ -220,7 +220,7 @@ func TestRunEnvGet_Errors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			setupVaultProject(t)
-			if err := runEnvSet([]string{tc.seedKey, "v"}, tc.seedEnv, false); err != nil {
+			if err := runEnvSet([]string{tc.seedKey, "v"}, tc.seedEnv, false, ""); err != nil {
 				t.Fatalf("seed: %v", err)
 			}
 
@@ -237,7 +237,7 @@ func TestRunEnvGet_Errors(t *testing.T) {
 
 func TestRunEnvDelete_RemovesKey(t *testing.T) {
 	setupVaultProject(t)
-	if err := runEnvSet([]string{"FOO", "bar"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"FOO", "bar"}, "global", false, ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
@@ -253,10 +253,10 @@ func TestRunEnvDelete_RemovesKey(t *testing.T) {
 
 func TestRunEnvDelete_LeavesOtherKeysAlone(t *testing.T) {
 	setupVaultProject(t)
-	if err := runEnvSet([]string{"FOO", "1"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"FOO", "1"}, "global", false, ""); err != nil {
 		t.Fatalf("seed FOO: %v", err)
 	}
-	if err := runEnvSet([]string{"BAR", "2"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"BAR", "2"}, "global", false, ""); err != nil {
 		t.Fatalf("seed BAR: %v", err)
 	}
 
@@ -302,7 +302,7 @@ func TestRunEnvDelete_Errors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			setupVaultProject(t)
-			if err := runEnvSet([]string{tc.seedKey, "v"}, tc.seedEnv, false); err != nil {
+			if err := runEnvSet([]string{tc.seedKey, "v"}, tc.seedEnv, false, ""); err != nil {
 				t.Fatalf("seed: %v", err)
 			}
 
@@ -337,7 +337,7 @@ func TestRunEnvSet_LargeValueWarning(t *testing.T) {
 		done <- b.String()
 	}()
 
-	if err := runEnvSet([]string{"BIG", big}, "global", false); err != nil {
+	if err := runEnvSet([]string{"BIG", big}, "global", false, ""); err != nil {
 		t.Fatalf("runEnvSet: %v", err)
 	}
 	_ = w.Close()

--- a/pkg/userFlags/env_crud_test.go
+++ b/pkg/userFlags/env_crud_test.go
@@ -521,3 +521,131 @@ func TestParseTypedValue_UnknownType(t *testing.T) {
 		}
 	}
 }
+
+func TestRunEnvSet_TypedInt(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"userAge", "3939"}, "global", false, "int"); err != nil {
+		t.Fatalf("runEnvSet: %v", err)
+	}
+	got := readStoredValue(t, "global", "userAge")
+	num, ok := got.(json.Number)
+	if !ok {
+		t.Fatalf("stored value = %v (%T), want json.Number", got, got)
+	}
+	if num.String() != "3939" {
+		t.Errorf("stored = %q, want %q", num.String(), "3939")
+	}
+}
+
+func TestRunEnvSet_TypedFloat(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"ratio", "1.5"}, "global", false, "float"); err != nil {
+		t.Fatalf("runEnvSet: %v", err)
+	}
+	got := readStoredValue(t, "global", "ratio")
+	num, ok := got.(json.Number)
+	if !ok || num.String() != "1.5" {
+		t.Errorf("stored = %v (%T), want json.Number(\"1.5\")", got, got)
+	}
+}
+
+func TestRunEnvSet_TypedBool(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"ENABLED", "true"}, "global", false, "bool"); err != nil {
+		t.Fatalf("runEnvSet: %v", err)
+	}
+	got := readStoredValue(t, "global", "ENABLED")
+	b, ok := got.(bool)
+	if !ok || !b {
+		t.Errorf("stored = %v (%T), want true (bool)", got, got)
+	}
+}
+
+func TestRunEnvSet_TypedJSON(t *testing.T) {
+	setupVaultProject(t)
+	if err := runEnvSet([]string{"config", `{"port":8000}`}, "global", false, "json"); err != nil {
+		t.Fatalf("runEnvSet: %v", err)
+	}
+	got := readStoredValue(t, "global", "config")
+	m, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("stored = %v (%T), want map[string]any", got, got)
+	}
+	num, ok := m["port"].(json.Number)
+	if !ok || num.String() != "8000" {
+		t.Errorf("config.port = %v (%T), want json.Number(\"8000\")", m["port"], m["port"])
+	}
+}
+
+func TestRunEnvSet_TypedStdin(t *testing.T) {
+	setupVaultProject(t)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := w.WriteString("42\n"); err != nil {
+		t.Fatalf("write pipe: %v", err)
+	}
+	_ = w.Close()
+
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = orig })
+
+	if err := runEnvSet([]string{"port"}, "global", true, "int"); err != nil {
+		t.Fatalf("runEnvSet: %v", err)
+	}
+
+	got := readStoredValue(t, "global", "port")
+	num, ok := got.(json.Number)
+	if !ok || num.String() != "42" {
+		t.Errorf("stored = %v, want json.Number(\"42\")", got)
+	}
+}
+
+func TestRunEnvSet_TypedInvalidValueAbortsBeforeStore(t *testing.T) {
+	setupVaultProject(t)
+	// Seed an existing value so we can verify it stays untouched.
+	if err := runEnvSet([]string{"port", "8000"}, "global", false, "int"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Reset with invalid int should error and not touch the stored value.
+	err := runEnvSet([]string{"port", "not-a-number"}, "global", false, "int")
+	if err == nil {
+		t.Fatal("expected error for invalid int, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid int") {
+		t.Errorf("error %q should mention 'invalid int'", err.Error())
+	}
+
+	got := readStoredValue(t, "global", "port")
+	num, ok := got.(json.Number)
+	if !ok || num.String() != "8000" {
+		t.Errorf("seed value mutated by failed set: got %v, want json.Number(\"8000\")", got)
+	}
+}
+
+func TestRunEnvSet_TypedUnknownTypeErrors(t *testing.T) {
+	setupVaultProject(t)
+	err := runEnvSet([]string{"K", "v"}, "global", false, "integer")
+	if err == nil {
+		t.Fatal("expected error for unknown type, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown type") {
+		t.Errorf("error %q should mention 'unknown type'", err.Error())
+	}
+}
+
+func TestRunEnvSet_DefaultTypeIsString(t *testing.T) {
+	setupVaultProject(t)
+	// Number-shaped string with no --type stays a string (backward compat).
+	if err := runEnvSet([]string{"token", "3939"}, "global", false, ""); err != nil {
+		t.Fatalf("runEnvSet: %v", err)
+	}
+	got := readStoredValue(t, "global", "token")
+	if s, ok := got.(string); !ok || s != "3939" {
+		t.Errorf("stored = %v (%T), want \"3939\" (string)", got, got)
+	}
+}

--- a/pkg/userFlags/env_crud_test.go
+++ b/pkg/userFlags/env_crud_test.go
@@ -135,7 +135,8 @@ func TestRunEnvGet_PrintsString(t *testing.T) {
 func TestRunEnvGet_PrintsNonString(t *testing.T) {
 	setupVaultProject(t)
 
-	// Seed non-string types via the store directly (CLI `set` always stores strings).
+	// Seed non-string types via the store directly to keep this test focused on
+	// runEnvGet's printing behavior independent of runEnvSet/--type.
 	if err := vault.WithStoreLock(func() error {
 		ageKey, _ := vault.EnsureKeypair()
 		store, _ := vault.ReadStore()

--- a/pkg/userFlags/env_edit_test.go
+++ b/pkg/userFlags/env_edit_test.go
@@ -31,7 +31,7 @@ func fakeEditor(t *testing.T, body string) string {
 
 func TestRunEnvEdit_NoChange(t *testing.T) {
 	setupVaultProject(t)
-	if err := runEnvSet([]string{"FOO", "bar"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"FOO", "bar"}, "global", false, ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
@@ -48,7 +48,7 @@ func TestRunEnvEdit_NoChange(t *testing.T) {
 
 func TestRunEnvEdit_EditorFailsNoWrite(t *testing.T) {
 	setupVaultProject(t)
-	if err := runEnvSet([]string{"FOO", "bar"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"FOO", "bar"}, "global", false, ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
@@ -68,7 +68,7 @@ func TestRunEnvEdit_EditorFailsNoWrite(t *testing.T) {
 
 func TestRunEnvEdit_SaveValidJSON(t *testing.T) {
 	setupVaultProject(t)
-	if err := runEnvSet([]string{"OLD", "v"}, "staging", false); err != nil {
+	if err := runEnvSet([]string{"OLD", "v"}, "staging", false, ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
@@ -85,7 +85,7 @@ func TestRunEnvEdit_SaveValidJSON(t *testing.T) {
 
 func TestRunEnvEdit_InvalidJSONPreservesStore(t *testing.T) {
 	setupVaultProject(t)
-	if err := runEnvSet([]string{"FOO", "bar"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"FOO", "bar"}, "global", false, ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
@@ -165,7 +165,7 @@ func TestRunEnvEdit_Errors(t *testing.T) {
 // hang waiting for keypress.
 func TestRunEnvEdit_NoDefaultGlobal(t *testing.T) {
 	setupVaultProject(t)
-	if err := runEnvSet([]string{"FOO", "bar"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"FOO", "bar"}, "global", false, ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
@@ -205,7 +205,7 @@ func TestRunEnvEdit_WholesaleReplacesEnv(t *testing.T) {
 	for _, kv := range [][2]string{
 		{"KEEP", "1"}, {"REMOVE_ME", "2"}, {"ALSO_REMOVE", "3"},
 	} {
-		if err := runEnvSet([]string{kv[0], kv[1]}, "global", false); err != nil {
+		if err := runEnvSet([]string{kv[0], kv[1]}, "global", false, ""); err != nil {
 			t.Fatalf("seed %s: %v", kv[0], err)
 		}
 	}
@@ -236,10 +236,10 @@ func TestRunEnvEdit_WholesaleReplacesEnv(t *testing.T) {
 // guarantee: replacing one env must not affect any other env in the store.
 func TestRunEnvEdit_LeavesOtherEnvsUntouched(t *testing.T) {
 	setupVaultProject(t)
-	if err := runEnvSet([]string{"P", "prod-value"}, "prod", false); err != nil {
+	if err := runEnvSet([]string{"P", "prod-value"}, "prod", false, ""); err != nil {
 		t.Fatalf("seed prod: %v", err)
 	}
-	if err := runEnvSet([]string{"S", "staging-value"}, "staging", false); err != nil {
+	if err := runEnvSet([]string{"S", "staging-value"}, "staging", false, ""); err != nil {
 		t.Fatalf("seed staging: %v", err)
 	}
 

--- a/pkg/userFlags/env_list_test.go
+++ b/pkg/userFlags/env_list_test.go
@@ -13,7 +13,7 @@ func TestRunEnvList_PrintsSortedNames(t *testing.T) {
 
 	// Seed: prod, global, staging — listing should sort alphabetically.
 	for _, env := range []string{"prod", "global", "staging"} {
-		if err := runEnvSet([]string{"K", "v"}, env, false); err != nil {
+		if err := runEnvSet([]string{"K", "v"}, env, false, ""); err != nil {
 			t.Fatalf("seed %s: %v", env, err)
 		}
 	}
@@ -69,7 +69,7 @@ func TestRunEnvList_TooManyArgs(t *testing.T) {
 
 func TestRunEnvKeys_MasksByDefault(t *testing.T) {
 	setupVaultProject(t)
-	if err := runEnvSet([]string{"API_KEY", "sk-123"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"API_KEY", "sk-123"}, "global", false, ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
@@ -93,7 +93,7 @@ func TestRunEnvKeys_MasksByDefault(t *testing.T) {
 
 func TestRunEnvKeys_ShowReveals(t *testing.T) {
 	setupVaultProject(t)
-	if err := runEnvSet([]string{"API_KEY", "sk-123"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"API_KEY", "sk-123"}, "global", false, ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
@@ -115,7 +115,7 @@ func TestRunEnvKeys_ShowReveals(t *testing.T) {
 func TestRunEnvKeys_SortsKeys(t *testing.T) {
 	setupVaultProject(t)
 	for _, k := range []string{"ZETA", "alpha", "MIDDLE"} {
-		if err := runEnvSet([]string{k, "v"}, "global", false); err != nil {
+		if err := runEnvSet([]string{k, "v"}, "global", false, ""); err != nil {
 			t.Fatalf("seed: %v", err)
 		}
 	}
@@ -148,7 +148,7 @@ func TestRunEnvKeys_SortsKeys(t *testing.T) {
 func TestRunEnvKeys_SearchSubstring(t *testing.T) {
 	setupVaultProject(t)
 	for _, k := range []string{"API_KEY", "DB_URL", "api_token", "TIMEOUT"} {
-		if err := runEnvSet([]string{k, "v"}, "global", false); err != nil {
+		if err := runEnvSet([]string{k, "v"}, "global", false, ""); err != nil {
 			t.Fatalf("seed: %v", err)
 		}
 	}
@@ -172,7 +172,7 @@ func TestRunEnvKeys_SearchSubstring(t *testing.T) {
 func TestRunEnvKeys_SearchGlob(t *testing.T) {
 	setupVaultProject(t)
 	for _, k := range []string{"API_KEY", "API_TOKEN", "DB_URL"} {
-		if err := runEnvSet([]string{k, "v"}, "global", false); err != nil {
+		if err := runEnvSet([]string{k, "v"}, "global", false, ""); err != nil {
 			t.Fatalf("seed: %v", err)
 		}
 	}
@@ -195,7 +195,7 @@ func TestRunEnvKeys_SearchGlob(t *testing.T) {
 
 func TestRunEnvKeys_SearchNoMatches(t *testing.T) {
 	setupVaultProject(t)
-	if err := runEnvSet([]string{"API_KEY", "v"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"API_KEY", "v"}, "global", false, ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
@@ -228,7 +228,7 @@ func TestRunEnvKeys_Errors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			setupVaultProject(t)
-			if err := runEnvSet([]string{"K", "v"}, "global", false); err != nil {
+			if err := runEnvSet([]string{"K", "v"}, "global", false, ""); err != nil {
 				t.Fatalf("seed: %v", err)
 			}
 
@@ -289,10 +289,10 @@ func TestFormatTableValue_EscapesControlChars(t *testing.T) {
 // We render two rows; both must appear on their own line, in order.
 func TestRunEnvKeys_AlignsValuesContainingControlChars(t *testing.T) {
 	setupVaultProject(t)
-	if err := runEnvSet([]string{"FIRST", "value\rwith-cr"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"FIRST", "value\rwith-cr"}, "global", false, ""); err != nil {
 		t.Fatalf("seed FIRST: %v", err)
 	}
-	if err := runEnvSet([]string{"SECOND", "plain"}, "global", false); err != nil {
+	if err := runEnvSet([]string{"SECOND", "plain"}, "global", false, ""); err != nil {
 		t.Fatalf("seed SECOND: %v", err)
 	}
 

--- a/pkg/yamlparser/apiTypes.go
+++ b/pkg/yamlparser/apiTypes.go
@@ -324,7 +324,10 @@ func processVariable(v any) (any, error) {
 	}
 
 	switch val := v.(type) {
-	case string, bool, int, int32, int64, float32, float64:
+	case string, bool,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
 		// Basic types can be used as-is
 		return val, nil
 

--- a/pkg/yamlparser/apiTypes_test.go
+++ b/pkg/yamlparser/apiTypes_test.go
@@ -263,3 +263,27 @@ func TestEncodeBody(t *testing.T) {
 		})
 	}
 }
+
+func TestProcessVariable_PreservesUintFamily(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   any
+	}{
+		{"uint", uint(3939)},
+		{"uint8", uint8(42)},
+		{"uint16", uint16(8000)},
+		{"uint32", uint32(70000)},
+		{"uint64", uint64(3939)},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := processVariable(tc.in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.in {
+				t.Errorf("got %v (%T), want %v (%T)", got, got, tc.in, tc.in)
+			}
+		})
+	}
+}

--- a/pkg/yamlparser/translateTypes.go
+++ b/pkg/yamlparser/translateTypes.go
@@ -1,12 +1,32 @@
 package yamlparser
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/xaaha/hulak/pkg/utils"
 )
+
+// normalizeNumber converts a json.Number to a concrete int64/float64 so the
+// downstream yaml encoder emits it as a number instead of a quoted string.
+// Vault store decodes numbers with json.Number to preserve int/float
+// distinction, but goccy/go-yaml marshals json.Number (a string under the
+// hood) as "3939" rather than 3939, which breaks GraphQL Int variables.
+func normalizeNumber(v any) any {
+	num, ok := v.(json.Number)
+	if !ok {
+		return v
+	}
+	if i, err := num.Int64(); err == nil {
+		return i
+	}
+	if f, err := num.Float64(); err == nil {
+		return f
+	}
+	return v
+}
 
 type actionType string
 
@@ -165,6 +185,7 @@ func setValueOnAfterMap(
 	afterMap map[string]any,
 	replaceWith any,
 ) map[string]any {
+	replaceWith = normalizeNumber(replaceWith)
 	var current any = afterMap
 
 	for i, value := range path {

--- a/pkg/yamlparser/translateTypes.go
+++ b/pkg/yamlparser/translateTypes.go
@@ -9,23 +9,41 @@ import (
 	"github.com/xaaha/hulak/pkg/utils"
 )
 
-// normalizeNumber converts a json.Number to a concrete int64/float64 so the
-// downstream yaml encoder emits it as a number instead of a quoted string.
-// Vault store decodes numbers with json.Number to preserve int/float
+// normalizeNumber converts json.Number values to concrete int64/float64 so
+// the downstream yaml encoder emits them as numbers instead of quoted
+// strings. Vault store decodes numbers with json.Number to preserve int/float
 // distinction, but goccy/go-yaml marshals json.Number (a string under the
 // hood) as "3939" rather than 3939, which breaks GraphQL Int variables.
+//
+// Recurses into map[string]any and []any so json.Number nested inside a
+// `--type json` secret (e.g. {"port": 8000}) is also converted before it
+// reaches the yaml encoder. Maps and slices are rebuilt rather than mutated
+// in place so the caller's input is not modified.
 func normalizeNumber(v any) any {
-	num, ok := v.(json.Number)
-	if !ok {
+	switch val := v.(type) {
+	case json.Number:
+		if i, err := val.Int64(); err == nil {
+			return i
+		}
+		if f, err := val.Float64(); err == nil {
+			return f
+		}
+		return v
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, item := range val {
+			out[k] = normalizeNumber(item)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, item := range val {
+			out[i] = normalizeNumber(item)
+		}
+		return out
+	default:
 		return v
 	}
-	if i, err := num.Int64(); err == nil {
-		return i
-	}
-	if f, err := num.Float64(); err == nil {
-		return f
-	}
-	return v
 }
 
 type actionType string

--- a/pkg/yamlparser/translateTypes_test.go
+++ b/pkg/yamlparser/translateTypes_test.go
@@ -498,6 +498,26 @@ func TestSetValueOnAfterMap(t *testing.T) {
 			replaceWith: json.Number("300.12"),
 			expected:    map[string]any{"height": float64(300.12)},
 		},
+		{
+			// Real flow: yaml `{{.cfg}}` templates a map into its fmt repr.
+			// swapValue compares that repr to fmt.Sprintf(replaceWith); if equal,
+			// the normalized replaceWith lands in afterMap.
+			name:     "nested json.Number in map normalizes when swap triggers",
+			afterMap: map[string]any{"cfg": "map[active:true name:svc port:8000]"},
+			path:     []any{"cfg"},
+			replaceWith: map[string]any{
+				"port":   json.Number("8000"),
+				"name":   "svc",
+				"active": true,
+			},
+			expected: map[string]any{
+				"cfg": map[string]any{
+					"port":   int64(8000),
+					"name":   "svc",
+					"active": true,
+				},
+			},
+		},
 	}
 
 	for _, tt := range testCases {
@@ -512,6 +532,90 @@ func TestSetValueOnAfterMap(t *testing.T) {
 				resStr,
 			)
 		}
+	}
+}
+
+func TestNormalizeNumber(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   any
+		want any
+	}{
+		{
+			name: "top-level int json.Number",
+			in:   json.Number("3939"),
+			want: int64(3939),
+		},
+		{
+			name: "top-level float json.Number",
+			in:   json.Number("1.5"),
+			want: float64(1.5),
+		},
+		{
+			name: "plain string untouched",
+			in:   "hello",
+			want: "hello",
+		},
+		{
+			name: "plain bool untouched",
+			in:   true,
+			want: true,
+		},
+		{
+			name: "nil untouched",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "nested json.Number in map",
+			in: map[string]any{
+				"port":  json.Number("8000"),
+				"ratio": json.Number("1.5"),
+				"name":  "svc",
+			},
+			want: map[string]any{
+				"port":  int64(8000),
+				"ratio": float64(1.5),
+				"name":  "svc",
+			},
+		},
+		{
+			name: "nested json.Number in slice",
+			in:   []any{json.Number("80"), json.Number("443"), "alpha"},
+			want: []any{int64(80), int64(443), "alpha"},
+		},
+		{
+			name: "deeply nested map/slice/map",
+			in: map[string]any{
+				"inner": []any{
+					map[string]any{"n": json.Number("42")},
+				},
+			},
+			want: map[string]any{
+				"inner": []any{
+					map[string]any{"n": int64(42)},
+				},
+			},
+		},
+		{
+			name: "empty map untouched",
+			in:   map[string]any{},
+			want: map[string]any{},
+		},
+		{
+			name: "empty slice untouched",
+			in:   []any{},
+			want: []any{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeNumber(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("normalizeNumber(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/pkg/yamlparser/translateTypes_test.go
+++ b/pkg/yamlparser/translateTypes_test.go
@@ -1,6 +1,7 @@
 package yamlparser
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -482,6 +483,20 @@ func TestSetValueOnAfterMap(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name:        "json.Number int normalizes to int64",
+			afterMap:    map[string]any{"age": "3939"},
+			path:        []any{"age"},
+			replaceWith: json.Number("3939"),
+			expected:    map[string]any{"age": int64(3939)},
+		},
+		{
+			name:        "json.Number float normalizes to float64",
+			afterMap:    map[string]any{"height": "300.12"},
+			path:        []any{"height"},
+			replaceWith: json.Number("300.12"),
+			expected:    map[string]any{"height": float64(300.12)},
 		},
 	}
 


### PR DESCRIPTION
- Adds tests and supports all types that json supports for the Graphql Handling

## What changed

### Bug fix: GraphQL Int variables sent as strings
- `goccy/go-yaml` marshals `json.Number` as a quoted string during the yaml roundtrip in `checkYamlFile`, so vault-stored ints reached GraphQL as `"3939"` instead of `3939`
- `normalizeNumber` converts `json.Number` to concrete `int64`/`float64` at the entry of `setValueOnAfterMap`
- Recurses into `map[string]any` and `[]any` so nested numbers inside `--type json` values are also normalized
- `processVariable` in `apiTypes.go` now accepts the full `int8`/`uint`/`uint8`/`uint16`/`uint32`/`uint64` family (yaml decode produces `uint64`, previously fell into the default branch that double-marshaled to `float64`)

### Feature: `hulak secrets set --type`
- New `--type` / `-t` flag on `secrets set`: `string|int|float|bool|json` (default `string`, backward compatible)
- `parseTypedValue` validates strictly: `ParseInt`/`ParseFloat`/`ParseBool` for scalars, `json.Decoder` with `UseNumber()` for json
- Strict json mode rejects trailing data after the value (e.g. `{"a":1}garbage`) while still accepting trailing whitespace
- Parse failure aborts before the vault lock so a bad invocation never opens the store
- Applies uniformly to positional, `--stdin`, and interactive prompt input
- `int`/`float` stored as `json.Number` to match the vault decoder's `UseNumber()` shape — write-then-read is a no-op
- `--type` surfaces automatically in `hulak secrets set -h` via the existing alias map and `printFlags`
- 3 new examples in the command help (`--type int`, `--type bool`, `--type json`)

## Tests added
- `TestParseTypedValue_*` — 11 functions covering each type happy path, invalid value, unknown type, default-empty-type, json trailing-data, and json trailing-whitespace
- `TestRunEnvSet_Typed*` — 8 integration tests asserting the vault stores the expected typed shape for each `--type`, that invalid values abort before the store lock, and that the no-flag path stays string for backward compat
- `TestEnvSetCmd_FlagWiring` — exercises `newEnvSetCmd()` → `Flags.Parse` → `Run` to lock in the `-t`/`--type` alias wiring (verified to detect regression)
- `TestNormalizeNumber` — 9 sub-tests covering top-level scalars, untouched primitives, nested map, nested slice, deeply nested map→slice→map, and empty containers
- `TestSetValueOnAfterMap` — new sub-cases for `json.Number` int and float normalization, plus a nested map normalization case with a realistic post-template placeholder
- `TestProcessVariable_PreservesUintFamily` — covers all five uint widths

## Manual verification
- `go run . secrets set userAge 3939 --type int` then `go run . secrets get userAge` prints `3939` (no quotes)
- `go run . run e2etests/test_collection/graphql.hk.yml --debug -env global` request body now sends `"variables":{"age":3939,...}` (number) and the server returns `200 OK` instead of the previous `400 Int cannot represent non-integer value: "3939"`

## Backward compatibility
- Omitting `--type` keeps storing strings — existing scripts behave identically
- Existing string values in vaults are untouched; user reruns `set --type` only if they want to upgrade a key
- `secrets get` already handled non-strings via `printValue` (strings raw, others JSON-encoded), so typed values round-trip cleanly