### PR TITLE
Foundation: save and print response body only by default

### DIFF
--- a/pkg/apiCalls/apicalls.go
+++ b/pkg/apiCalls/apicalls.go
@@ -108,7 +108,7 @@ func SendAndSaveAPIRequest(ctx context.Context, secretsMap map[string]any, path 
 		return nil, "", err
 	}
 
-	respBytes, saveErr := SerializeAndSaveResp(resp, path)
+	respBytes, saveErr := SerializeAndSaveResp(&resp, path)
 	status := ""
 	if resp.Response != nil {
 		status = resp.Response.Status
@@ -120,7 +120,7 @@ func SendAndSaveAPIRequest(ctx context.Context, secretsMap map[string]any, path 
 // disk next to the request file. Returns an error if the disk write fails so
 // the caller can fail the task. A successful HTTP request with a missing
 // response file should not look like a success to the user.
-func PrintAndSaveFinalResp(resp CustomResponse, path string) error {
+func PrintAndSaveFinalResp(resp *CustomResponse, path string) error {
 	respBytes, saveErr := SerializeAndSaveResp(resp, path)
 	if respBytes != nil {
 		PrintRespBytes(respBytes)
@@ -128,20 +128,45 @@ func PrintAndSaveFinalResp(resp CustomResponse, path string) error {
 	return saveErr
 }
 
-// SerializeAndSaveResp serializes the response, saves it to disk next to the
-// request file, and returns the serialized bytes. It does NOT print to
-// stdout. Use this when the caller needs to defer printing (e.g. when the
-// response will be printed after a stderr spinner clears).
-func SerializeAndSaveResp(resp CustomResponse, path string) ([]byte, error) {
-	jsonData, err := json.MarshalIndent(resp, "", "  ")
-	if err != nil {
-		utils.PrintWarningStderr("serializing response: " + err.Error())
-		// Fallback so the disk write still has something useful.
-		strBody := fmt.Sprintf("%+v", resp)
-		return []byte(strBody), evalAndWriteRes(strBody, resp.contentType, path)
+// SerializeAndSaveResp writes the response to disk next to the request
+// file and returns the bytes. Does not print.
+//
+// Default: raw response body (JSON pretty-printed, others byte-perfect).
+// --debug: full CustomResponse (request, response, http_info, duration).
+func SerializeAndSaveResp(resp *CustomResponse, path string) ([]byte, error) {
+	if resp.isDebug() {
+		jsonData, err := json.MarshalIndent(resp, "", "  ")
+		if err != nil {
+			utils.PrintWarningStderr("serializing response: " + err.Error())
+			// Fallback so the disk write still has something useful.
+			strBody := fmt.Sprintf("%+v", resp)
+			return []byte(strBody), evalAndWriteRes(strBody, resp.contentType, path)
+		}
+		strBody := string(jsonData)
+		return jsonData, evalAndWriteRes(strBody, resp.contentType, path)
 	}
-	strBody := string(jsonData)
-	return jsonData, evalAndWriteRes(strBody, resp.contentType, path)
+
+	body := defaultBodyForOutput(resp.rawBody)
+	return body, evalAndWriteRes(string(body), resp.contentType, path)
+}
+
+// defaultBodyForOutput returns the bytes used for default-mode save and
+// print: raw bytes verbatim, but pretty-printed when the payload is valid
+// JSON so the on-disk file is readable. Falls back to the original bytes
+// when json.Indent fails so non-JSON content (HTML, XML, plain text, binary)
+// is preserved exactly.
+func defaultBodyForOutput(raw []byte) []byte {
+	if len(raw) == 0 {
+		return raw
+	}
+	if !IsJSON(string(raw)) {
+		return raw
+	}
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, raw, "", "  "); err != nil {
+		return raw
+	}
+	return pretty.Bytes()
 }
 
 // PrintRespBytes prints serialized response JSON to stdout, colored when

--- a/pkg/apiCalls/apicalls.go
+++ b/pkg/apiCalls/apicalls.go
@@ -147,6 +147,10 @@ func SerializeAndSaveResp(resp *CustomResponse, path string) ([]byte, error) {
 	}
 
 	body := defaultBodyForOutput(resp.rawBody)
+	if len(body) == 0 {
+		// 204 No Content and friends: nothing to print or save.
+		return body, nil
+	}
 	return body, evalAndWriteRes(string(body), resp.contentType, path)
 }
 

--- a/pkg/apiCalls/apicalls_test.go
+++ b/pkg/apiCalls/apicalls_test.go
@@ -691,6 +691,37 @@ func TestSerializeAndSaveResp_Default(t *testing.T) {
 	}
 }
 
+// TestSerializeAndSaveResp_EmptyBody verifies that an empty response body
+// (HTTP 204 No Content and similar) does not error and writes no file.
+func TestSerializeAndSaveResp_EmptyBody(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := dir + "/req.hk.yaml"
+	resp := &CustomResponse{
+		Response:    &ResponseInfo{StatusCode: 204, Status: "204 No Content"},
+		Duration:    "1.00ms",
+		contentType: "",
+		rawBody:     []byte{},
+	}
+	bytesOut, err := SerializeAndSaveResp(resp, inputPath)
+	if err != nil {
+		t.Fatalf("empty body should not error, got: %v", err)
+	}
+	if len(bytesOut) != 0 {
+		t.Errorf("expected zero-length bytes, got %d: %q", len(bytesOut), bytesOut)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading temp dir: %v", err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected no files written for empty body, found: %v", names)
+	}
+}
+
 // TestSerializeAndSaveResp_Debug verifies --debug mode preserves the full
 // wrapped CustomResponse shape (request, response, http_info, duration).
 func TestSerializeAndSaveResp_Debug(t *testing.T) {

--- a/pkg/apiCalls/apicalls_test.go
+++ b/pkg/apiCalls/apicalls_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -536,4 +537,203 @@ func TestMockServerWithHandler(t *testing.T) {
 	if resp2.StatusCode != 201 {
 		t.Errorf("POST: expected 201, got %d", resp2.StatusCode)
 	}
+}
+
+func TestIsDebug(t *testing.T) {
+	tests := []struct {
+		name string
+		resp CustomResponse
+		want bool
+	}{
+		{"nil Request is default mode", CustomResponse{}, false},
+		{"set Request is debug mode", CustomResponse{Request: &RequestInfo{Method: "GET"}}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.resp.isDebug(); got != tc.want {
+				t.Errorf("isDebug() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultBodyForOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want []byte
+	}{
+		{
+			name: "empty input returned as-is",
+			in:   []byte{},
+			want: []byte{},
+		},
+		{
+			name: "nil input returned as-is",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "valid JSON pretty-printed",
+			in:   []byte(`{"a":1,"b":{"c":2}}`),
+			want: []byte("{\n  \"a\": 1,\n  \"b\": {\n    \"c\": 2\n  }\n}"),
+		},
+		{
+			name: "already-formatted JSON re-indented to two spaces",
+			in:   []byte("{\n    \"a\": 1\n}"),
+			want: []byte("{\n  \"a\": 1\n}"),
+		},
+		{
+			name: "HTML preserved byte-perfect",
+			in:   []byte("<!DOCTYPE html><html><body>x</body></html>"),
+			want: []byte("<!DOCTYPE html><html><body>x</body></html>"),
+		},
+		{
+			name: "XML preserved byte-perfect",
+			in:   []byte("<root><k>v</k></root>"),
+			want: []byte("<root><k>v</k></root>"),
+		},
+		{
+			name: "plain text preserved byte-perfect",
+			in:   []byte("hello world\nline two"),
+			want: []byte("hello world\nline two"),
+		},
+		{
+			name: "malformed JSON returned as-is (fallback path)",
+			in:   []byte(`{"a": 1,`),
+			want: []byte(`{"a": 1,`),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := defaultBodyForOutput(tc.in)
+			if !bytes.Equal(got, tc.want) {
+				t.Errorf("defaultBodyForOutput()\n  got:  %q\n  want: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSerializeAndSaveResp_Default verifies that default mode writes only
+// the response body — no request/duration/http_info wrapper. JSON bodies
+// are pretty-printed, non-JSON content is preserved byte-perfect.
+func TestSerializeAndSaveResp_Default(t *testing.T) {
+	tests := []struct {
+		name        string
+		rawBody     []byte
+		contentType string
+		wantOnDisk  string
+		wantExt     string
+	}{
+		{
+			name:        "JSON body is pretty-printed",
+			rawBody:     []byte(`{"data":{"id":42}}`),
+			contentType: "application/json",
+			wantOnDisk:  "{\n  \"data\": {\n    \"id\": 42\n  }\n}",
+			wantExt:     ".json",
+		},
+		{
+			name:        "HTML body kept byte-perfect",
+			rawBody:     []byte("<!DOCTYPE html><html><body>ok</body></html>"),
+			contentType: "text/html",
+			wantOnDisk:  "<!DOCTYPE html><html><body>ok</body></html>",
+			wantExt:     ".html",
+		},
+		{
+			name:        "XML body kept byte-perfect",
+			rawBody:     []byte("<root><k>v</k></root>"),
+			contentType: "application/xml",
+			wantOnDisk:  "<root><k>v</k></root>",
+			wantExt:     ".xml",
+		},
+		{
+			name:        "plain text body kept byte-perfect",
+			rawBody:     []byte("plain text response"),
+			contentType: "text/plain",
+			wantOnDisk:  "plain text response",
+			wantExt:     ".txt",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			// Path the runner passes is a yaml-like input; evalAndWriteRes
+			// strips the trailing extension and appends the resolved one.
+			inputPath := dir + "/req.hk.yaml"
+			resp := &CustomResponse{
+				Response:    &ResponseInfo{StatusCode: 200, Status: "200 OK"},
+				Duration:    "10.00ms",
+				contentType: tc.contentType,
+				rawBody:     tc.rawBody,
+			}
+			bytesOut, err := SerializeAndSaveResp(resp, inputPath)
+			if err != nil {
+				t.Fatalf("SerializeAndSaveResp returned error: %v", err)
+			}
+			if string(bytesOut) != tc.wantOnDisk {
+				t.Errorf("returned bytes mismatch\n  got:  %q\n  want: %q", bytesOut, tc.wantOnDisk)
+			}
+			// The wrapper keys must NOT appear in default mode output.
+			for _, leak := range []string{`"response"`, `"duration"`, `"status_code"`, `"http_info"`, `"request"`} {
+				if strings.Contains(string(bytesOut), leak) {
+					t.Errorf("default-mode bytes contain wrapper key %s: %s", leak, bytesOut)
+				}
+			}
+			diskPath := dir + "/req.hk_response" + tc.wantExt
+			onDisk, readErr := readFile(t, diskPath)
+			if readErr != nil {
+				t.Fatalf("reading saved file %s: %v", diskPath, readErr)
+			}
+			if onDisk != tc.wantOnDisk {
+				t.Errorf("on-disk content mismatch\n  got:  %q\n  want: %q", onDisk, tc.wantOnDisk)
+			}
+		})
+	}
+}
+
+// TestSerializeAndSaveResp_Debug verifies --debug mode preserves the full
+// wrapped CustomResponse shape (request, response, http_info, duration).
+func TestSerializeAndSaveResp_Debug(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := dir + "/req.hk.yaml"
+	resp := &CustomResponse{
+		Request: &RequestInfo{
+			Method: "POST",
+			URL:    "https://example.com/api",
+		},
+		Response: &ResponseInfo{
+			StatusCode: 200,
+			Status:     "200 OK",
+			Body:       map[string]any{"ok": true},
+		},
+		HTTPInfo:    &HTTPInfo{Protocol: "HTTP/1.1"},
+		Duration:    "12.34ms",
+		contentType: "application/json",
+		rawBody:     []byte(`{"ok":true}`),
+	}
+	bytesOut, err := SerializeAndSaveResp(resp, inputPath)
+	if err != nil {
+		t.Fatalf("SerializeAndSaveResp returned error: %v", err)
+	}
+	// Wrapped output must include the metadata keys.
+	for _, want := range []string{`"request"`, `"response"`, `"http_info"`, `"duration"`} {
+		if !strings.Contains(string(bytesOut), want) {
+			t.Errorf("debug bytes missing wrapper key %s\n  got: %s", want, bytesOut)
+		}
+	}
+	// Parse to confirm the saved JSON is structurally well-formed.
+	var roundTrip map[string]any
+	if err := json.Unmarshal(bytesOut, &roundTrip); err != nil {
+		t.Fatalf("debug bytes are not valid JSON: %v", err)
+	}
+	if _, ok := roundTrip["request"]; !ok {
+		t.Error("debug JSON missing request key")
+	}
+}
+
+// readFile is a small test helper.
+func readFile(t *testing.T, path string) (string, error) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	return string(b), err
 }

--- a/pkg/apiCalls/prepare.go
+++ b/pkg/apiCalls/prepare.go
@@ -62,7 +62,11 @@ func processResponse(
 	contentType := resp.Header.Get("Content-Type")
 
 	if !debug {
-		// Return minimal set of data
+		// Return minimal set of data. rawBody is what the file writer
+		// and stdout printer actually emit in default mode; the wrapped
+		// Response/Duration fields stay populated so downstream callers
+		// (runner outcome line) can still read status without re-parsing.
+		// Request stays nil — isDebug() reads that as "default mode".
 		return CustomResponse{
 			Response: &ResponseInfo{
 				StatusCode: resp.StatusCode,
@@ -71,6 +75,7 @@ func processResponse(
 			},
 			Duration:    durationFormatted,
 			contentType: contentType,
+			rawBody:     respBody,
 		}, nil
 	}
 
@@ -126,6 +131,7 @@ func processResponse(
 		HTTPInfo:    &tlsInfo,
 		Duration:    durationFormatted,
 		contentType: contentType,
+		rawBody:     respBody,
 	}, nil
 }
 

--- a/pkg/apiCalls/types.go
+++ b/pkg/apiCalls/types.go
@@ -12,6 +12,20 @@ type CustomResponse struct {
 	// file can use the right extension (#208). Unexported so it doesn't
 	// leak into the JSON output users see — encoding/json skips it.
 	contentType string
+
+	// rawBody is the exact bytes returned by the server. Used in default
+	// (non-debug) mode so saved files and stdout output match what the
+	// server sent, byte-for-byte for non-JSON content and pretty-printed
+	// for JSON. Unexported — JSON encoder ignores it.
+	rawBody []byte
+}
+
+// isDebug reports whether this response was built in debug mode.
+// processResponse only sets Request when --debug is on, so its presence
+// is a reliable signal. A dedicated bool field would push the struct
+// over the lint size threshold for pass-by-value.
+func (r *CustomResponse) isDebug() bool {
+	return r.Request != nil
 }
 
 // RequestInfo has all the information about the  request body

--- a/pkg/features/auth20.go
+++ b/pkg/features/auth20.go
@@ -138,7 +138,7 @@ func SendAPIRequestForAuth2(ctx context.Context, secretsMap map[string]any, file
 	if err != nil {
 		return err
 	}
-	return apicalls.PrintAndSaveFinalResp(resp, filePath)
+	return apicalls.PrintAndSaveFinalResp(&resp, filePath)
 }
 
 // isWSL checks if the Go program is running inside Windows Subsystem for Linux

--- a/pkg/tui/gqlexplorer/formitem.go
+++ b/pkg/tui/gqlexplorer/formitem.go
@@ -155,10 +155,11 @@ func (f *formItem) View() string {
 			for i, line := range strings.Split(inputBox, "\n") {
 				b.WriteString("\n")
 				if i == 0 {
-					b.WriteString(connector + line)
+					b.WriteString(connector)
 				} else {
-					b.WriteString(continuePad + line)
+					b.WriteString(continuePad)
 				}
+				b.WriteString(line)
 			}
 			return strings.TrimPrefix(b.String(), "\n")
 		}
@@ -178,10 +179,11 @@ func (f *formItem) View() string {
 		for i, line := range strings.Split(inputBox, "\n") {
 			b.WriteString("\n")
 			if i == 0 {
-				b.WriteString(connector + line)
+				b.WriteString(connector)
 			} else {
-				b.WriteString(continuePad + line)
+				b.WriteString(continuePad)
 			}
+			b.WriteString(line)
 		}
 		return b.String()
 	case formItemDropdown:

--- a/pkg/tui/gqlexplorer/model.go
+++ b/pkg/tui/gqlexplorer/model.go
@@ -375,7 +375,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case queryExecutedMsg:
 		m.executing = false
 		m.updateActionRow()
-		m.handleQueryExecuted(msg)
+		m.handleQueryExecuted(&msg)
 		return m, nil
 	case queryErrorMsg:
 		m.executing = false
@@ -1088,7 +1088,7 @@ func (m *Model) restoreResponseFromCache(formKey string) {
 	m.responsePanel.Footer = ""
 }
 
-func (m *Model) handleQueryExecuted(msg queryExecutedMsg) {
+func (m *Model) handleQueryExecuted(msg *queryExecutedMsg) {
 	var bodyJSON []byte
 	if msg.resp.Response != nil && msg.resp.Response.Body != nil {
 		bodyJSON, _ = json.MarshalIndent(msg.resp.Response.Body, "", "  ")

--- a/pkg/tui/gqlexplorer/render.go
+++ b/pkg/tui/gqlexplorer/render.go
@@ -64,7 +64,8 @@ func (m *Model) renderList() (string, int) {
 			if focused {
 				row.WriteString(tui.SubtitleStyle.Render(selectedPrefix + op.Name))
 			} else {
-				row.WriteString(selectedPrefix + op.Name)
+				row.WriteString(selectedPrefix)
+				row.WriteString(op.Name)
 			}
 			wrapW := max(m.leftPanelWidth()-detailPadding, 1)
 			for _, text := range []string{op.Description, op.Endpoint} {


### PR DESCRIPTION
Closes #226.

## Changes
- Default save and stdout now write the raw response body. JSON is pretty-printed; HTML, XML, plain text, and other content stay byte-perfect.
- `--debug` retains the current wrapped shape (request, response, http_info, duration). No behavior change for debug consumers.
- Empty response body (HTTP 204 and similar) no longer errors; returns zero bytes, writes no file.
- `CustomResponse` gained an unexported `rawBody []byte` and an `isDebug()` method (`Request != nil` heuristic). Avoids growing the struct past the lint pass-by-value threshold.
- `SerializeAndSaveResp` and `PrintAndSaveFinalResp` now take `*CustomResponse`. Callers in `apicalls`, `features/auth20`, and `tui/gqlexplorer` updated accordingly.
- Fixed two pre-existing `writestring` lint warnings in `tui/gqlexplorer/formitem.go` and `tui/gqlexplorer/render.go` so the linter stays at 0.

## Tests
- `TestIsDebug` — Request nil/set drives the heuristic.
- `TestDefaultBodyForOutput` — empty, nil, JSON pretty-printed, already-indented JSON re-indented to two spaces, HTML/XML/plain text preserved, malformed JSON falls back to raw.
- `TestSerializeAndSaveResp_Default` — JSON/HTML/XML/plain disk content + returned bytes match; wrapper keys do not leak.
- `TestSerializeAndSaveResp_Debug` — wrapper keys present, output is valid JSON.
- `TestSerializeAndSaveResp_EmptyBody` — no error, zero bytes, no file written.

## Verification
- `mise run check` — lint 0 issues, all packages green.

## Test plan
- [ ] `hulak run e2etests/test_collection/graphql.hk.yml` — saved file is the raw response body, not the wrapper.
- [ ] `hulak run e2etests/test_collection/graphql.hk.yml --debug` — saved file is the wrapped CustomResponse shape.
- [ ] Run something returning 204 — no error, no `_response.json` file created.