### PR TITLE
don't pick global as default for the user

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -257,7 +257,7 @@ Read the full guide in [graphql-explorer.md](./graphql-explorer.md).
 Manage environment secrets stored in the encrypted vault (.hulak/store.age).
 
 Secrets are organized by environment (e.g. global, staging, prod).
-The default environment is "global" unless --env is specified.
+When --env is omitted, you'll be prompted to pick an environment interactively.
 
 'env' is retained as an alias for backward compatibility with pre-0.3 docs. See [docs/store.md](./store.md) for the full encryption model and team-sharing flows.
 

--- a/main.go
+++ b/main.go
@@ -92,12 +92,12 @@ func runInteractiveFlow(env *string, envSet bool) string {
 		return selectedFile
 	}
 
-	selectedEnv, err := envselect.RunEnvSelector()
+	selectedEnv, cancelled, err := envselect.RunEnvSelector()
 	if err != nil {
 		utils.PanicRedAndExit("%v", err)
 	}
 
-	if selectedEnv == "" {
+	if cancelled {
 		os.Exit(0)
 	}
 

--- a/man/hulak.1
+++ b/man/hulak.1
@@ -125,7 +125,7 @@ Directory path to run in alphabetical order
 Print the built request and exit without sending it
 .TP
 .B \-\-env, \-\-environment <string>
-Environment file to use during the call
+Environment to use (omit to pick interactively)
 .TP
 .B \-\-f, \-\-file <string>
 File name for making an API request (case\-insensitive)

--- a/pkg/features/graphql/graphql.go
+++ b/pkg/features/graphql/graphql.go
@@ -144,11 +144,11 @@ func loadSecretsForEnv(env string) (map[string]any, string, error) {
 
 	// If no env provided, show the interactive selector
 	if selectedEnv == "" {
-		picked, err := envselect.RunEnvSelector()
+		picked, cancelled, err := envselect.RunEnvSelector()
 		if err != nil {
 			return nil, "", fmt.Errorf("environment selector: %w", err)
 		}
-		if picked == "" {
+		if cancelled {
 			return nil, "", nil
 		}
 		selectedEnv = picked

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -119,14 +119,14 @@ func Execute(f *Flags) error {
 			return fmt.Errorf("not a hulak project — run 'hulak init' to set up")
 		}
 		if !f.EnvSet {
-			selectedEnv, err := envSelector()
+			picked, cancelled, err := envSelector()
 			if err != nil {
 				return fmt.Errorf("environment selector: %w", err)
 			}
-			if selectedEnv == "" {
-				return nil // user cancelled the picker; not an error
+			if cancelled {
+				return nil
 			}
-			f.Env = selectedEnv
+			f.Env = picked
 		}
 		var err error
 		envMap, err = InitializeProject(f.Env, true)

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -176,9 +176,9 @@ func TestExecute_EnvNotSet_CallsSelector(t *testing.T) {
 	defer func() { envSelector = orig }()
 
 	called := false
-	envSelector = func() (string, error) {
+	envSelector = func() (string, bool, error) {
 		called = true
-		return "picked-env", nil
+		return "picked-env", false, nil
 	}
 
 	// File with template vars
@@ -210,9 +210,9 @@ func TestExecute_EnvSet_SkipsSelector(t *testing.T) {
 	defer func() { envSelector = orig }()
 
 	called := false
-	envSelector = func() (string, error) {
+	envSelector = func() (string, bool, error) {
 		called = true
-		return "should-not-be-used", nil
+		return "should-not-be-used", false, nil
 	}
 
 	// File with template vars
@@ -242,9 +242,9 @@ func TestExecute_NoTemplateVars_SkipsSelector(t *testing.T) {
 	defer func() { envSelector = orig }()
 
 	called := false
-	envSelector = func() (string, error) {
+	envSelector = func() (string, bool, error) {
 		called = true
-		return "should-not-be-used", nil
+		return "should-not-be-used", false, nil
 	}
 
 	// File WITHOUT template vars

--- a/pkg/tui/envselect/envselect.go
+++ b/pkg/tui/envselect/envselect.go
@@ -1,8 +1,12 @@
 package envselect
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"strings"
+
+	"golang.org/x/term"
 
 	"github.com/xaaha/hulak/pkg/tui"
 	"github.com/xaaha/hulak/pkg/utils"
@@ -75,10 +79,23 @@ func envItems() ([]string, error) {
 // RunEnvSelector runs the environment selector and returns the selected environment.
 // Surfaces vault-layer errors verbatim so the user sees the actual problem
 // (e.g. "identity file is corrupt") instead of an empty selector.
+//
+// When stdin is not a terminal (CI, cron, piped input), the selector refuses
+// to launch and returns an actionable error. Without this guard, bubbletea
+// would silently fall back to /dev/tty — which in CI with a PTY hangs forever
+// waiting for keypress, and in detached contexts surfaces a cryptic
+// "could not open a new TTY" error. The check is gated on having items to
+// show so that the more helpful "no envs configured" error still wins when
+// the store is empty.
 func RunEnvSelector() (string, error) {
 	items, err := envItems()
 	if err != nil {
 		return "", err
+	}
+	if len(items) > 0 && !term.IsTerminal(int(os.Stdin.Fd())) { //nolint:gosec // G115 fd is small non-neg
+		return "", errors.New(
+			"no --env provided and stdin is not a terminal — pass --env <name> to skip the picker",
+		)
 	}
 	return tui.RunSelector(items, "Select Environment: ", noEnvFilesError())
 }

--- a/pkg/tui/envselect/envselect.go
+++ b/pkg/tui/envselect/envselect.go
@@ -76,9 +76,15 @@ func envItems() ([]string, error) {
 	return items, nil
 }
 
-// RunEnvSelector runs the environment selector and returns the selected environment.
-// Surfaces vault-layer errors verbatim so the user sees the actual problem
-// (e.g. "identity file is corrupt") instead of an empty selector.
+// RunEnvSelector runs the environment selector and reports whether the user
+// cancelled (Esc/Ctrl+C). Surfaces vault-layer errors verbatim so the user
+// sees the actual problem (e.g. "identity file is corrupt") instead of an
+// empty selector.
+//
+// The cancelled bool exists so callers don't have to infer cancellation from
+// a magic empty string — Esc and "the picker errored" become unambiguous.
+// On cancel, returns ("", true, nil); on success, (env, false, nil); on
+// error, ("", false, err).
 //
 // When stdin is not a terminal (CI, cron, piped input), the selector refuses
 // to launch and returns an actionable error. Without this guard, bubbletea
@@ -87,15 +93,22 @@ func envItems() ([]string, error) {
 // "could not open a new TTY" error. The check is gated on having items to
 // show so that the more helpful "no envs configured" error still wins when
 // the store is empty.
-func RunEnvSelector() (string, error) {
+func RunEnvSelector() (env string, cancelled bool, err error) {
 	items, err := envItems()
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	if len(items) > 0 && !term.IsTerminal(int(os.Stdin.Fd())) { //nolint:gosec // G115 fd is small non-neg
-		return "", errors.New(
+		return "", false, errors.New(
 			"no --env provided and stdin is not a terminal — pass --env <name> to skip the picker",
 		)
 	}
-	return tui.RunSelector(items, "Select Environment: ", noEnvFilesError())
+	picked, err := tui.RunSelector(items, "Select Environment: ", noEnvFilesError())
+	if err != nil {
+		return "", false, err
+	}
+	if picked == "" {
+		return "", true, nil
+	}
+	return picked, false, nil
 }

--- a/pkg/tui/envselect/envselect_test.go
+++ b/pkg/tui/envselect/envselect_test.go
@@ -290,7 +290,7 @@ func TestRunEnvSelector_NonTTYFailsFast(t *testing.T) {
 		t.Skip("test runner has a TTY on stdin; cannot exercise the non-TTY guard")
 	}
 
-	tmpDir := setupVaultProject(t)
+	setupVaultProject(t)
 
 	id, err := age.GenerateX25519Identity()
 	if err != nil {
@@ -305,11 +305,13 @@ func TestRunEnvSelector_NonTTYFailsFast(t *testing.T) {
 	if err := vault.WriteStore(store, id.Recipient()); err != nil {
 		t.Fatalf("WriteStore: %v", err)
 	}
-	_ = tmpDir
 
-	_, err = RunEnvSelector()
+	_, cancelled, err := RunEnvSelector()
 	if err == nil {
 		t.Fatal("expected non-TTY guard to refuse, got nil error")
+	}
+	if cancelled {
+		t.Error("cancelled should be false on error path")
 	}
 	if !strings.Contains(err.Error(), "not a terminal") {
 		t.Errorf("error should mention non-terminal context, got: %v", err)

--- a/pkg/tui/envselect/envselect_test.go
+++ b/pkg/tui/envselect/envselect_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"filippo.io/age"
+	"golang.org/x/term"
 
 	"github.com/xaaha/hulak/pkg/utils"
 	"github.com/xaaha/hulak/pkg/vault"
@@ -277,6 +278,45 @@ func setupVaultProject(t *testing.T) string {
 	}
 
 	return tmpDir
+}
+
+// TestRunEnvSelector_NonTTYFailsFast asserts the selector refuses to launch
+// when stdin is not a terminal. Without this guard, bubbletea would fall back
+// to /dev/tty and hang in CI (PTY-allocated jobs) or emit a cryptic open
+// error (detached contexts). The error must point the user at --env so the
+// recovery is obvious.
+func TestRunEnvSelector_NonTTYFailsFast(t *testing.T) {
+	if term.IsTerminal(int(os.Stdin.Fd())) { //nolint:gosec // G115 fd is small non-neg
+		t.Skip("test runner has a TTY on stdin; cannot exercise the non-TTY guard")
+	}
+
+	tmpDir := setupVaultProject(t)
+
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("GenerateX25519Identity: %v", err)
+	}
+	if err := vault.SetIdentity(id.String()); err != nil {
+		t.Fatalf("SetIdentity: %v", err)
+	}
+	store := &vault.Store{Envs: map[string]vault.Env{
+		"global": {"K": "v"},
+	}}
+	if err := vault.WriteStore(store, id.Recipient()); err != nil {
+		t.Fatalf("WriteStore: %v", err)
+	}
+	_ = tmpDir
+
+	_, err = RunEnvSelector()
+	if err == nil {
+		t.Fatal("expected non-TTY guard to refuse, got nil error")
+	}
+	if !strings.Contains(err.Error(), "not a terminal") {
+		t.Errorf("error should mention non-terminal context, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--env") {
+		t.Errorf("error should suggest passing --env, got: %v", err)
+	}
 }
 
 // TestEnvItems_VaultErrors regression for #209 — vault read failures used to

--- a/pkg/userFlags/cli_contract_test.go
+++ b/pkg/userFlags/cli_contract_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
-
-	"github.com/xaaha/hulak/pkg/utils"
 )
 
 // TestSubCommandsExist verifies every expected subcommand is registered.
@@ -343,9 +341,10 @@ func TestParseRunArgsBadPath(t *testing.T) {
 	}
 }
 
-// TestParseRunArgsDefaultEnv verifies that an empty envFlagVal falls back to
-// the default environment.
-func TestParseRunArgsDefaultEnv(t *testing.T) {
+// TestParseRunArgsNoEnv verifies that omitting --env leaves Env empty and
+// EnvSet false, so the runner knows to invoke the picker instead of silently
+// defaulting to "global".
+func TestParseRunArgsNoEnv(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "test.hk.yaml")
 	if err := os.WriteFile(tmpFile, []byte("kind: API"), 0o600); err != nil {
 		t.Fatal(err)
@@ -356,8 +355,8 @@ func TestParseRunArgsDefaultEnv(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if f.Env != utils.DefaultEnvVal {
-		t.Errorf("Env = %q, want default %q", f.Env, utils.DefaultEnvVal)
+	if f.Env != "" {
+		t.Errorf("Env = %q, want empty so the runner invokes the picker", f.Env)
 	}
 	if f.EnvSet {
 		t.Error("EnvSet should be false when no env is provided")

--- a/pkg/userFlags/env_crud.go
+++ b/pkg/userFlags/env_crud.go
@@ -103,7 +103,7 @@ func newEnvSetCmd() *command {
 		Examples: []*utils.CommandHelp{
 			{
 				Command:     "hulak secrets set API_KEY sk-123",
-				Description: "Set a value in the default (global) environment",
+				Description: "Pick an environment from the TUI, then set",
 			},
 			{
 				Command:     "hulak secrets set DB_URL --env prod",
@@ -253,7 +253,7 @@ func newEnvGetCmd() *command {
 		Examples: []*utils.CommandHelp{
 			{
 				Command:     "hulak secrets get API_KEY",
-				Description: "Print API_KEY from the default environment",
+				Description: "Pick an environment from the TUI, then print API_KEY",
 			},
 			{
 				Command:     "hulak secrets get DB_URL --env prod",
@@ -347,7 +347,7 @@ func newEnvDeleteCmd() *command {
 		Examples: []*utils.CommandHelp{
 			{
 				Command:     "hulak secrets delete OLD_KEY",
-				Description: "Delete OLD_KEY from the default environment",
+				Description: "Pick an environment from the TUI, then delete OLD_KEY",
 			},
 			{
 				Command:     "hulak secrets rm STALE_TOKEN --env staging",

--- a/pkg/userFlags/env_crud.go
+++ b/pkg/userFlags/env_crud.go
@@ -158,9 +158,12 @@ func runEnvSet(args []string, envName string, useStdin bool, typeName string) er
 		return err
 	}
 
-	envName, err := resolveEnv(envName)
+	envName, cancelled, err := resolveEnv(envName)
 	if err != nil {
 		return err
+	}
+	if cancelled {
+		return nil
 	}
 
 	if err := utils.ValidateEnvName(envName); err != nil {
@@ -281,9 +284,12 @@ func runEnvGet(args []string, envName string) error {
 		return err
 	}
 
-	envName, err := resolveEnv(envName)
+	envName, cancelled, err := resolveEnv(envName)
 	if err != nil {
 		return err
+	}
+	if cancelled {
+		return nil
 	}
 
 	if err := utils.ValidateEnvName(envName); err != nil {
@@ -373,9 +379,12 @@ func runEnvDelete(args []string, envName string) error {
 		return err
 	}
 
-	envName, err := resolveEnv(envName)
+	envName, cancelled, err := resolveEnv(envName)
 	if err != nil {
 		return err
+	}
+	if cancelled {
+		return nil
 	}
 
 	if err := utils.ValidateEnvName(envName); err != nil {

--- a/pkg/userFlags/env_crud.go
+++ b/pkg/userFlags/env_crud.go
@@ -83,7 +83,7 @@ func parseTypedValue(raw, typeName string) (any, error) {
 // newEnvSetCmd returns the command struct for `hulak secrets set`.
 func newEnvSetCmd() *command {
 	setFs := flag.NewFlagSet("env set", flag.ContinueOnError)
-	setEnv := registerEnvFlag(setFs, utils.DefaultEnvVal, "Environment to operate on")
+	setEnv := registerEnvFlag(setFs, "", "Environment to operate on")
 	setStdin := setFs.Bool("stdin", false, "Read value from stdin")
 	var setType string
 	typeUsage := "Value type: " + strings.Join(validSetTypes[:], "|")
@@ -157,6 +157,15 @@ func runEnvSet(args []string, envName string, useStdin bool, typeName string) er
 	if err := requireVaultProject(); err != nil {
 		return err
 	}
+
+	if envName == "" {
+		picked, err := envPicker()
+		if err != nil {
+			return err
+		}
+		envName = picked
+	}
+
 	if err := utils.ValidateEnvName(envName); err != nil {
 		return err
 	}
@@ -230,7 +239,7 @@ func resolveSetValue(args []string, useStdin bool, key string) (string, error) {
 // newEnvGetCmd returns the command struct for `hulak secrets get`.
 func newEnvGetCmd() *command {
 	getFs := flag.NewFlagSet("env get", flag.ContinueOnError)
-	getEnv := registerEnvFlag(getFs, utils.DefaultEnvVal, "Environment to operate on")
+	getEnv := registerEnvFlag(getFs, "", "Environment to operate on")
 
 	return &command{
 		Name:    "get",
@@ -274,6 +283,15 @@ func runEnvGet(args []string, envName string) error {
 	if err := requireVaultProject(); err != nil {
 		return err
 	}
+
+	if envName == "" {
+		picked, err := envPicker()
+		if err != nil {
+			return err
+		}
+		envName = picked
+	}
+
 	if err := utils.ValidateEnvName(envName); err != nil {
 		return err
 	}
@@ -315,7 +333,7 @@ func printValue(value any) error {
 // newEnvDeleteCmd returns the command struct for `hulak secrets delete`.
 func newEnvDeleteCmd() *command {
 	deleteFs := flag.NewFlagSet("env delete", flag.ContinueOnError)
-	deleteEnv := registerEnvFlag(deleteFs, utils.DefaultEnvVal, "Environment to operate on")
+	deleteEnv := registerEnvFlag(deleteFs, "", "Environment to operate on")
 
 	return &command{
 		Name:    "delete",
@@ -360,6 +378,15 @@ func runEnvDelete(args []string, envName string) error {
 	if err := requireVaultProject(); err != nil {
 		return err
 	}
+
+	if envName == "" {
+		picked, err := envPicker()
+		if err != nil {
+			return err
+		}
+		envName = picked
+	}
+
 	if err := utils.ValidateEnvName(envName); err != nil {
 		return err
 	}

--- a/pkg/userFlags/env_crud.go
+++ b/pkg/userFlags/env_crud.go
@@ -158,12 +158,9 @@ func runEnvSet(args []string, envName string, useStdin bool, typeName string) er
 		return err
 	}
 
-	if envName == "" {
-		picked, err := envPicker()
-		if err != nil {
-			return err
-		}
-		envName = picked
+	envName, err := resolveEnv(envName)
+	if err != nil {
+		return err
 	}
 
 	if err := utils.ValidateEnvName(envName); err != nil {
@@ -284,12 +281,9 @@ func runEnvGet(args []string, envName string) error {
 		return err
 	}
 
-	if envName == "" {
-		picked, err := envPicker()
-		if err != nil {
-			return err
-		}
-		envName = picked
+	envName, err := resolveEnv(envName)
+	if err != nil {
+		return err
 	}
 
 	if err := utils.ValidateEnvName(envName); err != nil {
@@ -379,12 +373,9 @@ func runEnvDelete(args []string, envName string) error {
 		return err
 	}
 
-	if envName == "" {
-		picked, err := envPicker()
-		if err != nil {
-			return err
-		}
-		envName = picked
+	envName, err := resolveEnv(envName)
+	if err != nil {
+		return err
 	}
 
 	if err := utils.ValidateEnvName(envName); err != nil {

--- a/pkg/userFlags/env_crud_test.go
+++ b/pkg/userFlags/env_crud_test.go
@@ -89,7 +89,6 @@ func TestRunEnvSet_Errors(t *testing.T) {
 	}{
 		{"missing key", []string{}, "global", false, "missing required argument"},
 		{"invalid env name (space)", []string{"K", "v"}, "bad name", false, "invalid"},
-		{"invalid env name (empty)", []string{"K", "v"}, "", false, "empty"},
 		{"invalid env name (reserved prefix)", []string{"K", "v"}, "_internal", false, "reserved"},
 		{
 			"too many positionals",
@@ -694,10 +693,10 @@ func TestEnvSetCmd_FlagWiring(t *testing.T) {
 		args []string // full args after `secrets set`
 		key  string
 	}{
-		{"long flag --type int", []string{"--type", "int", "longInt", "100"}, "longInt"},
-		{"short flag -t int", []string{"-t", "int", "shortInt", "200"}, "shortInt"},
-		{"long flag --type bool", []string{"--type", "bool", "longBool", "true"}, "longBool"},
-		{"short flag -t bool", []string{"-t", "bool", "shortBool", "false"}, "shortBool"},
+		{"long flag --type int", []string{"--env", "global", "--type", "int", "longInt", "100"}, "longInt"},
+		{"short flag -t int", []string{"--env", "global", "-t", "int", "shortInt", "200"}, "shortInt"},
+		{"long flag --type bool", []string{"--env", "global", "--type", "bool", "longBool", "true"}, "longBool"},
+		{"short flag -t bool", []string{"--env", "global", "-t", "bool", "shortBool", "false"}, "shortBool"},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/userFlags/env_edit.go
+++ b/pkg/userFlags/env_edit.go
@@ -11,16 +11,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/xaaha/hulak/pkg/tui/envselect"
 	"github.com/xaaha/hulak/pkg/utils"
 	"github.com/xaaha/hulak/pkg/vault"
 )
-
-// envPicker is the function called to interactively pick an environment when
-// the user omits --env on `hulak secrets edit`. Indirected as a package variable
-// so tests can stub it out — calling the real selector would open a TUI on
-// /dev/tty and wait for keypress, hanging non-interactive test runs.
-var envPicker = envselect.RunEnvSelector
 
 // newEnvEditCmd returns the command struct for `hulak secrets edit`.
 func newEnvEditCmd() *command {
@@ -79,12 +72,9 @@ func runEnvEdit(args []string, envName string) error {
 		return err
 	}
 
-	if envName == "" {
-		picked, err := envPicker()
-		if err != nil {
-			return err
-		}
-		envName = picked
+	envName, err := resolveEnv(envName)
+	if err != nil {
+		return err
 	}
 
 	if err := utils.ValidateEnvName(envName); err != nil {

--- a/pkg/userFlags/env_edit.go
+++ b/pkg/userFlags/env_edit.go
@@ -72,9 +72,12 @@ func runEnvEdit(args []string, envName string) error {
 		return err
 	}
 
-	envName, err := resolveEnv(envName)
+	envName, cancelled, err := resolveEnv(envName)
 	if err != nil {
 		return err
+	}
+	if cancelled {
+		return nil
 	}
 
 	if err := utils.ValidateEnvName(envName); err != nil {

--- a/pkg/userFlags/env_edit_test.go
+++ b/pkg/userFlags/env_edit_test.go
@@ -172,9 +172,9 @@ func TestRunEnvEdit_NoDefaultGlobal(t *testing.T) {
 	prevPicker := envPicker
 	t.Cleanup(func() { envPicker = prevPicker })
 	pickerCalled := false
-	envPicker = func() (string, error) {
+	envPicker = func() (string, bool, error) {
 		pickerCalled = true
-		return "", errors.New("picker disabled in tests")
+		return "", false, errors.New("picker disabled in tests")
 	}
 
 	t.Setenv("EDITOR", fakeEditor(t, `{"GOT_EDITED":"yes"}`))

--- a/pkg/userFlags/env_list.go
+++ b/pkg/userFlags/env_list.go
@@ -111,12 +111,9 @@ func runEnvKeys(args []string, envName, search string, show bool) error {
 		return err
 	}
 
-	if envName == "" {
-		picked, err := envPicker()
-		if err != nil {
-			return err
-		}
-		envName = picked
+	envName, err := resolveEnv(envName)
+	if err != nil {
+		return err
 	}
 
 	if err := utils.ValidateEnvName(envName); err != nil {

--- a/pkg/userFlags/env_list.go
+++ b/pkg/userFlags/env_list.go
@@ -111,9 +111,12 @@ func runEnvKeys(args []string, envName, search string, show bool) error {
 		return err
 	}
 
-	envName, err := resolveEnv(envName)
+	envName, cancelled, err := resolveEnv(envName)
 	if err != nil {
 		return err
+	}
+	if cancelled {
+		return nil
 	}
 
 	if err := utils.ValidateEnvName(envName); err != nil {

--- a/pkg/userFlags/env_list.go
+++ b/pkg/userFlags/env_list.go
@@ -63,7 +63,7 @@ func runEnvList(args []string) error {
 // newEnvKeysCmd returns the command struct for `hulak secrets keys`.
 func newEnvKeysCmd() *command {
 	keysFs := flag.NewFlagSet("env keys", flag.ContinueOnError)
-	keysEnv := registerEnvFlag(keysFs, utils.DefaultEnvVal, "Environment to operate on")
+	keysEnv := registerEnvFlag(keysFs, "", "Environment to operate on")
 	keysShow := registerShowFlag(keysFs, "Reveal values instead of masking them")
 	keysSearch := keysFs.String(
 		"search",
@@ -110,6 +110,15 @@ func runEnvKeys(args []string, envName, search string, show bool) error {
 	if err := requireVaultProject(); err != nil {
 		return err
 	}
+
+	if envName == "" {
+		picked, err := envPicker()
+		if err != nil {
+			return err
+		}
+		envName = picked
+	}
+
 	if err := utils.ValidateEnvName(envName); err != nil {
 		return err
 	}

--- a/pkg/userFlags/env_picker.go
+++ b/pkg/userFlags/env_picker.go
@@ -1,0 +1,24 @@
+// Centralizes the "no --env → interactive picker" fallback used by the
+// secrets subcommands (set, get, delete, keys, edit). Keeping the package
+// variable and helper here means tests have a single stub point and the
+// fallback shape stays consistent across commands.
+package userflags
+
+import "github.com/xaaha/hulak/pkg/tui/envselect"
+
+// envPicker is the function called to interactively pick an environment when
+// the user omits --env on a secrets subcommand. Indirected as a package
+// variable so tests can stub it out — calling the real selector would open
+// a TUI on /dev/tty and hang non-interactive test runs.
+var envPicker = envselect.RunEnvSelector
+
+// resolveEnv returns envName when non-empty, otherwise prompts the user via
+// the envselect TUI. A cancelled picker returns "" with no error; callers
+// should pass that through to ValidateEnvName, which rejects empty names —
+// that's the single chokepoint for "no env was chosen".
+func resolveEnv(envName string) (string, error) {
+	if envName != "" {
+		return envName, nil
+	}
+	return envPicker()
+}

--- a/pkg/userFlags/env_picker.go
+++ b/pkg/userFlags/env_picker.go
@@ -13,12 +13,24 @@ import "github.com/xaaha/hulak/pkg/tui/envselect"
 var envPicker = envselect.RunEnvSelector
 
 // resolveEnv returns envName when non-empty, otherwise prompts the user via
-// the envselect TUI. A cancelled picker returns "" with no error; callers
-// should pass that through to ValidateEnvName, which rejects empty names —
-// that's the single chokepoint for "no env was chosen".
-func resolveEnv(envName string) (string, error) {
+// the envselect TUI.
+//
+// The bool return distinguishes "user hit Esc to cancel" (cancelled=true,
+// no error) from "the picker errored" (cancelled=false, err set) and from
+// the normal path (cancelled=false, value set). Without it, callers couldn't
+// tell a deliberate cancel from an accidental empty value, and would surface
+// a misleading "environment name cannot be empty" from ValidateEnvName.
+// On cancel, callers should return nil — Esc is a user action, not a failure.
+func resolveEnv(envName string) (resolved string, cancelled bool, err error) {
 	if envName != "" {
-		return envName, nil
+		return envName, false, nil
 	}
-	return envPicker()
+	picked, err := envPicker()
+	if err != nil {
+		return "", false, err
+	}
+	if picked == "" {
+		return "", true, nil
+	}
+	return picked, false, nil
 }

--- a/pkg/userFlags/env_picker.go
+++ b/pkg/userFlags/env_picker.go
@@ -9,28 +9,17 @@ import "github.com/xaaha/hulak/pkg/tui/envselect"
 // envPicker is the function called to interactively pick an environment when
 // the user omits --env on a secrets subcommand. Indirected as a package
 // variable so tests can stub it out — calling the real selector would open
-// a TUI on /dev/tty and hang non-interactive test runs.
+// a TUI on /dev/tty and hang non-interactive test runs. The (string, bool,
+// error) shape comes from envselect.RunEnvSelector; see its doc for the
+// cancelled-bool contract.
 var envPicker = envselect.RunEnvSelector
 
 // resolveEnv returns envName when non-empty, otherwise prompts the user via
-// the envselect TUI.
-//
-// The bool return distinguishes "user hit Esc to cancel" (cancelled=true,
-// no error) from "the picker errored" (cancelled=false, err set) and from
-// the normal path (cancelled=false, value set). Without it, callers couldn't
-// tell a deliberate cancel from an accidental empty value, and would surface
-// a misleading "environment name cannot be empty" from ValidateEnvName.
-// On cancel, callers should return nil — Esc is a user action, not a failure.
+// the envselect TUI. The cancelled bool propagates from the picker so callers
+// can distinguish a deliberate Esc/Ctrl+C from an error and exit cleanly.
 func resolveEnv(envName string) (resolved string, cancelled bool, err error) {
 	if envName != "" {
 		return envName, false, nil
 	}
-	picked, err := envPicker()
-	if err != nil {
-		return "", false, err
-	}
-	if picked == "" {
-		return "", true, nil
-	}
-	return picked, false, nil
+	return envPicker()
 }

--- a/pkg/userFlags/env_picker_test.go
+++ b/pkg/userFlags/env_picker_test.go
@@ -1,0 +1,85 @@
+package userflags
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestResolveEnv covers the three branches of resolveEnv: bypass when envName
+// is already set, picker-success, picker-cancel, and picker-error. The cancel
+// case is the regression guard for the contract that callers rely on to do a
+// clean exit on Esc — without it, callers fall through to ValidateEnvName and
+// the user sees a misleading "environment name cannot be empty".
+func TestResolveEnv(t *testing.T) {
+	pickerErr := errors.New("picker boom")
+
+	tests := []struct {
+		name          string
+		envName       string
+		pickerEnv     string
+		pickerCancel  bool
+		pickerErr     error
+		wantResolved  string
+		wantCancelled bool
+		wantErr       error
+		// pickerCalled asserts whether the picker was invoked. envName != ""
+		// must bypass it; envName == "" must call it exactly once.
+		wantPickerCalled bool
+	}{
+		{
+			name:             "envName set bypasses picker",
+			envName:          "prod",
+			wantResolved:     "prod",
+			wantPickerCalled: false,
+		},
+		{
+			name:             "empty envName + picker returns env",
+			envName:          "",
+			pickerEnv:        "staging",
+			wantResolved:     "staging",
+			wantPickerCalled: true,
+		},
+		{
+			name:             "empty envName + picker cancelled",
+			envName:          "",
+			pickerCancel:     true,
+			wantCancelled:    true,
+			wantPickerCalled: true,
+		},
+		{
+			name:             "empty envName + picker errors",
+			envName:          "",
+			pickerErr:        pickerErr,
+			wantErr:          pickerErr,
+			wantPickerCalled: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prev := envPicker
+			t.Cleanup(func() { envPicker = prev })
+
+			called := false
+			envPicker = func() (string, bool, error) {
+				called = true
+				return tc.pickerEnv, tc.pickerCancel, tc.pickerErr
+			}
+
+			gotEnv, gotCancelled, gotErr := resolveEnv(tc.envName)
+
+			if called != tc.wantPickerCalled {
+				t.Errorf("picker called = %v, want %v", called, tc.wantPickerCalled)
+			}
+			if gotEnv != tc.wantResolved {
+				t.Errorf("env = %q, want %q", gotEnv, tc.wantResolved)
+			}
+			if gotCancelled != tc.wantCancelled {
+				t.Errorf("cancelled = %v, want %v", gotCancelled, tc.wantCancelled)
+			}
+			if !errors.Is(gotErr, tc.wantErr) {
+				t.Errorf("err = %v, want %v", gotErr, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/userFlags/flags.go
+++ b/pkg/userFlags/flags.go
@@ -60,11 +60,11 @@ var (
 
 // go's init func executes automatically, and registers the flags during package initialization
 func init() {
-	flag.StringVar(&flagEnv, "env", utils.DefaultEnvVal, "Environment file to use during the call")
+	flag.StringVar(&flagEnv, "env", "", "Environment file to use during the call")
 	flag.StringVar(
 		&flagEnv,
 		"environment",
-		utils.DefaultEnvVal,
+		"",
 		"Environment file to use during the call",
 	)
 

--- a/pkg/userFlags/flags.go
+++ b/pkg/userFlags/flags.go
@@ -60,12 +60,12 @@ var (
 
 // go's init func executes automatically, and registers the flags during package initialization
 func init() {
-	flag.StringVar(&flagEnv, "env", "", "Environment file to use during the call")
+	flag.StringVar(&flagEnv, "env", "", "Environment to use (omit to pick interactively)")
 	flag.StringVar(
 		&flagEnv,
 		"environment",
 		"",
-		"Environment file to use during the call",
+		"Environment to use (omit to pick interactively)",
 	)
 
 	flag.StringVar(&flagFP, "fp", "", "Relative (or absolute) file path of the request file")

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -462,8 +462,6 @@ func parseRunArgs(a runCmdArgs) (*runner.Flags, error) {
 	if a.Env != "" {
 		f.Env = a.Env
 		f.EnvSet = true
-	} else {
-		f.Env = utils.DefaultEnvVal
 	}
 
 	if info.IsDir() {

--- a/pkg/userFlags/subcommands.go
+++ b/pkg/userFlags/subcommands.go
@@ -484,7 +484,7 @@ func newEnvCmd() *command {
 		Short:   "Manage encrypted environment secrets",
 		Long: "Manage environment secrets stored in the encrypted vault (.hulak/store.age).\n\n" +
 			"Secrets are organized by environment (e.g. global, staging, prod).\n" +
-			"The default environment is \"global\" unless --env is specified.\n\n" +
+			"When --env is omitted, you'll be prompted to pick an environment interactively.\n\n" +
 			"'env' is retained as an alias for backward compatibility with pre-0.3 docs.",
 		Examples: []*utils.CommandHelp{
 			{


### PR DESCRIPTION
## Always ask

for user's env... picking global as default is confusing for new users

- **show picker when empty**
- **show env picker if not -env is not present**
- **centralize**
- **check if cancelled**
- **fix help text as global is not automatically picked anymore**

## Breaking change

Omitting `--env` no longer silently defaults to the `global` environment.

- **Interactive use**: `hulak secrets set/get/delete/keys/edit` and `hulak run` now show an env picker when `--env` is missing.
- **Scripted / CI use**: the picker refuses to launch on non-TTY stdin and returns an actionable error pointing at `--env <name>` — so scripts that relied on the implicit `global` default must pass `--env global` explicitly (or pick a different env).

Cancellation (Esc/Ctrl+C) in the picker is now a clean exit (code 0, no output) — previously the secrets commands surfaced a misleading "environment name cannot be empty" error on cancel.