### PR TITLE
Harden GraphQL explorer response save: owner-only perms

### DIFF
--- a/pkg/tui/gqlexplorer/model.go
+++ b/pkg/tui/gqlexplorer/model.go
@@ -1170,7 +1170,10 @@ func (m *Model) saveResponse() tea.Cmd {
 	fileName := op.Name + "-" + stamp + utils.ResponseBase + ".json"
 	fullPath := filepath.Join(dir, fileName)
 
-	if err := os.WriteFile(fullPath, []byte(m.responseBody), utils.FilePer); err != nil {
+	// Response bodies routinely echo tokens/PII. Save owner-only (0o600),
+	// matching the CLI response writer, not the world-readable FilePer used for
+	// shareable source files.
+	if err := os.WriteFile(fullPath, []byte(m.responseBody), utils.SecretPer); err != nil {
 		return m.enqueueNotification(tui.NotificationError, "Save failed: "+err.Error())
 	}
 	return m.enqueueNotification(tui.NotificationInfo, "Saved "+relativePath(fullPath))

--- a/pkg/tui/gqlexplorer/model.go
+++ b/pkg/tui/gqlexplorer/model.go
@@ -1170,9 +1170,6 @@ func (m *Model) saveResponse() tea.Cmd {
 	fileName := op.Name + "-" + stamp + utils.ResponseBase + ".json"
 	fullPath := filepath.Join(dir, fileName)
 
-	// Response bodies routinely echo tokens/PII. Save owner-only (0o600),
-	// matching the CLI response writer, not the world-readable FilePer used for
-	// shareable source files.
 	if err := os.WriteFile(fullPath, []byte(m.responseBody), utils.SecretPer); err != nil {
 		return m.enqueueNotification(tui.NotificationError, "Save failed: "+err.Error())
 	}
@@ -1222,7 +1219,8 @@ func (m *Model) responseHeader() string {
 	}
 	saveColor := focusColor(focused, badgeColor[TypeMutation])
 	saveChip := tui.RenderChip(saveLabel, tui.ChipVariantBadge, saveColor)
-	parts = append(parts,
+	parts = append(
+		parts,
 		tui.HelpStyle.Render(formatResponseSize(len(m.responseBody))),
 		m.mouse.Mark(m.saveZoneID(), saveChip),
 	)

--- a/pkg/tui/gqlexplorer/savefile_test.go
+++ b/pkg/tui/gqlexplorer/savefile_test.go
@@ -1,0 +1,49 @@
+package gqlexplorer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/xaaha/hulak/pkg/utils"
+)
+
+// TestSaveResponse_OwnerOnlyPerms guards the fix for issue #166: an explorer
+// response body can echo tokens/PII, so it must be written owner-only (0o600),
+// not with the world-readable FilePer used for shareable source files.
+func TestSaveResponse_OwnerOnlyPerms(t *testing.T) {
+	dir := t.TempDir()
+	m := &Model{
+		responseBody:    `{"access_token":"super-secret"}`,
+		filtered:        []UnifiedOperation{{Name: "getUser", Endpoint: "e"}},
+		cursor:          0,
+		schemaFilePaths: map[string]string{"e": filepath.Join(dir, "schema.json")},
+	}
+
+	if cmd := m.saveResponse(); cmd == nil {
+		t.Fatal("saveResponse returned nil cmd; expected a save notification")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var saved string
+	for _, e := range entries {
+		if !e.IsDir() {
+			saved = filepath.Join(dir, e.Name())
+		}
+	}
+	if saved == "" {
+		t.Fatal("no response file written")
+	}
+
+	info, err := os.Stat(saved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != utils.SecretPer.Perm() {
+		t.Errorf("response file perms = %o, want %o (secret-bearing body must be owner-only)",
+			perm, utils.SecretPer.Perm())
+	}
+}


### PR DESCRIPTION
Part of #166.

## Problem

The GraphQL explorer saved response bodies with `utils.FilePer` (`0o644`, world-readable). Response bodies routinely echo back tokens, session IDs, and PII, so on a shared host any other user could read them. The CLI response writer already uses `0o600` for exactly this reason — the two paths disagreed.

## Fix

The explorer response save (`pkg/tui/gqlexplorer/model.go`) now writes with `utils.SecretPer` (`0o600`), matching the CLI. Owner-only, secret-bearing bodies stay private.

The `.gql` and `.hk.yaml` saves keep `0o644` — those are shareable source files meant to be committed, not secret-bearing artifacts.

## Test

`TestSaveResponse_OwnerOnlyPerms` asserts the written response file is `0o600`, guarding against a regression back to the world-readable default.

`go test ./...`, `go vet ./...`, and `golangci-lint run` all clean.

## Scope note

This is the concrete security slice of #166. The broader items in that issue — the AI-oriented redacted export flow, and routing explorer saves through the CLI's shared serialized writer — are addressed/superseded elsewhere:

- The AI copy/paste ergonomic goal is largely served by the new MCP server (#238).
- Routing explorer saves through the shared writer (`SerializeAndSaveResp`) is a larger, optional refactor that also changes the on-disk format; tracked as a follow-up.

Recommend closing #166 as superseded once this lands.