### PR TITLE
fix: precise env-var detection (ignore comments and getFile'd bodies)

### DIFF
--- a/pkg/utils/template.go
+++ b/pkg/utils/template.go
@@ -8,42 +8,39 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+
+	yaml "github.com/goccy/go-yaml"
 )
 
+// templateVarPattern matches a dot-access template reference like {{.token}}
+// or {{ .token }}, tolerating whitespace between the braces and the dot the
+// same way Go's template engine does at substitution time.
 var templateVarPattern = regexp.MustCompile(`\{\{\s*\.`)
 
-// FileHasTemplateVars checks if a file contains Go template variable references
-// (e.g., {{.token}}) that require environment variable resolution.
-// It checks {{getFile ...}} references and inspects the referenced files as well.
+// FileHasTemplateVars reports whether a request file's YAML values contain env
+// variable references (e.g. {{.token}}) that require environment resolution.
+//
+// It decodes the YAML so comments never count — they are dropped by the decoder
+// and never reach runtime substitution. It does not follow {{getFile ...}}
+// references either: getFile dumps the referenced file's raw content into
+// context and hulak never re-templates it (single-pass substitution), so an env
+// var inside a referenced file can never resolve and must not force env loading.
 func FileHasTemplateVars(filePath string) bool {
-	return fileHasTemplateVars(filePath, map[string]bool{})
-}
-
-func fileHasTemplateVars(filePath string, visited map[string]bool) bool {
 	resolvedPath, err := resolveFilePath(filePath)
 	if err != nil {
 		return false
 	}
-	if visited[resolvedPath] {
-		return false
-	}
-	visited[resolvedPath] = true
 
 	content, err := os.ReadFile(resolvedPath)
 	if err != nil {
 		return false
 	}
-	if templateVarPattern.Match(content) {
-		return true
-	}
 
-	for _, arg := range extractGetFileArgs(string(content)) {
-		if fileHasTemplateVars(arg, visited) {
-			return true
-		}
+	var data map[string]any
+	if err := yaml.Unmarshal(content, &data); err != nil {
+		return false
 	}
-
-	return false
+	return MapHasEnvVars(data)
 }
 
 // ReferencedFiles returns the files a request pulls in via {{getFile}},
@@ -111,8 +108,9 @@ func projectRootRel(arg string) string {
 	return anchorToRoot(clean, root)
 }
 
-// MapHasEnvVars recursively checks if any string value in the map
-// contains "{{." which indicates an env variable reference.
+// MapHasEnvVars recursively checks whether any string value in the map holds a
+// dot-access template reference ({{.key}} or {{ .key }}), which indicates an
+// env variable reference.
 func MapHasEnvVars(data map[string]any) bool {
 	for _, val := range data {
 		if hasEnvVar(val) {
@@ -248,7 +246,7 @@ func withinRoot(absPath, root string) bool {
 func hasEnvVar(val any) bool {
 	switch v := val.(type) {
 	case string:
-		return strings.Contains(v, "{{.")
+		return templateVarPattern.MatchString(v)
 	case map[string]any:
 		return MapHasEnvVars(v)
 	case []any:

--- a/pkg/utils/template_test.go
+++ b/pkg/utils/template_test.go
@@ -58,14 +58,31 @@ func TestFileHasTemplateVars(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "getFile_with_env_vars_in_referenced_file",
+			// getFile dumps the referenced file's raw content into context and
+			// hulak never re-templates it (single-pass substitution), so an env
+			// var inside the referenced file can never resolve. It must not force
+			// env resolution.
+			name:     "getFile_body_env_vars_do_not_count",
 			content:  buildGetFileContent("query.graphql"),
-			expected: true,
+			expected: false,
 		},
 		{
-			name:     "getFile_unquoted_with_env_vars_in_referenced_file",
+			name:     "getFile_unquoted_body_env_vars_do_not_count",
 			content:  buildGetFileContentNoQuotes("unquoted.graphql"),
-			expected: true,
+			expected: false,
+		},
+		{
+			// A template var living only in a YAML comment never reaches runtime
+			// substitution (the decoder drops comments), so it must not force env
+			// resolution.
+			name:     "env_var_only_in_full_line_comment",
+			content:  "---\nkind: GraphQL\nurl: http://example.com/graphql\n# Authorization: Bearer {{.token}}\n",
+			expected: false,
+		},
+		{
+			name:     "env_var_only_in_inline_comment",
+			content:  "---\nkind: GraphQL\nurl: http://example.com/graphql # {{.token}}\n",
+			expected: false,
 		},
 		{
 			name:     "only_getValueOf_no_env_vars",


### PR DESCRIPTION
Closes #243

## Problem

`hulak run <file>` showed the env picker even when the request needed no environment. Two false positives:

1. **YAML comments** — a `{{.var}}` inside a `#` comment triggered the picker.
2. **getFile'd bodies** — a `{{.var}}` inside a file pulled in via `{{getFile "path"}}` triggered the picker.

Both `run` (`runner.go`) and `gql` (`gqlFiles.go` via `NeedsEnvResolution`) gate the picker on `utils.FileHasTemplateVars`, so the imprecision hit both.

## Root cause

`utils.FileHasTemplateVars` scanned raw file bytes with the regex `{{\s*\.` and recursed into every `{{getFile}}` reference, scanning those files too. The raw scan matched comments; the recursion flagged env vars inside referenced files.

The recursion guards a feature that does not exist: substitution is single-pass (only call site is per-value during YAML parse). `{{getFile "x"}}` dumps `x`'s raw text into the output; a `{{.var}}` inside `x` is never re-templated. Proven empirically and matches the documented contract (`docs/actions.md`): getFile "gets the file content as string and dumps it in context."

## Fix

Decode the YAML and delegate to the existing `MapHasEnvVars` primitive (already used by `gql`'s `peekFileInfo`). Drop the raw regex and the getFile recursion. Both `run` and `gql` become precise through the one shared primitive.

- Comments: ignored (decoder drops them).
- getFile'd bodies: not followed (raw dumps, no substitution).
- Real env vars in request YAML (incl. `variables:` blocks): still detected.
- `{{ .key }}` with whitespace: still detected — `hasEnvVar` uses the `{{\s*\.` pattern instead of a literal `{{.` substring check.

## Tests

- Two recursion tests repurposed to assert getFile'd body env vars do not count.
- Two comment cases added (full-line + inline).
- Full suite passes; verified end-to-end that `hulak run` on a comment-only file goes straight to the request with no env picker.