### PR TITLE
getFile "*" sibling shorthand + case/underscore-insensitive action names

### DIFF
--- a/assets/schema.json
+++ b/assets/schema.json
@@ -263,9 +263,9 @@
               "properties": {
                 "query": {
                   "type": "string",
-                  "description": "GraphQL query string",
+                  "description": "GraphQL query string. Use {{getFile \"*.gql\"}} to read the sibling .gql file with the same basename as this request.",
                   "minLength": 1,
-                  "default": "{{getFile `path/to/file.gql`}}"
+                  "default": "{{getFile \"*.gql\"}}"
                 },
                 "variables": {
                   "type": "object",

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -1,5 +1,8 @@
 # How to access variables?
 
+> [!Note]
+> Action names are case and underscore insensitive. `{{getFile}}`, `{{getfile}}`, `{{GetFile}}`, and `{{get_file}}` all call the same function. This applies to every action below (`getValueOf`, `getFile`, `basicAuth`, `os`). Your `{{.key}}` values stay case sensitive.
+
 ## 1. Accessing secrets from the vault
 
 Hulak resolves `{{.key}}` template values from the encrypted vault (`.hulak/store.age`). Set a secret once with `hulak secrets keys set`. Then reference it in your request files.
@@ -127,6 +130,25 @@ body:
 ```
 
 `getFile` gets the entire file content and dumps it in context. For example, in the above example, it dumps the content in the query section of grapqhl
+
+### Sibling shorthand: `getFile "*.ext"`
+
+When the file you want sits next to the request file and shares its name, use `*` as the name. The `*` stands for the current request file's basename. Whatever follows `*` is appended.
+
+```yaml
+# in genesis/getUser.hk.yaml
+body:
+  graphql:
+    query: '{{getFile "*.gql"}}' # reads genesis/getUser.gql
+```
+
+This works for any extension.
+
+```yaml
+body: '{{getFile "*.json"}}' # reads <thisfile>.json next to the request
+```
+
+The basename is the request file name without its `.hk.yaml`, `.hk.yml`, `.yaml`, or `.yml` suffix. The lookup is always the same directory as the request file, so renaming or moving the pair keeps the link intact. If the sibling file is missing, hulak reports the exact name it looked for. Regular path arguments (anything not starting with `*`) resolve from the project root as before.
 
 ## 3. Using `basicAuth`
 

--- a/pkg/envparser/replaceVars.go
+++ b/pkg/envparser/replaceVars.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -59,6 +60,27 @@ func formatMissingKeyError(keyName string) error {
 	)
 }
 
+// actionTokenRe matches the command identifier at the start of a template
+// action ("{{", optional trim marker, optional spaces, then the identifier).
+// Field accessors ({{.key}}) and variables ({{$x}}) don't match — they don't
+// start with an identifier char — so only function-position tokens are touched.
+var actionTokenRe = regexp.MustCompile(`(\{\{-?[ \t]*)([A-Za-z_][A-Za-z0-9_]*)`)
+
+// canonicalizeActionNames rewrites the leading command token of each template
+// action to its canonical spelling when it is a known action, so getfile,
+// GetFile, and get_file all resolve to getFile. Only tokens whose normalized
+// form is a known action are rewritten; every other identifier is left as-is.
+func canonicalizeActionNames(s string) string {
+	return actionTokenRe.ReplaceAllStringFunc(s, func(match string) string {
+		groups := actionTokenRe.FindStringSubmatch(match)
+		prefix, token := groups[1], groups[2]
+		if canonical, ok := utils.CanonicalActionName(token); ok {
+			return prefix + canonical
+		}
+		return match
+	})
+}
+
 func replaceVariables(
 	strToChange string,
 	secretsMap map[string]any,
@@ -78,7 +100,7 @@ func replaceVariables(
 	tmpl, err := template.New("template").
 		Funcs(funcMap).
 		Option("missingkey=error").
-		Parse(strToChange)
+		Parse(canonicalizeActionNames(strToChange))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/envparser/replaceVars.go
+++ b/pkg/envparser/replaceVars.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -61,6 +62,7 @@ func formatMissingKeyError(keyName string) error {
 func replaceVariables(
 	strToChange string,
 	secretsMap map[string]any,
+	currentFile string,
 ) (string, error) {
 	if len(strToChange) == 0 {
 		return "", nil
@@ -68,7 +70,7 @@ func replaceVariables(
 
 	funcMap := template.FuncMap{
 		utils.TemplateFuncGetValueOf: actions.GetValueOf,
-		utils.TemplateFuncGetFile:    actions.GetFile,
+		utils.TemplateFuncGetFile:    getFileFor(currentFile),
 		utils.TemplateFuncBasicAuth:  actions.BasicAuth,
 		utils.TemplateFuncOs:         os.Getenv,
 	}
@@ -97,12 +99,12 @@ func replaceVariables(
 // containing template variables using the replaceVariables function.
 // It ensures that non-string values (e.g., booleans, integers) are preserved and validates against unsupported types.
 // Returns a new map with resolved values or an error if any resolution fails.
-func prepareMap(secretsMap map[string]any) (map[string]any, error) {
+func prepareMap(secretsMap map[string]any, currentFile string) (map[string]any, error) {
 	updatedMap := make(map[string]any)
 	for key, val := range secretsMap {
 		switch v := val.(type) {
 		case string:
-			changedValue, err := replaceVariables(v, secretsMap)
+			changedValue, err := replaceVariables(v, secretsMap, currentFile)
 			if err != nil {
 				return nil, err
 			}
@@ -119,20 +121,52 @@ func prepareMap(secretsMap map[string]any) (map[string]any, error) {
 // SubstituteVariables Substitutes template variables in a given string strToChange using the secretsMap.
 // It first prepares the map by resolving all nested variables using prepareMap
 // and then applies replaceVariables to the input string.
+// currentFile is the path of the request file being processed; it anchors the
+// getFile "*" sibling shorthand. Pass "" when there is no file context.
 // Returns the final substituted string or an error if any step fails.
 func SubstituteVariables(
 	strToChange string,
 	secretsMap map[string]any,
+	currentFile string,
 ) (any, error) {
-	finalMap, err := prepareMap(secretsMap)
+	finalMap, err := prepareMap(secretsMap, currentFile)
 	if err != nil {
 		return nil, err
 	}
 
-	result, err := replaceVariables(strToChange, finalMap)
+	result, err := replaceVariables(strToChange, finalMap, currentFile)
 	if err != nil {
 		return nil, err
 	}
 
 	return result, nil
+}
+
+// getFileFor returns a getFile template function bound to the request file
+// currently being processed. When the arg uses the "*" sibling shorthand it is
+// expanded relative to currentFile (see utils.SiblingPath); otherwise it falls
+// through to the normal path-based actions.GetFile unchanged.
+func getFileFor(currentFile string) func(string) (string, error) {
+	return func(arg string) (string, error) {
+		sibling, ok := utils.SiblingPath(currentFile, arg)
+		if !ok {
+			return actions.GetFile(arg)
+		}
+		if currentFile == "" {
+			return "", fmt.Errorf(
+				`getFile %q sibling shorthand is only valid inside a request file`, arg,
+			)
+		}
+		if arg == "*" {
+			return "", fmt.Errorf(`getFile %q needs an extension, e.g. "*.gql"`, arg)
+		}
+		content, err := actions.GetFile(sibling)
+		if err != nil {
+			return "", fmt.Errorf(
+				"no sibling file %s next to %s: %w",
+				filepath.Base(sibling), filepath.Base(currentFile), err,
+			)
+		}
+		return content, nil
+	}
 }

--- a/pkg/envparser/replaceVars.go
+++ b/pkg/envparser/replaceVars.go
@@ -182,7 +182,15 @@ func getFileFor(currentFile string) func(string) (string, error) {
 		if arg == "*" {
 			return "", fmt.Errorf(`getFile %q needs an extension, e.g. "*.gql"`, arg)
 		}
-		content, err := actions.GetFile(sibling)
+		// Resolve against the cwd so the sibling is read from the request file's
+		// own directory. A relative currentFile makes SiblingPath return a
+		// relative path, which actions.GetFile would otherwise re-root at the
+		// project root instead of next to the request file.
+		abs, err := filepath.Abs(sibling)
+		if err != nil {
+			return "", err
+		}
+		content, err := actions.GetFile(abs)
 		if err != nil {
 			return "", fmt.Errorf(
 				"no sibling file %s next to %s: %w",

--- a/pkg/envparser/replaceVars_test.go
+++ b/pkg/envparser/replaceVars_test.go
@@ -9,6 +9,85 @@ import (
 	"testing"
 )
 
+func TestCanonicalizeActionNames(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "lowercase getfile canonicalized",
+			in:   `{{getfile "*.gql"}}`,
+			want: `{{getFile "*.gql"}}`,
+		},
+		{
+			name: "underscore variant canonicalized",
+			in:   `{{get_file "*.gql"}}`,
+			want: `{{getFile "*.gql"}}`,
+		},
+		{
+			name: "uppercase with spaces and trim marker",
+			in:   `{{- GET_VALUE_OF "token" "auth.json" }}`,
+			want: `{{- getValueOf "token" "auth.json" }}`,
+		},
+		{
+			name: "field access is untouched",
+			in:   `{{.getfile}}`,
+			want: `{{.getfile}}`,
+		},
+		{
+			name: "unknown function is untouched",
+			in:   `{{someOther "x"}}`,
+			want: `{{someOther "x"}}`,
+		},
+		{
+			name: "arg contents are untouched",
+			in:   `{{getFile "get_file/getfile.gql"}}`,
+			want: `{{getFile "get_file/getfile.gql"}}`,
+		},
+		{
+			name: "no template syntax unchanged",
+			in:   `plain string get_file`,
+			want: `plain string get_file`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canonicalizeActionNames(tt.in); got != tt.want {
+				t.Errorf("canonicalizeActionNames(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSubstituteVariables_ActionNameTolerance drives case/underscore-insensitive
+// action names end to end through the template executor.
+func TestSubstituteVariables_ActionNameTolerance(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "env"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(root)
+	body := "query { user { id } }"
+	if err := os.WriteFile(filepath.Join(root, "q.gql"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	currentFile := filepath.Join(root, "q.hk.yaml")
+
+	for _, spelling := range []string{"getFile", "getfile", "GetFile", "get_file", "GET_FILE"} {
+		t.Run(spelling, func(t *testing.T) {
+			got, err := SubstituteVariables(`{{`+spelling+` "*.gql"}}`, map[string]any{}, currentFile)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != body {
+				t.Errorf("got %q, want %q", got, body)
+			}
+		})
+	}
+}
+
 // TestSubstituteVariables_SiblingGetFile exercises the getFile "*" sibling
 // shorthand end to end: it resolves a file next to the current request file,
 // errors clearly when the sibling is missing, and rejects misuse.

--- a/pkg/envparser/replaceVars_test.go
+++ b/pkg/envparser/replaceVars_test.go
@@ -145,6 +145,41 @@ func TestSubstituteVariables_SiblingGetFile(t *testing.T) {
 	})
 }
 
+// TestSubstituteVariables_SiblingRelativeFromSubdir guards that the "*" sibling
+// resolves next to the request file even when it is passed as a relative path
+// from a working directory below the project root. A decoy file with the same
+// name at the project root would be picked if the sibling were re-rooted there
+// instead of resolved next to the request file.
+func TestSubstituteVariables_SiblingRelativeFromSubdir(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "env"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	genesis := filepath.Join(root, "genesis")
+	if err := os.MkdirAll(genesis, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Same basename in two places: the real neighbor in genesis/ and a decoy at
+	// the project root. Re-rooting would read the decoy.
+	if err := os.WriteFile(filepath.Join(genesis, "getUser.gql"), []byte("REAL"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "getUser.gql"), []byte("DECOY"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// cwd is the subdir, and the request file is given as a bare relative name.
+	t.Chdir(genesis)
+	got, err := SubstituteVariables(`{{getFile "*.gql"}}`, map[string]any{}, "getUser.hk.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "REAL" {
+		t.Errorf("got %q, want %q (sibling re-rooted to the project root instead of the request dir)", got, "REAL")
+	}
+}
+
 // TestSubstituteVariablesWithJSONNumber guards against a regression where the
 // vault decoded numbers as json.Number (to preserve int/float distinction) but
 // prepareMap rejected the type with "unsupported type for key '...': json.Number".

--- a/pkg/envparser/replaceVars_test.go
+++ b/pkg/envparser/replaceVars_test.go
@@ -4,9 +4,67 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// TestSubstituteVariables_SiblingGetFile exercises the getFile "*" sibling
+// shorthand end to end: it resolves a file next to the current request file,
+// errors clearly when the sibling is missing, and rejects misuse.
+func TestSubstituteVariables_SiblingGetFile(t *testing.T) {
+	// A hulak project (env/ marker) so actions.GetFile can find the root.
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "env"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(root)
+
+	reqDir := filepath.Join(root, "genesis")
+	if err := os.MkdirAll(reqDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	currentFile := filepath.Join(reqDir, "getUser.hk.yaml")
+	gqlBody := "query { user { id } }"
+	if err := os.WriteFile(filepath.Join(reqDir, "getUser.gql"), []byte(gqlBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("resolves sibling next to current file", func(t *testing.T) {
+		got, err := SubstituteVariables(`{{getFile "*.gql"}}`, map[string]any{}, currentFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != gqlBody {
+			t.Errorf("got %q, want %q", got, gqlBody)
+		}
+	})
+
+	t.Run("missing sibling gives a clear error", func(t *testing.T) {
+		_, err := SubstituteVariables(`{{getFile "*.json"}}`, map[string]any{}, currentFile)
+		if err == nil {
+			t.Fatal("expected error for missing sibling")
+		}
+		if !strings.Contains(err.Error(), "getUser.json") ||
+			!strings.Contains(err.Error(), "getUser.hk.yaml") {
+			t.Errorf("error should name both files, got: %v", err)
+		}
+	})
+
+	t.Run("bare star needs an extension", func(t *testing.T) {
+		_, err := SubstituteVariables(`{{getFile "*"}}`, map[string]any{}, currentFile)
+		if err == nil || !strings.Contains(err.Error(), "extension") {
+			t.Errorf("expected an extension-required error, got: %v", err)
+		}
+	})
+
+	t.Run("sibling shorthand outside a file context errors", func(t *testing.T) {
+		_, err := SubstituteVariables(`{{getFile "*.gql"}}`, map[string]any{}, "")
+		if err == nil || !strings.Contains(err.Error(), "request file") {
+			t.Errorf("expected a file-context error, got: %v", err)
+		}
+	})
+}
 
 // TestSubstituteVariablesWithJSONNumber guards against a regression where the
 // vault decoded numbers as json.Number (to preserve int/float distinction) but
@@ -17,7 +75,7 @@ func TestSubstituteVariablesWithJSONNumber(t *testing.T) {
 		"application_id": json.Number("12345"),
 		"url":            "https://api.example.com/apps/{{.application_id}}",
 	}
-	got, err := SubstituteVariables("{{.url}}", secretsMap)
+	got, err := SubstituteVariables("{{.url}}", secretsMap, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -269,7 +327,7 @@ func TestSubstituteVariables(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			output, err := SubstituteVariables(tc.stringToChange, tc.varMap)
+			output, err := SubstituteVariables(tc.stringToChange, tc.varMap, "")
 
 			// Compare output
 			if output != tc.expectedOutput {
@@ -478,7 +536,7 @@ func TestSubstituteVariablesWithImprovedErrors(t *testing.T) {
 				defer os.Unsetenv("hulakEnv")
 			}
 
-			_, err := SubstituteVariables(tc.stringToChange, tc.varMap)
+			_, err := SubstituteVariables(tc.stringToChange, tc.varMap, "")
 
 			if err == nil {
 				t.Fatal("Expected error, got nil")

--- a/pkg/tui/gqlexplorer/savefile.go
+++ b/pkg/tui/gqlexplorer/savefile.go
@@ -70,14 +70,17 @@ func (m *Model) createHulakRequestFile() tea.Cmd {
 		return m.enqueueNotification(tui.NotificationError, "Empty query")
 	}
 
-	var stamp string
-	gqlFileName := op.Name + ".gql"
-	gqlPath := filepath.Join(dir, gqlFileName)
-	if fileExists(gqlPath) {
-		stamp = time.Now().Format("20060102-150405")
-		gqlFileName = op.Name + "-" + stamp + ".gql"
-		gqlPath = filepath.Join(dir, gqlFileName)
+	// The request and its query file share one basename so the getFile "*.gql"
+	// sibling shorthand in the generated YAML always resolves. If either name is
+	// taken, stamp both together to keep the pair matched.
+	base := op.Name
+	if fileExists(filepath.Join(dir, base+".gql")) ||
+		fileExists(filepath.Join(dir, base+".hk.yaml")) {
+		base = op.Name + "-" + time.Now().Format("20060102-150405")
 	}
+	gqlPath := filepath.Join(dir, base+".gql")
+	yamlPath := filepath.Join(dir, base+".hk.yaml")
+
 	if err := os.WriteFile(gqlPath, []byte(query), utils.FilePer); err != nil {
 		return m.enqueueNotification(tui.NotificationError, "Save .gql failed: "+err.Error())
 	}
@@ -87,26 +90,14 @@ func (m *Model) createHulakRequestFile() tea.Cmd {
 		raw, _ = readRawParentFields(parentPath) // best-effort; zero-value falls back to resolved
 	}
 
-	gqlRelPath := relativePath(gqlPath)
-	yamlContent := buildHkYaml(op, m.detailForm, m.apiInfos, gqlRelPath, raw)
-
-	yamlFileName := op.Name + ".hk.yaml"
-	yamlPath := filepath.Join(dir, yamlFileName)
-	if fileExists(yamlPath) {
-		if stamp == "" {
-			stamp = time.Now().Format("20060102-150405")
-		}
-		yamlFileName = op.Name + "-" + stamp + ".hk.yaml"
-		yamlPath = filepath.Join(dir, yamlFileName)
-	}
-
+	yamlContent := buildHkYaml(op, m.detailForm, m.apiInfos, raw)
 	if err := os.WriteFile(yamlPath, []byte(yamlContent), utils.FilePer); err != nil {
 		return m.enqueueNotification(tui.NotificationError, "Save failed: "+err.Error())
 	}
 
 	return m.enqueueNotification(
 		tui.NotificationInfo,
-		fmt.Sprintf("Created %s and %s", relativePath(yamlPath), gqlRelPath),
+		fmt.Sprintf("Created %s and %s", relativePath(yamlPath), relativePath(gqlPath)),
 	)
 }
 
@@ -114,7 +105,6 @@ func buildHkYaml(
 	op *UnifiedOperation,
 	df *DetailForm,
 	apiInfos map[string]yamlparser.APIInfo,
-	gqlRelPath string,
 	raw rawParentFields,
 ) string {
 	var sb strings.Builder
@@ -147,7 +137,9 @@ func buildHkYaml(
 	}
 
 	sb.WriteString("body:\n  graphql:\n")
-	fmt.Fprintf(&sb, "    query: '{{getFile %q}}'\n", gqlRelPath)
+	// The generated .gql sits next to this request file with the same basename,
+	// so the "*" sibling shorthand keeps the pair rename/move-safe.
+	sb.WriteString("    query: '{{getFile \"*.gql\"}}'\n")
 
 	varsMap := BuildVariablesMap(op, df)
 	if len(varsMap) > 0 {

--- a/pkg/utils/actions.go
+++ b/pkg/utils/actions.go
@@ -1,8 +1,45 @@
 package utils
 
+import "strings"
+
 const (
 	TemplateFuncGetFile    = "getFile"
 	TemplateFuncGetValueOf = "getValueOf"
 	TemplateFuncBasicAuth  = "basicAuth"
 	TemplateFuncOs         = "os"
 )
+
+// templateFuncNames is the canonical set of template action names. It is the
+// single source the name resolver derives its variants from — add a new action
+// here and every case/underscore spelling of it resolves automatically.
+var templateFuncNames = []string{
+	TemplateFuncGetFile,
+	TemplateFuncGetValueOf,
+	TemplateFuncBasicAuth,
+	TemplateFuncOs,
+}
+
+// canonicalActions maps a normalized action name to its canonical spelling.
+var canonicalActions = buildCanonicalActions()
+
+func buildCanonicalActions() map[string]string {
+	m := make(map[string]string, len(templateFuncNames))
+	for _, name := range templateFuncNames {
+		m[normalizeActionName(name)] = name
+	}
+	return m
+}
+
+// normalizeActionName lowercases and strips underscores so getFile, getfile,
+// GetFile, and get_file all collapse to the same key. Underscore is therefore
+// reserved as a word separator for future multi-word action names.
+func normalizeActionName(s string) string {
+	return strings.ToLower(strings.ReplaceAll(s, "_", ""))
+}
+
+// CanonicalActionName returns the canonical spelling of a template action name
+// written in any case/underscore variant, and whether it is a known action.
+func CanonicalActionName(token string) (string, bool) {
+	canonical, ok := canonicalActions[normalizeActionName(token)]
+	return canonical, ok
+}

--- a/pkg/utils/actions_test.go
+++ b/pkg/utils/actions_test.go
@@ -1,0 +1,40 @@
+package utils
+
+import "testing"
+
+func TestCanonicalActionName(t *testing.T) {
+	tests := []struct {
+		token string
+		want  string
+		ok    bool
+	}{
+		{"getFile", "getFile", true},
+		{"getfile", "getFile", true},
+		{"GetFile", "getFile", true},
+		{"GETFILE", "getFile", true},
+		{"get_file", "getFile", true},
+		{"Get_File", "getFile", true},
+		{"getValueOf", "getValueOf", true},
+		{"get_value_of", "getValueOf", true},
+		{"GETVALUEOF", "getValueOf", true},
+		{"basicAuth", "basicAuth", true},
+		{"basic_auth", "basicAuth", true},
+		{"os", "os", true},
+		{"OS", "os", true},
+		{"unknown", "", false},
+		{"getFiles", "", false},
+		{"", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.token, func(t *testing.T) {
+			got, ok := CanonicalActionName(tt.token)
+			if ok != tt.ok {
+				t.Fatalf("CanonicalActionName(%q) ok = %v, want %v", tt.token, ok, tt.ok)
+			}
+			if got != tt.want {
+				t.Errorf("CanonicalActionName(%q) = %q, want %q", tt.token, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/sibling.go
+++ b/pkg/utils/sibling.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// SiblingPath expands the getFile sibling shorthand. When arg begins with "*",
+// the "*" stands for the current file's basename (its name with the hulak YAML
+// suffix removed) and the remainder of arg is appended, yielding a path to a
+// file sitting next to the current one in the same directory:
+//
+//	current: genesis/getUser.hk.yaml
+//	  "*.gql"      -> genesis/getUser.gql
+//	  "*.json"     -> genesis/getUser.json
+//	  "*.tar.gz"   -> genesis/getUser.tar.gz
+//
+// It returns the resolved path and true. For any arg that does not begin with
+// "*" it returns "", false, leaving normal getFile resolution untouched.
+func SiblingPath(currentFile, arg string) (string, bool) {
+	if !strings.HasPrefix(arg, "*") {
+		return "", false
+	}
+
+	base := filepath.Base(currentFile)
+	stem := base
+	for _, suf := range RequestExts {
+		if trimmed, ok := strings.CutSuffix(base, suf); ok {
+			stem = trimmed
+			break
+		}
+	}
+
+	suffix := arg[len("*"):]
+	return filepath.Join(filepath.Dir(currentFile), stem+suffix), true
+}

--- a/pkg/utils/sibling_test.go
+++ b/pkg/utils/sibling_test.go
@@ -1,0 +1,106 @@
+package utils
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSiblingPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		currentFile string
+		arg         string
+		want        string
+		wantOK      bool
+	}{
+		{
+			name:        "gql sibling from .hk.yaml",
+			currentFile: filepath.Join("genesis", "getUser.hk.yaml"),
+			arg:         "*.gql",
+			want:        filepath.Join("genesis", "getUser.gql"),
+			wantOK:      true,
+		},
+		{
+			name:        "json sibling",
+			currentFile: filepath.Join("genesis", "getUser.hk.yaml"),
+			arg:         "*.json",
+			want:        filepath.Join("genesis", "getUser.json"),
+			wantOK:      true,
+		},
+		{
+			name:        "multi-dot extension keeps everything after star",
+			currentFile: filepath.Join("a", "b", "backup.hk.yaml"),
+			arg:         "*.tar.gz",
+			want:        filepath.Join("a", "b", "backup.tar.gz"),
+			wantOK:      true,
+		},
+		{
+			name:        "hk.yml suffix stripped",
+			currentFile: "getUser.hk.yml",
+			arg:         "*.gql",
+			want:        "getUser.gql",
+			wantOK:      true,
+		},
+		{
+			name:        "plain yaml suffix stripped",
+			currentFile: "getUser.yaml",
+			arg:         "*.gql",
+			want:        "getUser.gql",
+			wantOK:      true,
+		},
+		{
+			name:        "yml suffix stripped",
+			currentFile: "getUser.yml",
+			arg:         "*.gql",
+			want:        "getUser.gql",
+			wantOK:      true,
+		},
+		{
+			name:        "longest suffix wins: .hk.yaml not .yaml",
+			currentFile: "report.hk.yaml",
+			arg:         "*.gql",
+			want:        "report.gql",
+			wantOK:      true,
+		},
+		{
+			name:        "arbitrary literal suffix after star",
+			currentFile: "getUser.hk.yaml",
+			arg:         "*-response.json",
+			want:        "getUser-response.json",
+			wantOK:      true,
+		},
+		{
+			name:        "non-star arg is not a sibling",
+			currentFile: "getUser.hk.yaml",
+			arg:         "genesis/other.gql",
+			want:        "",
+			wantOK:      false,
+		},
+		{
+			name:        "mid-path star is literal, not a sibling",
+			currentFile: "getUser.hk.yaml",
+			arg:         "sub/*.gql",
+			want:        "",
+			wantOK:      false,
+		},
+		{
+			name:        "bare star resolves to stem with no extension",
+			currentFile: filepath.Join("genesis", "getUser.hk.yaml"),
+			arg:         "*",
+			want:        filepath.Join("genesis", "getUser"),
+			wantOK:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := SiblingPath(tt.currentFile, tt.arg)
+			if ok != tt.wantOK {
+				t.Fatalf("SiblingPath(%q, %q) ok = %v, want %v", tt.currentFile, tt.arg, ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Errorf("SiblingPath(%q, %q) = %q, want %q", tt.currentFile, tt.arg, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/yamlparser/yamlparser.go
+++ b/pkg/yamlparser/yamlparser.go
@@ -24,16 +24,19 @@ import (
 func replaceVarsWithValues(
 	dict map[string]any,
 	secretsMap map[string]any,
+	currentFile string,
 ) (map[string]any, error) {
-	return replaceVarsWithPrefix(dict, secretsMap, "")
+	return replaceVarsWithPrefix(dict, secretsMap, "", currentFile)
 }
 
 // replaceVarsWithPrefix is the recursive helper. prefix is the dotted path
 // of the parent map; the empty string at the root suppresses a leading dot.
+// currentFile anchors the getFile "*" sibling shorthand.
 func replaceVarsWithPrefix(
 	dict map[string]any,
 	secretsMap map[string]any,
 	prefix string,
+	currentFile string,
 ) (map[string]any, error) {
 	changedMap := make(map[string]any)
 
@@ -45,7 +48,7 @@ func replaceVarsWithPrefix(
 
 		switch valTyped := val.(type) {
 		case map[string]any:
-			nestedMap, err := replaceVarsWithPrefix(valTyped, secretsMap, fullKey)
+			nestedMap, err := replaceVarsWithPrefix(valTyped, secretsMap, fullKey, currentFile)
 			if err != nil {
 				return nil, err
 			}
@@ -57,7 +60,7 @@ func replaceVarsWithPrefix(
 				changedMap[key] = valTyped
 				continue
 			}
-			finalChangedValue, err := envparser.SubstituteVariables(valTyped, secretsMap)
+			finalChangedValue, err := envparser.SubstituteVariables(valTyped, secretsMap, currentFile)
 			if err != nil {
 				return nil, fmt.Errorf("substituting %q: %w", fullKey, err)
 			}
@@ -70,7 +73,7 @@ func replaceVarsWithPrefix(
 					innerMap[k] = v
 					continue
 				}
-				finalChangedValue, err := envparser.SubstituteVariables(v, secretsMap)
+				finalChangedValue, err := envparser.SubstituteVariables(v, secretsMap, currentFile)
 				if err != nil {
 					return nil, fmt.Errorf("substituting %q: %w", fullKey+"."+k, err)
 				}
@@ -112,7 +115,7 @@ func checkYamlFile(filepath string, secretsMap map[string]any) (*bytes.Buffer, e
 	data = utils.ConvertKeysToLowerCase(data)
 
 	// parse all the values to with {{.key}} from .env folder
-	parsedMap, err := replaceVarsWithValues(data, secretsMap)
+	parsedMap, err := replaceVarsWithValues(data, secretsMap, filepath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/yamlparser/yamlparser_test.go
+++ b/pkg/yamlparser/yamlparser_test.go
@@ -123,7 +123,7 @@ func TestStringVariableSubstitution(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := replaceVarsWithValues(tc.input, tc.envVars)
+			result, err := replaceVarsWithValues(tc.input, tc.envVars, "")
 			if err != nil {
 				t.Fatalf("replaceVarsWithValues returned an error: %v", err)
 			}


### PR DESCRIPTION
Closes #150

Implements the maintainer's preferred direction from the issue's IMPORTANT note: a `getFile` pattern for the same-basename paired-file case, instead of a separate `queryFile` action. Plus an ergonomics fix for action-name spelling.

## 1. getFile `*` sibling shorthand

`*` stands for the current request file's basename. Whatever follows is appended, and the file is looked up **next to the request file** in the same directory.

```yaml
# genesis/getUser.hk.yaml
body:
  graphql:
    query: '{{getFile "*.gql"}}'   # -> genesis/getUser.gql
```

Works for any extension (`*.json`, `*.txt`, `*.tar.gz`, ...). Basename = request filename minus `.hk.yaml` / `.hk.yml` / `.yaml` / `.yml`.

### Disambiguation

`*` is the signal, chosen because it is **not a valid path** `getFile` resolves today (there is no globbing), so no existing request changes meaning. A leading `.gql` was rejected precisely because it collides with a real dotfile at the project root. `*` is only special at the **start** of the arg; a mid-path `*` stays literal. Every non-`*` argument keeps today's project-root path resolution byte-for-byte.

Errors are explicit: missing sibling names the exact file it looked for; bare `"*"` (no extension) and use outside a file context both error.

The GraphQL explorer scaffold now emits `{{getFile "*.gql"}}` and names the request/query pair with one shared basename, so the shorthand always resolves (previously the two files could get different collision-stamped names).

## 2. Case- and underscore-insensitive action names

`getFile`, `getfile`, `GetFile`, `GETFILE`, and `get_file` now all resolve to the same action. Applies to every action (`getValueOf`, `getFile`, `basicAuth`, `os`).

One resolver in `utils` (`CanonicalActionName`) derives all variants from the canonical name list, so a future action gets every spelling for free. Underscore is reserved as the word separator for future multi-word names. A pre-parse pass canonicalizes only the leading command token of each action; `{{.field}}` accessors, argument strings, and unknown functions are left untouched.

## Notes

- Current-file path is threaded through the existing substitution chain (`checkYamlFile` already had it; it was dropped before `SubstituteVariables`). `actions.GetFile` stays pure; the sibling logic lives in a closure bound per request file.
- Docs: `docs/actions.md` documents both features. Schema: the GraphQL `query` default is now `{{getFile "*.gql"}}`.

## Tests

- `SiblingPath` table (stems, extensions, non-`*`, mid-path `*`, bare `*`)
- end-to-end sibling resolution + all error paths
- `CanonicalActionName` table + `canonicalizeActionNames` rewrite table
- name-tolerance end to end

`go test ./...`, `go vet ./...`, `golangci-lint run` all clean.