### PR TITLE
Fix getFile resolver: resolve relative paths from project root, not cwd

### DIFF
--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -104,7 +104,9 @@ func processValueOf(key, fileName string) any {
 	// Validate inputs
 	if key == "" || fileName == "" {
 		if key == "" {
-			utils.PrintErrorStderr(fmt.Sprintf("provide key for %s action", utils.TemplateFuncGetValueOf))
+			utils.PrintErrorStderr(
+				fmt.Sprintf("provide key for %s action", utils.TemplateFuncGetValueOf),
+			)
 		} else {
 			utils.PrintErrorStderr(
 				fmt.Sprintf(
@@ -190,7 +192,9 @@ func resolveJSONFilePath(fileName string) (string, error) {
 
 	// Handle multiple matches warning
 	if len(yamlPathList) > 1 {
-		utils.PrintWarningStderr(fmt.Sprintf("multiple '%s' files; using %s", cleanFileName, yamlPathList[0]))
+		utils.PrintWarningStderr(
+			fmt.Sprintf("multiple '%s' files; using %s", cleanFileName, yamlPathList[0]),
+		)
 	}
 
 	singlePath := yamlPathList[0]

--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -72,68 +72,21 @@ func BasicAuth(username, password string) string {
 	return "Basic " + encoded
 }
 
-// GetFile reads the content of a file given its relative or absolute path
+// GetFile reads the content of a file referenced by a {{getFile}} template.
+// Resolution is delegated to utils.ResolveProjectFile: relative paths are
+// project-root-relative (never cwd-relative), absolute paths are used as-is,
+// and either way the file must live inside the project root.
 func GetFile(filePath string) (string, error) {
-	// Check if file path is empty
-	if filePath == "" {
-		return "", fmt.Errorf("file path cannot be empty")
-	}
-
-	cleanPath := filepath.Clean(filePath)
-
-	// Use project root as the base allowed directory
-	projectRoot, found := utils.FindProjectRoot()
-	if !found {
-		return "", fmt.Errorf("not a hulak project: could not find project root")
-	}
-
-	// Try to resolve as absolute path first
-	absPath, err := filepath.Abs(cleanPath)
+	absPath, err := utils.ResolveProjectFile(filePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve path %s: %w", cleanPath, err)
+		return "", err
 	}
 
-	// Check if file exists and is readable
-	fileInfo, err := os.Stat(absPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			// Try relative to working directory if absolute path doesn't exist
-			relPath := filepath.Join(projectRoot, cleanPath)
-			fileInfo, err = os.Stat(relPath)
-			if err != nil {
-				if os.IsNotExist(err) {
-					return "", fmt.Errorf("file does not exist %s", absPath)
-				}
-				return "", fmt.Errorf("error accessing file %s: %w", filePath, err)
-			}
-			absPath = relPath
-		} else {
-			return "", fmt.Errorf("error accessing file %s: %w", filePath, err)
-		}
-	}
-
-	// ensure the file is within the working directory or explicitly allowed directories
-	if !strings.HasPrefix(absPath, projectRoot) {
-		// If you want to allow specific directories outside the working dir, add checks here
-		// For example, checking if it's in an allowed config directory
-		return "", fmt.Errorf(
-			"access denied: file path %s is outside the allowed directory",
-			filePath,
-		)
-	}
-
-	// Check if it's a regular file (not a directory)
-	if fileInfo.IsDir() {
-		return "", fmt.Errorf("%s is a directory, not a file", filePath)
-	}
-
-	// Read the file content preserving all formatting
 	content, err := os.ReadFile(absPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read file %s: %w", filePath, err)
 	}
 
-	// Return the content as is, preserving all newlines and formatting
 	return string(content), nil
 }
 

--- a/pkg/utils/template.go
+++ b/pkg/utils/template.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -75,7 +76,7 @@ func collectFileRefs(resolvedPath string, seen map[string]bool, deps *[]string) 
 		// to the project root. Dedup and recursion key on the real file; a
 		// not-yet-created file is still surfaced, anchored to the project root
 		// so the reported path is where a run would look for it.
-		resolved, err := resolveFilePath(arg)
+		resolved, err := ResolveProjectFile(arg)
 		if err != nil {
 			resolved = projectRootRel(arg)
 		}
@@ -172,31 +173,82 @@ func parseTemplateArg(input string) string {
 	}
 }
 
+// resolveFilePath locates a file for static analysis (env-var detection, dep
+// listing). Unlike ResolveProjectFile it enforces no project containment and
+// tolerates a caller-supplied absolute path outside any project, since the
+// caller has already located the file. Relative paths are project-root-relative
+// (never cwd-relative), matching the runtime getFile rule.
 func resolveFilePath(filePath string) (string, error) {
 	if filePath == "" {
 		return "", errors.New("file path cannot be empty")
 	}
 
 	cleanPath := filepath.Clean(filePath)
-	absPath, err := filepath.Abs(cleanPath)
-	if err != nil {
-		return "", err
+	if filepath.IsAbs(cleanPath) {
+		if _, err := os.Stat(cleanPath); err != nil {
+			return "", err
+		}
+		return cleanPath, nil
 	}
 
-	_, statErr := os.Stat(absPath)
-	if statErr == nil {
-		return absPath, nil
-	}
-	if !os.IsNotExist(statErr) {
-		return "", statErr
-	}
-
-	projectRoot, _ := FindProjectRoot()
-	relPath := filepath.Join(projectRoot, cleanPath)
+	root, _ := FindProjectRoot()
+	relPath := filepath.Join(root, cleanPath)
 	if _, err := os.Stat(relPath); err != nil {
 		return "", err
 	}
 	return relPath, nil
+}
+
+// ResolveProjectFile resolves a getFile path to an absolute path inside the
+// project root. It is the single source of truth for getFile resolution, used
+// by both the runtime (actions.GetFile) and the dependency lister.
+//
+// A relative path is always project-root-relative, never cwd-relative, so
+// resolution is identical no matter where hulak is invoked from. An absolute
+// path is used as-is. Either way the result must live inside the project root
+// and point at an existing regular file.
+func ResolveProjectFile(filePath string) (string, error) {
+	if filePath == "" {
+		return "", errors.New("file path cannot be empty")
+	}
+
+	projectRoot, found := FindProjectRoot()
+	if !found {
+		return "", errors.New("not a hulak project: could not find project root")
+	}
+
+	cleanPath := filepath.Clean(filePath)
+	absPath := cleanPath
+	if !filepath.IsAbs(cleanPath) {
+		absPath = filepath.Join(projectRoot, cleanPath)
+	}
+
+	if !withinRoot(absPath, projectRoot) {
+		return "", fmt.Errorf("access denied: file path %s is outside the project root", filePath)
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("file does not exist %s", absPath)
+		}
+		return "", err
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("%s is a directory, not a file", filePath)
+	}
+	return absPath, nil
+}
+
+// withinRoot reports whether absPath is root itself or nested under it, using a
+// path-segment comparison so a sibling like /project-evil does not count as
+// being inside /project.
+func withinRoot(absPath, root string) bool {
+	rel, err := filepath.Rel(root, absPath)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 func hasEnvVar(val any) bool {

--- a/pkg/utils/template.go
+++ b/pkg/utils/template.go
@@ -89,19 +89,26 @@ func collectFileRefs(resolvedPath string, seen map[string]bool, deps *[]string) 
 	}
 }
 
+// anchorToRoot is the shared getFile anchoring rule: an absolute path passes
+// through, a relative path is joined to the project root. filepath.Join keeps
+// this correct on every OS separator.
+func anchorToRoot(cleanPath, root string) string {
+	if filepath.IsAbs(cleanPath) {
+		return cleanPath
+	}
+	return filepath.Join(root, cleanPath)
+}
+
 // projectRootRel anchors a getFile arg that does not resolve to an existing
-// file. Absolute args pass through; relative args join the project root — the
-// same base actions.GetFile uses — falling back to the cleaned arg when the
-// root cannot be found.
+// file, so the lister can still report where a run would look for it. Falls
+// back to the cleaned arg when no project root is found.
 func projectRootRel(arg string) string {
 	clean := filepath.Clean(arg)
-	if filepath.IsAbs(clean) {
+	root, ok := FindProjectRoot()
+	if !ok {
 		return clean
 	}
-	if root, ok := FindProjectRoot(); ok {
-		return filepath.Join(root, clean)
-	}
-	return clean
+	return anchorToRoot(clean, root)
 }
 
 // MapHasEnvVars recursively checks if any string value in the map
@@ -176,27 +183,19 @@ func parseTemplateArg(input string) string {
 // resolveFilePath locates a file for static analysis (env-var detection, dep
 // listing). Unlike ResolveProjectFile it enforces no project containment and
 // tolerates a caller-supplied absolute path outside any project, since the
-// caller has already located the file. Relative paths are project-root-relative
-// (never cwd-relative), matching the runtime getFile rule.
+// caller has already located the file. A relative path is joined to the project
+// root (never cwd-first), falling back to cwd only when no project root exists.
 func resolveFilePath(filePath string) (string, error) {
 	if filePath == "" {
 		return "", errors.New("file path cannot be empty")
 	}
 
-	cleanPath := filepath.Clean(filePath)
-	if filepath.IsAbs(cleanPath) {
-		if _, err := os.Stat(cleanPath); err != nil {
-			return "", err
-		}
-		return cleanPath, nil
-	}
-
 	root, _ := FindProjectRoot()
-	relPath := filepath.Join(root, cleanPath)
-	if _, err := os.Stat(relPath); err != nil {
+	path := anchorToRoot(filepath.Clean(filePath), root)
+	if _, err := os.Stat(path); err != nil {
 		return "", err
 	}
-	return relPath, nil
+	return path, nil
 }
 
 // ResolveProjectFile resolves a getFile path to an absolute path inside the
@@ -217,12 +216,7 @@ func ResolveProjectFile(filePath string) (string, error) {
 		return "", errors.New("not a hulak project: could not find project root")
 	}
 
-	cleanPath := filepath.Clean(filePath)
-	absPath := cleanPath
-	if !filepath.IsAbs(cleanPath) {
-		absPath = filepath.Join(projectRoot, cleanPath)
-	}
-
+	absPath := anchorToRoot(filepath.Clean(filePath), projectRoot)
 	if !withinRoot(absPath, projectRoot) {
 		return "", fmt.Errorf("access denied: file path %s is outside the project root", filePath)
 	}

--- a/pkg/utils/template_test.go
+++ b/pkg/utils/template_test.go
@@ -317,19 +317,19 @@ func TestResolveFilePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := resolveFilePath(tt.input)
+			got, err := ResolveProjectFile(tt.input)
 			if tt.wantErr {
 				if err == nil {
-					t.Errorf("resolveFilePath(%q) expected error, got nil", tt.input)
+					t.Errorf("ResolveProjectFile(%q) expected error, got nil", tt.input)
 				}
 				return
 			}
 			if err != nil {
-				t.Errorf("resolveFilePath(%q) unexpected error: %v", tt.input, err)
+				t.Errorf("ResolveProjectFile(%q) unexpected error: %v", tt.input, err)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("resolveFilePath(%q) = %q, want %q", tt.input, got, tt.want)
+				t.Errorf("ResolveProjectFile(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}
@@ -372,12 +372,62 @@ func TestResolveFilePath_FromChildDir(t *testing.T) {
 	}
 
 	// Relative path "root.txt" should resolve via project root, not cwd
-	got, err := resolveFilePath("root.txt")
+	got, err := ResolveProjectFile("root.txt")
 	if err != nil {
-		t.Fatalf("resolveFilePath(\"root.txt\") from child dir: unexpected error: %v", err)
+		t.Fatalf("ResolveProjectFile(\"root.txt\") from child dir: unexpected error: %v", err)
 	}
 	if got != rootFile {
-		t.Errorf("resolveFilePath(\"root.txt\") from child dir = %q, want %q", got, rootFile)
+		t.Errorf("ResolveProjectFile(\"root.txt\") from child dir = %q, want %q", got, rootFile)
+	}
+}
+
+// TestResolveProjectFile_ChildCollision is the issue #239 regression: a
+// relative getFile path must resolve against the project root even when a
+// same-named file also exists under the cwd. The old cwd-first resolver picked
+// the child copy and silently returned the wrong file.
+func TestResolveProjectFile_ChildCollision(t *testing.T) {
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	tmpDir := t.TempDir()
+	tmpDir, err = filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to resolve symlinks: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(tmpDir, EnvironmentFolder), DirPer); err != nil {
+		t.Fatalf("failed to create env dir: %v", err)
+	}
+
+	// Same relative name at both the project root and a child dir.
+	rootFile := filepath.Join(tmpDir, "data.json")
+	if err := os.WriteFile(rootFile, []byte("root"), FilePer); err != nil {
+		t.Fatalf("failed to write root file: %v", err)
+	}
+	childDir := filepath.Join(tmpDir, "child")
+	if err := os.Mkdir(childDir, DirPer); err != nil {
+		t.Fatalf("failed to create child dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(childDir, "data.json"), []byte("child"), FilePer); err != nil {
+		t.Fatalf("failed to write child file: %v", err)
+	}
+	if err := os.Chdir(childDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	got, err := ResolveProjectFile("data.json")
+	if err != nil {
+		t.Fatalf("ResolveProjectFile(\"data.json\") from child dir: unexpected error: %v", err)
+	}
+	if got != rootFile {
+		t.Errorf("ResolveProjectFile(\"data.json\") = %q, want the project-root copy %q (cwd copy wrongly picked)",
+			got, rootFile)
 	}
 }
 


### PR DESCRIPTION
Closes #239

## Problem

The `getFile` path resolver tried the current working directory before the project root. From the CLI (which does not `chdir` to the project root), a relative `getFile` path could silently resolve to a same-named file under the cwd instead of the intended project-root file.

```
cwd = /project/genesis
getFile "data.json"
  /project/genesis/data.json   <- existed, got picked (wrong)
  /project/data.json           <- intended file, never reached
```

## Fix

Relative `getFile` paths are now always project-root-relative. Absolute paths are used as-is. The cwd attempt is gone, so resolution is identical no matter where hulak is invoked.

- New `utils.ResolveProjectFile` is the single source of truth for runtime `getFile` resolution: root-relative for relative paths, containment-checked, must be an existing regular file. `actions.GetFile` now delegates to it, dropping its duplicated resolution block.
- Containment check upgraded from `strings.HasPrefix` to a path-segment comparison (`withinRoot`), so a sibling like `/project-evil` no longer counts as inside `/project`.
- `utils.resolveFilePath` is kept but scoped to best-effort static analysis (env-var detection, dependency listing). It tolerates a caller-supplied absolute path outside a project, and its relative-path rule is fixed to root-first (never cwd).

The MCP server was never affected: its tools run inside `withProjectDir` (cwd = project root), so the two resolution attempts already coincided.

## Tests

- `TestResolveProjectFile_ChildCollision` — the #239 regression: same-named file at both the child dir and the project root, asserts the root copy wins.
- Existing resolver + `GetFile` tests retargeted and still pass.

`go test ./...`, `go vet ./...`, and `golangci-lint run` all clean.