### PR TITLE
Fix release notes refresh step in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,11 +42,15 @@ jobs:
           GH_PAT: ${{ steps.app-token.outputs.token }}
       - name: Refresh release notes from .github/release.yml
         # goreleaser creates the release with an empty body (its own
-        # changelog is disabled). This step regenerates the body using
-        # GitHub's auto-notes API, which groups merged PRs by label per
-        # .github/release.yml. Skipped on workflow_dispatch — that path
-        # uses --snapshot and doesn't publish a release.
+        # changelog is disabled). This step fetches GitHub's auto-notes
+        # (which group merged PRs by label per .github/release.yml) and
+        # writes them as the release body. Skipped on workflow_dispatch
+        # — that path uses --snapshot and doesn't publish a release.
         if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${{ github.ref_name }}" --generate-notes
+        run: |
+          gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="${{ github.ref_name }}" \
+            --jq .body \
+            | gh release edit "${{ github.ref_name }}" --notes-file -


### PR DESCRIPTION
## Summary
- `gh release edit` doesn't support `--generate-notes` (only `gh release create` does), so the post-goreleaser step in `release.yml` errored on v0.3.20 and left the release body empty.
- Fix: call the `releases/generate-notes` API to fetch the body, then pipe it into `gh release edit --notes-file -`.

## Verification
- v0.3.20's notes were already backfilled manually with the equivalent command — confirmed it produces the expected label-grouped output.
- Next tagged release will exercise the workflow step end-to-end.

## Test plan
- [ ] Merge, then tag a patch release (or wait for the next real release) and verify the "Refresh release notes" step succeeds and the release body shows label-grouped sections.